### PR TITLE
fix(ci): use setup-go built-in caching to prevent cache pollution

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,12 +88,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Cache Go build
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ matrix.os }}-${{ hashFiles('go.sum') }}
-          restore-keys: ${{ runner.os }}-go-build-
+          cache: true
       - run: go mod download
       - name: Build Go Code
         run: |
@@ -144,12 +139,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Cache Go build
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/go-build
-          key: ${{ matrix.os }}-go-build-${{ matrix.go-version }}-${{ hashFiles('go.sum') }}
-          restore-keys: ${{ runner.os }}-go-build-${{ hashFiles('go.sum') }}
+          cache: true
       - name: Run tests
         run: |
           PACKAGES=$(go list ./... | grep -v "/docs")


### PR DESCRIPTION
Replaced manual actions/cache steps with 'cache: true' in actions/setup-go. This ensures:
- Correct cache paths for all operating systems (Linux, macOS, Windows).
- Branch-scoped caching to prevent cross-branch contamination.
- Caching of both build (GOCACHE) and module (GOMODCACHE) caches.

Fixes: #339


