### PR TITLE
Support for Inbound JWT Credentials

### DIFF
--- a/core/helper.go
+++ b/core/helper.go
@@ -124,7 +124,7 @@ func ParseResponse[T Response](response *http.Response, value *T) error {
 		return ErrNilResponse
 	}
 
-	switch contentType := response.Header.Get(contentTypeHeader); contentType {
+	switch contentType := response.Header.Get(contentTypeHeader); contentTypeWithoutDirectives(contentType) {
 	case jsonContentType:
 		err = FromJson(response, &value)
 	default:
@@ -137,6 +137,14 @@ func ParseResponse[T Response](response *http.Response, value *T) error {
 	(*value).ParseHeaders(response.Header)
 
 	return nil
+}
+
+func contentTypeWithoutDirectives(contentType string) string {
+	if strings.Contains(contentType, ";") {
+		return strings.Split(contentType, ";")[0]
+	}
+
+	return contentType
 }
 
 // Deprecated: deprecated in v1.4.0. Please use SendGet2.

--- a/credentials/Readme.md
+++ b/credentials/Readme.md
@@ -41,3 +41,22 @@ func main() {
     ...
 }
 ```
+
+## JWT Token Credential
+
+ServiceNow also supports using [OAuth JWT API}(https://docs.servicenow.com/bundle/washingtondc-platform-security/page/administer/security/task/create-jwt-endpoint.html) to authenticate with your instance seamlessly using the inbound JWT grant type instead of username and password. It uses the same `TokenCredential`, but the SDK authenticates via a token retrieved using the provided JWT assertion. An RSA private key is needed to sign the token so ServiceNow can validate it (see link above).
+
+```golang
+import (
+    "github.com/michaeldcanady/servicenow-sdk-go/credentials"
+)
+
+func main() {
+    cred, err := credentials.NewJwtTokenCredential("clientID", "clientSecret", "kid", "baseURL", "user", "privateKeyPath")
+    if err != nil {
+        panic(err)
+    }
+
+    ...
+}
+```

--- a/credentials/error.go
+++ b/credentials/error.go
@@ -29,7 +29,10 @@ func (e *CredentialError) Error() string {
 }
 
 var (
-	EmptyClientID     = NewOauth2Error("clientId is empty")
-	EmptyClientSecret = NewOauth2Error("clientSecret is empty")
-	EmptyBaseURL      = NewOauth2Error("baseURL is empty")
+	EmptyClientID       = NewOauth2Error("clientId is empty")
+	EmptyClientSecret   = NewOauth2Error("clientSecret is empty")
+	EmptyBaseURL        = NewOauth2Error("baseURL is empty")
+	EmptyUser           = NewOauth2Error("user is empty")
+	EmptyPrivateKeyPath = NewOauth2Error("privateKeyPath is empty")
+	EmptyKeyID          = NewOauth2Error("kid is empty")
 )

--- a/credentials/token_credential.go
+++ b/credentials/token_credential.go
@@ -183,7 +183,6 @@ func (tc *TokenCredential) requestToken(data url.Values) (*AccessToken, error) {
 
 	AccessToken, err := decodeAccessToken(resp)
 	if err != nil {
-		fmt.Println("Got token:", AccessToken.AccessToken)
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.4 h1:QjV6pZ7/XZ7ryI2KuyeEDE8wnh7fHP9YnQy+R0LnH8I=
 github.com/gabriel-vasile/mimetype v1.4.4/go.mod h1:JwLei5XPtWdGiMFB5Pjle1oEeoSeEuJfJE+TtfvdB/s=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/internal/core/helper.go
+++ b/internal/core/helper.go
@@ -120,7 +120,7 @@ func ParseResponse[T Response](response *http.Response, value *T) error {
 		return ErrNilResponse
 	}
 
-	switch contentType := response.Header.Get(contentTypeHeader); contentType {
+	switch contentType := response.Header.Get(contentTypeHeader); contentTypeWithoutDirectives(contentType) {
 	case jsonContentType:
 		err = FromJSON(response, &value)
 	default:
@@ -141,4 +141,12 @@ func ResetCalls(calls ...*mock.Call) {
 			call.Unset()
 		}
 	}
+}
+
+func contentTypeWithoutDirectives(contentType string) string {
+	if strings.Contains(contentType, ";") {
+		return strings.Split(contentType, ";")[0]
+	}
+
+	return contentType
 }


### PR DESCRIPTION
Adding support for using JWT tokens to fetch access token via `TokenCredential`. I intentionally re-used and extended `TokenCredential` since it uses the same endpoints and logic. The only difference is in the request parameters for `oauth_token.do` and no support for refresh tokens.

I've also noticed our instance is sending back `Content-Type` with an additional directive `charset=UTF8` which caused the `ParseResponse` function to error with `unsupported content type: application/json;charset=UTF-8`.