### PR TITLE
fix(all): correct RecordElement link type mismatch and stale nil-guard tests

### DIFF
--- a/attachmentapi/file_test.go
+++ b/attachmentapi/file_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -236,30 +237,30 @@ func TestFileModel_ErrorBranches(t *testing.T) {
 		var nilM *File
 		for _, test := range tests {
 			res, err := test.get(nilM)
-			assert.NoError(t, err)
+			assert.ErrorIs(t, err, snerrors.ErrNilModel)
 			assert.Nil(t, res)
 		}
 
-		assert.Nil(t, nilM.SetAverageImageColor(nil))
-		assert.Nil(t, nilM.SetCompressed(nil))
-		assert.Nil(t, nilM.SetContentType(nil))
-		assert.Nil(t, nilM.SetCreatedByName(nil))
-		assert.Nil(t, nilM.SetDownloadLink(nil))
-		assert.Nil(t, nilM.SetFileName(nil))
-		assert.Nil(t, nilM.SetImageHeight(nil))
-		assert.Nil(t, nilM.SetImageWidth(nil))
-		assert.Nil(t, nilM.SetSizeBytes(nil))
-		assert.Nil(t, nilM.SetSizeCompressed(nil))
-		assert.Nil(t, nilM.SetSysCreatedBy(nil))
-		assert.Nil(t, nilM.SetSysCreatedOn(nil))
-		assert.Nil(t, nilM.SetSysID(nil))
-		assert.Nil(t, nilM.SetSysModCount(nil))
-		assert.Nil(t, nilM.SetSysTags(nil))
-		assert.Nil(t, nilM.SetSysUpdatedBy(nil))
-		assert.Nil(t, nilM.SetSysUpdatedOn(nil))
-		assert.Nil(t, nilM.SetTableName(nil))
-		assert.Nil(t, nilM.SetTableSysID(nil))
-		assert.Nil(t, nilM.SetUpdatedByName(nil))
+		assert.ErrorIs(t, nilM.SetAverageImageColor(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetCompressed(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetContentType(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetCreatedByName(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetDownloadLink(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetFileName(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetImageHeight(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetImageWidth(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSizeBytes(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSizeCompressed(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSysCreatedBy(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSysCreatedOn(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSysID(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSysModCount(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSysTags(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSysUpdatedBy(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetSysUpdatedOn(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetTableName(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetTableSysID(nil), snerrors.ErrNilModel)
+		assert.ErrorIs(t, nilM.SetUpdatedByName(nil), snerrors.ErrNilModel)
 	})
 }
 

--- a/attachmentapi/file_with_content_test.go
+++ b/attachmentapi/file_with_content_test.go
@@ -48,7 +48,7 @@ func TestFileWithContentModel_GetContent(t *testing.T) {
 		err      bool
 	}{
 		{"Ok", m, data, false},
-		{"NilM", nilM, nil, false},
+		{"NilM", nilM, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestFileWithContentModel_SetContent(t *testing.T) {
 		err   bool
 	}{
 		{"Ok", m, false},
-		{"NilM", nilM, false},
+		{"NilM", nilM, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -94,10 +94,10 @@ func TestFileWithContentModel_ErrorBranches(t *testing.T) {
 	}
 
 	mNilBS := &FileWithContent{file: &mockNilBSFile{}}
-	if _, err := mNilBS.GetContent(); err == nil || err.Error() != "backingStore is nil" {
+	if _, err := mNilBS.GetContent(); err == nil || err.Error() != "store is nil" {
 		t.Errorf("expected BS nil error in Get, got %v", err)
 	}
-	if err := mNilBS.SetContent(nil); err == nil || err.Error() != "backingStore is nil" {
+	if err := mNilBS.SetContent(nil); err == nil || err.Error() != "store is nil" {
 		t.Errorf("expected BS nil error in Set, got %v", err)
 	}
 }

--- a/batchapi/batch_request_test.go
+++ b/batchapi/batch_request_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 	"github.com/stretchr/testify/assert"
@@ -213,7 +214,7 @@ func TestBatchRequest_GetBatchRequestID(t *testing.T) {
 			test: func(t *testing.T) {
 				var m *BatchRequestModel
 				res, err := m.GetBatchRequestID()
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilModel)
 				assert.Nil(t, res)
 			},
 		},
@@ -243,7 +244,7 @@ func TestBatchRequest_SetBatchRequestID(t *testing.T) {
 			test: func(t *testing.T) {
 				var m *BatchRequestModel
 				err := m.SetBatchRequestID(nil)
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilModel)
 			},
 		},
 	}
@@ -274,7 +275,7 @@ func TestBatchRequest_GetRestRequests(t *testing.T) {
 			test: func(t *testing.T) {
 				var m *BatchRequestModel
 				res, err := m.GetRestRequests()
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilModel)
 				assert.Nil(t, res)
 			},
 		},
@@ -304,7 +305,7 @@ func TestBatchRequest_SetRestRequests(t *testing.T) {
 			test: func(t *testing.T) {
 				var m *BatchRequestModel
 				err := m.SetRestRequests(nil)
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilModel)
 			},
 		},
 	}

--- a/batchapi/batch_response_test.go
+++ b/batchapi/batch_response_test.go
@@ -367,7 +367,7 @@ func TestBatchResponse_GetBatchRequestID(t *testing.T) {
 				}
 
 				id, err := resp.GetBatchRequestID()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -377,7 +377,7 @@ func TestBatchResponse_GetBatchRequestID(t *testing.T) {
 				resp := (*BatchResponseModel)(nil)
 
 				id, err := resp.GetBatchRequestID()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -449,7 +449,7 @@ func TestBatchResponse_setBatchRequestID(t *testing.T) {
 				}
 
 				err := resp.setBatchRequestID(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -462,7 +462,7 @@ func TestBatchResponse_setBatchRequestID(t *testing.T) {
 				resp := (*BatchResponseModel)(nil)
 
 				err := resp.setBatchRequestID(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -545,7 +545,7 @@ func TestBatchResponse_GetServicedRequests(t *testing.T) {
 				}
 
 				id, err := resp.GetServicedRequests()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -555,7 +555,7 @@ func TestBatchResponse_GetServicedRequests(t *testing.T) {
 				resp := (*BatchResponseModel)(nil)
 
 				id, err := resp.GetServicedRequests()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -627,7 +627,7 @@ func TestBatchResponse_setServicedRequests(t *testing.T) {
 				}
 
 				err := resp.setServicedRequests(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -640,7 +640,7 @@ func TestBatchResponse_setServicedRequests(t *testing.T) {
 				resp := (*BatchResponseModel)(nil)
 
 				err := resp.setServicedRequests(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -723,7 +723,7 @@ func TestBatchResponse_GetUnservicedRequests(t *testing.T) {
 				}
 
 				id, err := resp.GetUnservicedRequests()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -733,7 +733,7 @@ func TestBatchResponse_GetUnservicedRequests(t *testing.T) {
 				resp := (*BatchResponseModel)(nil)
 
 				id, err := resp.GetUnservicedRequests()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -805,7 +805,7 @@ func TestBatchResponse_setUnservicedRequests(t *testing.T) {
 				}
 
 				err := resp.setUnservicedRequests(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -818,7 +818,7 @@ func TestBatchResponse_setUnservicedRequests(t *testing.T) {
 				resp := (*BatchResponseModel)(nil)
 
 				err := resp.setUnservicedRequests(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}

--- a/batchapi/rest_request_header_test.go
+++ b/batchapi/rest_request_header_test.go
@@ -233,7 +233,7 @@ func TestRestRequestHeader_GetName(t *testing.T) {
 
 				name, err := header.GetName()
 
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, name)
 
 				intModel.AssertExpectations(t)
@@ -246,7 +246,7 @@ func TestRestRequestHeader_GetName(t *testing.T) {
 
 				name, err := header.GetName()
 
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, name)
 			},
 		},
@@ -318,7 +318,7 @@ func TestRestRequestHeader_SetName(t *testing.T) {
 
 				err := header.SetName(input)
 
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -330,7 +330,7 @@ func TestRestRequestHeader_SetName(t *testing.T) {
 
 				err := header.SetName(internal.ToPointer("name"))
 
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -421,7 +421,7 @@ func TestRestRequestHeader_GetValue(t *testing.T) {
 
 				value, err := header.GetValue()
 
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, value)
 
 				intModel.AssertExpectations(t)
@@ -434,7 +434,7 @@ func TestRestRequestHeader_GetValue(t *testing.T) {
 
 				value, err := header.GetValue()
 
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, value)
 			},
 		},
@@ -506,7 +506,7 @@ func TestRestRequestHeader_SetValue(t *testing.T) {
 
 				err := header.SetValue(input)
 
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -518,7 +518,7 @@ func TestRestRequestHeader_SetValue(t *testing.T) {
 
 				err := header.SetValue(internal.ToPointer("value"))
 
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}

--- a/batchapi/rest_request_test.go
+++ b/batchapi/rest_request_test.go
@@ -248,7 +248,7 @@ func TestRestRequest_GetBody(t *testing.T) {
 				}
 
 				id, err := resp.GetBody()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -258,7 +258,7 @@ func TestRestRequest_GetBody(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				id, err := resp.GetBody()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -376,7 +376,7 @@ func TestRestRequest_SetBody(t *testing.T) {
 				}
 
 				err := resp.SetBody(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -389,7 +389,7 @@ func TestRestRequest_SetBody(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				err := resp.SetBody(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -472,7 +472,7 @@ func TestRestRequest_GetExcludeResponseHeaders(t *testing.T) {
 				}
 
 				id, err := resp.GetExcludeResponseHeaders()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -482,7 +482,7 @@ func TestRestRequest_GetExcludeResponseHeaders(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				id, err := resp.GetExcludeResponseHeaders()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -554,7 +554,7 @@ func TestRestRequest_SetExcludeResponseHeaders(t *testing.T) {
 				}
 
 				err := resp.SetExcludeResponseHeaders(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -567,7 +567,7 @@ func TestRestRequest_SetExcludeResponseHeaders(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				err := resp.SetExcludeResponseHeaders(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -650,7 +650,7 @@ func TestRestRequest_GetHeaders(t *testing.T) {
 				}
 
 				id, err := resp.GetHeaders()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -660,7 +660,7 @@ func TestRestRequest_GetHeaders(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				id, err := resp.GetHeaders()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -732,7 +732,7 @@ func TestRestRequest_SetHeaders(t *testing.T) {
 				}
 
 				err := resp.SetHeaders(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -745,7 +745,7 @@ func TestRestRequest_SetHeaders(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				err := resp.SetHeaders(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -828,7 +828,7 @@ func TestRestRequest_GetID(t *testing.T) {
 				}
 
 				id, err := resp.GetID()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -838,7 +838,7 @@ func TestRestRequest_GetID(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				id, err := resp.GetID()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -910,7 +910,7 @@ func TestRestRequest_SetID(t *testing.T) {
 				}
 
 				err := resp.SetID(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -923,7 +923,7 @@ func TestRestRequest_SetID(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				err := resp.SetID(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -1006,7 +1006,7 @@ func TestRestRequest_GetMethod(t *testing.T) {
 				}
 
 				id, err := resp.GetMethod()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -1016,7 +1016,7 @@ func TestRestRequest_GetMethod(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				id, err := resp.GetMethod()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -1088,7 +1088,7 @@ func TestRestRequest_SetMethod(t *testing.T) {
 				}
 
 				err := resp.SetMethod(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -1101,7 +1101,7 @@ func TestRestRequest_SetMethod(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				err := resp.SetMethod(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -1184,7 +1184,7 @@ func TestRestRequest_GetURL(t *testing.T) {
 				}
 
 				id, err := resp.GetURL()
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -1194,7 +1194,7 @@ func TestRestRequest_GetURL(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				id, err := resp.GetURL()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -1283,7 +1283,7 @@ func TestRestRequest_SetURL(t *testing.T) {
 				}
 
 				err := resp.SetURL(input)
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -1296,7 +1296,7 @@ func TestRestRequest_SetURL(t *testing.T) {
 				resp := (*RestRequestModel)(nil)
 
 				err := resp.SetURL(input)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			},
 		},
 	}

--- a/batchapi/serviced_request_model_test.go
+++ b/batchapi/serviced_request_model_test.go
@@ -287,7 +287,7 @@ func TestServicedRequestModel_GetBody(t *testing.T) {
 				}
 
 				id, err := resp.GetBody()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 				intModel.AssertExpectations(t)
 			},
@@ -298,7 +298,7 @@ func TestServicedRequestModel_GetBody(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				id, err := resp.GetBody()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -370,7 +370,7 @@ func TestServicedRequestModel_setBody(t *testing.T) {
 				}
 
 				err := resp.setBody(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -383,7 +383,7 @@ func TestServicedRequestModel_setBody(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				err := resp.setBody(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -475,7 +475,7 @@ func TestServicedRequestModel_GetErrorMessage(t *testing.T) {
 				}
 
 				id, err := resp.GetErrorMessage()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 				intModel.AssertExpectations(t)
 			},
@@ -486,7 +486,7 @@ func TestServicedRequestModel_GetErrorMessage(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				id, err := resp.GetErrorMessage()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -558,7 +558,7 @@ func TestServicedRequestModel_setErrorMessage(t *testing.T) {
 				}
 
 				err := resp.setErrorMessage(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -571,7 +571,7 @@ func TestServicedRequestModel_setErrorMessage(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				err := resp.setErrorMessage(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -602,7 +602,7 @@ func TestServicedRequestModel_GetExecutionTime(t *testing.T) {
 			test: func(t *testing.T) {
 				var m *ServicedRequestModel
 				res, err := m.GetExecutionTime()
-				assert.NoError(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, res)
 			},
 		},
@@ -632,7 +632,7 @@ func TestServicedRequestModel_setExecutionTime(t *testing.T) {
 			test: func(t *testing.T) {
 				var m *ServicedRequestModel
 				err := m.setExecutionTime(nil)
-				assert.NoError(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -724,7 +724,7 @@ func TestServicedRequestModel_GetHeaders(t *testing.T) {
 				}
 
 				id, err := resp.GetHeaders()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 				intModel.AssertExpectations(t)
 			},
@@ -735,7 +735,7 @@ func TestServicedRequestModel_GetHeaders(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				id, err := resp.GetHeaders()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -807,7 +807,7 @@ func TestServicedRequestModel_setHeaders(t *testing.T) {
 				}
 
 				err := resp.setHeaders(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -820,7 +820,7 @@ func TestServicedRequestModel_setHeaders(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				err := resp.setHeaders(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -912,7 +912,7 @@ func TestServicedRequestModel_GetID(t *testing.T) {
 				}
 
 				id, err := resp.GetID()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 				intModel.AssertExpectations(t)
 			},
@@ -923,7 +923,7 @@ func TestServicedRequestModel_GetID(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				id, err := resp.GetID()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -995,7 +995,7 @@ func TestServicedRequestModel_setID(t *testing.T) {
 				}
 
 				err := resp.setID(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -1008,7 +1008,7 @@ func TestServicedRequestModel_setID(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				err := resp.setID(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -1100,7 +1100,7 @@ func TestServicedRequestModel_GetRedirectURL(t *testing.T) {
 				}
 
 				id, err := resp.GetRedirectURL()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 				intModel.AssertExpectations(t)
 			},
@@ -1111,7 +1111,7 @@ func TestServicedRequestModel_GetRedirectURL(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				id, err := resp.GetRedirectURL()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -1183,7 +1183,7 @@ func TestServicedRequestModel_setRedirectURL(t *testing.T) {
 				}
 
 				err := resp.setRedirectURL(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -1196,7 +1196,7 @@ func TestServicedRequestModel_setRedirectURL(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				err := resp.setRedirectURL(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -1288,7 +1288,7 @@ func TestServicedRequestModel_GetStatusCode(t *testing.T) {
 				}
 
 				id, err := resp.GetStatusCode()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 				intModel.AssertExpectations(t)
 			},
@@ -1299,7 +1299,7 @@ func TestServicedRequestModel_GetStatusCode(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				id, err := resp.GetStatusCode()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -1371,7 +1371,7 @@ func TestServicedRequestModel_setStatusCode(t *testing.T) {
 				}
 
 				err := resp.setStatusCode(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -1384,7 +1384,7 @@ func TestServicedRequestModel_setStatusCode(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				err := resp.setStatusCode(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}
@@ -1476,7 +1476,7 @@ func TestServicedRequestModel_GetStatusText(t *testing.T) {
 				}
 
 				id, err := resp.GetStatusText()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Nil(t, id)
 				intModel.AssertExpectations(t)
 			},
@@ -1487,7 +1487,7 @@ func TestServicedRequestModel_GetStatusText(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				id, err := resp.GetStatusText()
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Nil(t, id)
 			},
 		},
@@ -1559,7 +1559,7 @@ func TestServicedRequestModel_setStatusText(t *testing.T) {
 				}
 
 				err := resp.setStatusText(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("store is nil"), err)
 
 				intModel.AssertExpectations(t)
 			},
@@ -1572,7 +1572,7 @@ func TestServicedRequestModel_setStatusText(t *testing.T) {
 				resp := (*ServicedRequestModel)(nil)
 
 				err := resp.setStatusText(input)
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 			},
 		},
 	}

--- a/core/main_error_test.go
+++ b/core/main_error_test.go
@@ -81,7 +81,7 @@ func TestMainError_Accessors(t *testing.T) {
 			setter:   func(m *MainError, v *string) error { return m.SetDetail(v) },
 			getter:   func(m *MainError) (*string, error) { return m.GetDetail() },
 			expected: nil,
-			wantErr:  false,
+			wantErr:  true,
 		},
 		{
 			name:     "Message Success",
@@ -97,7 +97,7 @@ func TestMainError_Accessors(t *testing.T) {
 			setter:   func(m *MainError, v *string) error { return m.SetMessage(v) },
 			getter:   func(m *MainError) (*string, error) { return m.GetMessage() },
 			expected: nil,
-			wantErr:  false,
+			wantErr:  true,
 		},
 		{
 			name:     "Status Success",
@@ -113,7 +113,7 @@ func TestMainError_Accessors(t *testing.T) {
 			setter:   func(m *MainError, v *string) error { return m.SetStatus(v) },
 			getter:   func(m *MainError) (*string, error) { return m.GetStatus() },
 			expected: nil,
-			wantErr:  false,
+			wantErr:  true,
 		},
 	}
 
@@ -142,12 +142,12 @@ func TestMainError_ErrorBranches(t *testing.T) {
 		fn      func() error
 		wantErr string
 	}{
-		{"GetDetail Nil BS", func() error { _, err := mNilBS.GetDetail(); return err }, "backingStore is nil"},
-		{"setDetail Nil BS", func() error { return mNilBS.SetDetail(nil) }, "backingStore is nil"},
-		{"GetMessage Nil BS", func() error { _, err := mNilBS.GetMessage(); return err }, "backingStore is nil"},
-		{"setMessage Nil BS", func() error { return mNilBS.SetMessage(nil) }, "backingStore is nil"},
-		{"GetStatus Nil BS", func() error { _, err := mNilBS.GetStatus(); return err }, "backingStore is nil"},
-		{"setStatus Nil BS", func() error { return mNilBS.SetStatus(nil) }, "backingStore is nil"},
+		{"GetDetail Nil BS", func() error { _, err := mNilBS.GetDetail(); return err }, "store is nil"},
+		{"setDetail Nil BS", func() error { return mNilBS.SetDetail(nil) }, "store is nil"},
+		{"GetMessage Nil BS", func() error { _, err := mNilBS.GetMessage(); return err }, "store is nil"},
+		{"setMessage Nil BS", func() error { return mNilBS.SetMessage(nil) }, "store is nil"},
+		{"GetStatus Nil BS", func() error { _, err := mNilBS.GetStatus(); return err }, "store is nil"},
+		{"setStatus Nil BS", func() error { return mNilBS.SetStatus(nil) }, "store is nil"},
 	}
 
 	for _, tt := range tests {

--- a/core/service_now_collection_response_test.go
+++ b/core/service_now_collection_response_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"testing"
 
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 	"github.com/stretchr/testify/assert"
 )
@@ -64,13 +65,13 @@ func TestBaseServiceNowCollectionResponse_ErrorBranches(t *testing.T) {
 	var nilR *BaseServiceNowCollectionResponse[*MainError]
 
 	r, err := nilR.GetResult()
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, snerrors.ErrNilModel)
 	assert.Nil(t, r)
 
 	l, err := nilR.GetNextLink()
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, snerrors.ErrNilModel)
 	assert.Nil(t, l)
 
 	err = nilR.SetNextLink(nil)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, snerrors.ErrNilModel)
 }

--- a/core/service_now_error_test.go
+++ b/core/service_now_error_test.go
@@ -53,7 +53,7 @@ func TestServiceNowError_GetError(t *testing.T) {
 		err      bool
 	}{
 		{"Ok", e, me, false},
-		{"NilE", nilE, nil, false},
+		{"NilE", nilE, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestServiceNowError_setError(t *testing.T) {
 		err   bool
 	}{
 		{"Ok", e, me, false},
-		{"NilE", nilE, me, false},
+		{"NilE", nilE, me, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -103,5 +103,5 @@ func TestServiceNowError_ErrorBranches(t *testing.T) {
 	eNilBS := &ServiceNowError{BackedModel: &mockNilBSModel{}}
 	val, err = eNilBS.GetError()
 	assert.Nil(t, val)
-	assert.Equal(t, errors.New("backingStore is nil"), err)
+	assert.Equal(t, errors.New("store is nil"), err)
 }

--- a/core/service_now_item_response_test.go
+++ b/core/service_now_item_response_test.go
@@ -61,7 +61,7 @@ func TestBaseServiceNowItemResponse_GetResult(t *testing.T) {
 		err   bool
 	}{
 		{"Ok", res, false},
-		{"NilM", nilR, false},
+		{"NilM", nilR, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestBaseServiceNowItemResponse_setResult(t *testing.T) {
 		err   bool
 	}{
 		{"Ok", res, me, false},
-		{"NilM", nilR, me, false},
+		{"NilM", nilR, me, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestBaseServiceNowItemResponse_ErrorBranches(t *testing.T) {
 	}
 
 	resNilBS := &BaseServiceNowItemResponse[*MainError]{backingStore: nil, backingStoreFactory: nil}
-	if err := resNilBS.setResult(nil); err == nil || err.Error() != "backingStore is nil" {
+	if err := resNilBS.setResult(nil); err == nil || err.Error() != "store is nil" {
 		t.Errorf("expected store nil error, got %v", err)
 	}
 }

--- a/tableapi/record_element.go
+++ b/tableapi/record_element.go
@@ -2,7 +2,6 @@ package tableapi
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/store"
 )
 
@@ -28,10 +27,6 @@ const (
 
 // GetDisplayValue returns the display value of the element.
 func (rE *RecordElement) GetDisplayValue() (ElementValue, error) {
-	if conversion.IsNil(rE) || conversion.IsNil(rE.BackedModel) {
-		return ElementValue{}, nil
-	}
-
 	return store.DefaultBackedModelAccessorFunc[*RecordElement, ElementValue](rE, recordDisplayValueKey)
 }
 
@@ -59,11 +54,11 @@ func (rE *RecordElement) SetValue(value any) error {
 }
 
 // GetLink returns the reference link of the element, if it is a reference field.
-func (rE *RecordElement) GetLink() (string, error) {
-	return store.DefaultBackedModelAccessorFunc[*RecordElement, string](rE, recordLinkKey)
+func (rE *RecordElement) GetLink() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*RecordElement, *string](rE, recordLinkKey)
 }
 
 // SetLink sets the reference link of the element.
 func (rE *RecordElement) SetLink(link *string) error {
-	return rE.set(recordLinkKey, link)
+	return store.DefaultBackedModelMutatorFunc(rE, recordLinkKey, link)
 }

--- a/tableapi/record_element_test.go
+++ b/tableapi/record_element_test.go
@@ -85,7 +85,7 @@ func TestRecordElementModel_GetDisplayValue(t *testing.T) {
 
 				elementValue, err := model.GetDisplayValue()
 
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Equal(t, ElementValue{}, elementValue)
 			},
 		},
@@ -96,7 +96,7 @@ func TestRecordElementModel_GetDisplayValue(t *testing.T) {
 
 				elementValue, err := model.GetDisplayValue()
 
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Equal(t, ElementValue{}, elementValue)
 			},
 		},
@@ -219,7 +219,7 @@ func TestRecordElementModel_GetValue(t *testing.T) {
 
 				elementValue, err := model.GetValue()
 
-				assert.Equal(t, errors.New("backingStore is nil"), err)
+				assert.Equal(t, errors.New("store is nil"), err)
 				assert.Equal(t, ElementValue{}, elementValue)
 			},
 		},
@@ -230,7 +230,7 @@ func TestRecordElementModel_GetValue(t *testing.T) {
 
 				elementValue, err := model.GetValue()
 
-				assert.Nil(t, err)
+				assert.Equal(t, errors.New("model is nil"), err)
 				assert.Equal(t, ElementValue{}, elementValue)
 			},
 		},
@@ -321,7 +321,7 @@ func TestRecordElementModel_GetLink(t *testing.T) {
 
 				assert.Nil(t, err)
 				assert.NotNil(t, elementValue)
-				assert.Equal(t, *value, elementValue)
+				assert.Equal(t, value, elementValue)
 			},
 		},
 		{
@@ -338,7 +338,7 @@ func TestRecordElementModel_GetLink(t *testing.T) {
 				elementValue, err := model.GetLink()
 
 				assert.Equal(t, errors.New("retrieval error"), err)
-				assert.Equal(t, "", elementValue)
+				assert.Nil(t, elementValue)
 			},
 		},
 		{
@@ -351,8 +351,8 @@ func TestRecordElementModel_GetLink(t *testing.T) {
 
 				elementValue, err := model.GetLink()
 
-				assert.Equal(t, errors.New("backingStore is nil"), err)
-				assert.Equal(t, "", elementValue)
+				assert.Equal(t, errors.New("store is nil"), err)
+				assert.Nil(t, elementValue)
 			},
 		},
 		{
@@ -362,8 +362,8 @@ func TestRecordElementModel_GetLink(t *testing.T) {
 
 				elementValue, err := model.GetLink()
 
-				assert.Nil(t, err)
-				assert.Equal(t, "", elementValue)
+				assert.Equal(t, errors.New("model is nil"), err)
+				assert.Nil(t, elementValue)
 			},
 		},
 	}
@@ -384,7 +384,7 @@ func TestRecordElementModel_SetLink(t *testing.T) {
 				link := internal.ToPointer("value")
 
 				backingStore := mocking.NewMockBackingStore()
-				backingStore.On("Set", "link", *link).Return(nil)
+				backingStore.On("Set", "link", link).Return(nil)
 
 				innerModel := mocking.NewMockModel()
 				innerModel.On("GetBackingStore").Return(backingStore)
@@ -404,7 +404,7 @@ func TestRecordElementModel_SetLink(t *testing.T) {
 				link := internal.ToPointer("value")
 
 				backingStore := mocking.NewMockBackingStore()
-				backingStore.On("Set", "link", *link).Return(errors.New("store error"))
+				backingStore.On("Set", "link", link).Return(errors.New("store error"))
 
 				innerModel := mocking.NewMockModel()
 				innerModel.On("GetBackingStore").Return(backingStore)


### PR DESCRIPTION
## Summary
- Fixes a real bug in `tableapi.RecordElement`: `SetLink` wrapped its value in `ElementValue` before storing it while `GetLink` read the store back out as a plain type, causing a runtime panic when both were exercised together. `GetLink`/`SetLink` now consistently use `*string`.
- Updates stale nil-model/nil-store test expectations in `attachmentapi`, `batchapi`, `core`, and `tableapi` that predated the `95ee5a9` store-accessor refactor and still asserted the old silent-zero-value contract instead of the current `ErrNilModel`/`ErrNilStore` sentinel errors — this was the reason `go test ./...` failed (and panicked) on `release/2.0`.

## Test plan
- `go build ./...` — clean
- `go test ./...` — full suite passes, no panics
- `golangci-lint run ./...` — no new findings (same 23 pre-existing, unrelated)

**BREAKING CHANGE**: `RecordElement.GetLink` now returns `(*string, error)` instead of `(string, error)`.