### PR TITLE
refactor(all): eliminate golangci-lint dupl findings and add request-builder shape interfaces

### DIFF
--- a/actsubapi/activities_request_builder.go
+++ b/actsubapi/activities_request_builder.go
@@ -1,6 +1,10 @@
 package actsubapi
 
 import (
+	"context"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -18,4 +22,20 @@ func NewActivitiesRequestBuilderInternal(pathParameters map[string]string, reque
 	return &ActivitiesRequestBuilder{
 		newCollectionGetRequestBuilder(pathParameters, requestAdapter, activitiesURLTemplate),
 	}
+}
+
+// Get sends a GET request to retrieve activities.
+func (rB *ActivitiesRequestBuilder) Get(ctx context.Context, config *ActivitiesRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.Get(ctx, config)
+}
+
+// ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve activities.
+func (rB *ActivitiesRequestBuilder) ToGetRequestInformation(ctx context.Context, config *ActivitiesRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/activities_request_builder.go
+++ b/actsubapi/activities_request_builder.go
@@ -1,12 +1,6 @@
 package actsubapi
 
 import (
-	"context"
-
-	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,51 +10,12 @@ const (
 
 // ActivitiesRequestBuilder provides operations to manage activities.
 type ActivitiesRequestBuilder struct {
-	core.RequestBuilder
+	*collectionGetRequestBuilder
 }
 
 // NewActivitiesRequestBuilderInternal instantiates a new ActivitiesRequestBuilder.
 func NewActivitiesRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *ActivitiesRequestBuilder {
 	return &ActivitiesRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, activitiesURLTemplate, pathParameters),
+		newCollectionGetRequestBuilder(pathParameters, requestAdapter, activitiesURLTemplate),
 	}
-}
-
-// Get sends a GET request to retrieve activities.
-func (rB *ActivitiesRequestBuilder) Get(ctx context.Context, config *ActivitiesRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowCollectionResponseFromDiscriminatorValue[*ActivitySubscriptionModel](CreateActivitySubscriptionModelFromDiscriminatorValue), core.DefaultErrorMapping())
-	if err != nil {
-		return nil, err
-	}
-
-	if res == nil {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel]), nil
-}
-
-// ToGetRequestInformation creates a RequestInformation object for a GET request.
-func (rB *ActivitiesRequestBuilder) ToGetRequestInformation(ctx context.Context, config *ActivitiesRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-
-	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
-
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return requestInfo, nil
 }

--- a/actsubapi/collection_get_request_builder.go
+++ b/actsubapi/collection_get_request_builder.go
@@ -1,0 +1,67 @@
+package actsubapi
+
+import (
+	"context"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
+	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+)
+
+// collectionGetRequestBuilder is the shared implementation behind every actsubapi
+// request builder whose only operation is a GET returning a collection of
+// ActivitySubscriptionModel (Activities, Contexts, SubObjects, FollowingItem,
+// SubscriberItem) - they differ only in URL template.
+type collectionGetRequestBuilder struct {
+	core.RequestBuilder
+}
+
+var _ core.CollectionGetRequestBuilder[*ActivitySubscriptionModel, abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*collectionGetRequestBuilder)(nil)
+
+// newCollectionGetRequestBuilder instantiates a new collectionGetRequestBuilder.
+func newCollectionGetRequestBuilder(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter, urlTemplate string) *collectionGetRequestBuilder {
+	return &collectionGetRequestBuilder{
+		core.NewBaseRequestBuilder(requestAdapter, urlTemplate, pathParameters),
+	}
+}
+
+// Get sends a GET request to retrieve the collection.
+func (rB *collectionGetRequestBuilder) Get(ctx context.Context, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, nil
+	}
+
+	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowCollectionResponseFromDiscriminatorValue[*ActivitySubscriptionModel](CreateActivitySubscriptionModelFromDiscriminatorValue), core.DefaultErrorMapping())
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, nil
+	}
+
+	return res.(*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel]), nil
+}
+
+// ToGetRequestInformation creates a RequestInformation object for a GET request.
+func (rB *collectionGetRequestBuilder) ToGetRequestInformation(ctx context.Context, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, nil
+	}
+
+	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
+	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
+
+	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
+
+	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
+
+	return requestInfo, nil
+}

--- a/actsubapi/collection_get_request_builder_test.go
+++ b/actsubapi/collection_get_request_builder_test.go
@@ -1,0 +1,125 @@
+package actsubapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCollectionGetRequestBuilder_Get(t *testing.T) {
+	type testCase struct {
+		name       string
+		nilBuilder bool
+		nilInner   bool
+		config     *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]
+		mockRes    interface{}
+		mockErr    error
+		expectErr  bool
+	}
+
+	tests := []testCase{
+		{
+			name:      "Success",
+			mockRes:   core.NewBaseServiceNowCollectionResponse[*ActivitySubscriptionModel](CreateActivitySubscriptionModelFromDiscriminatorValue),
+			expectErr: false,
+		},
+		{
+			name:      "Error",
+			mockErr:   assert.AnError,
+			expectErr: true,
+		},
+		{
+			name: "NilResponse",
+		},
+		{
+			name:       "Nil builder",
+			nilBuilder: true,
+		},
+		{
+			name:     "Nil inner request builder",
+			nilInner: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var builder *collectionGetRequestBuilder
+
+			switch {
+			case tc.nilBuilder:
+				builder = nil
+			case tc.nilInner:
+				builder = &collectionGetRequestBuilder{nil}
+			default:
+				adapter := &mocking.MockRequestAdapter{}
+				adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tc.mockRes, tc.mockErr)
+				builder = newCollectionGetRequestBuilder(map[string]string{"baseurl": "https://example.com"}, adapter, activitiesURLTemplate)
+			}
+
+			resp, err := builder.Get(context.Background(), tc.config)
+
+			switch {
+			case tc.nilBuilder, tc.nilInner:
+				assert.NoError(t, err)
+				assert.Nil(t, resp)
+			case tc.expectErr:
+				assert.Error(t, err)
+				assert.Nil(t, resp)
+			default:
+				assert.NoError(t, err)
+				if tc.mockRes != nil {
+					assert.Equal(t, tc.mockRes, resp)
+				} else {
+					assert.Nil(t, resp)
+				}
+			}
+		})
+	}
+}
+
+func TestCollectionGetRequestBuilder_ToGetRequestInformation(t *testing.T) {
+	tests := []struct {
+		name       string
+		nilBuilder bool
+		nilInner   bool
+	}{
+		{name: "Success"},
+		{name: "Nil builder", nilBuilder: true},
+		{name: "Nil inner request builder", nilInner: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var builder *collectionGetRequestBuilder
+
+			switch {
+			case tt.nilBuilder:
+				builder = nil
+			case tt.nilInner:
+				builder = &collectionGetRequestBuilder{nil}
+			default:
+				adapter := &mocking.MockRequestAdapter{}
+				builder = newCollectionGetRequestBuilder(map[string]string{"baseurl": "https://example.com"}, adapter, activitiesURLTemplate)
+			}
+
+			reqInfo, err := builder.ToGetRequestInformation(context.Background(), nil)
+
+			if tt.nilBuilder || tt.nilInner {
+				assert.NoError(t, err)
+				assert.Nil(t, reqInfo)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, reqInfo)
+			assert.Equal(t, abstractions.GET, reqInfo.Method)
+			assert.Equal(t, activitiesURLTemplate, reqInfo.UrlTemplate)
+			assert.Equal(t, "https://example.com", reqInfo.PathParameters["baseurl"])
+		})
+	}
+}

--- a/actsubapi/contexts_request_builder.go
+++ b/actsubapi/contexts_request_builder.go
@@ -1,12 +1,6 @@
 package actsubapi
 
 import (
-	"context"
-
-	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,51 +10,12 @@ const (
 
 // ContextsRequestBuilder provides operations to manage contexts.
 type ContextsRequestBuilder struct {
-	core.RequestBuilder
+	*collectionGetRequestBuilder
 }
 
 // NewContextsRequestBuilderInternal instantiates a new ContextsRequestBuilder.
 func NewContextsRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *ContextsRequestBuilder {
 	return &ContextsRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, contextsURLTemplate, pathParameters),
+		newCollectionGetRequestBuilder(pathParameters, requestAdapter, contextsURLTemplate),
 	}
-}
-
-// Get sends a GET request to retrieve contexts.
-func (rB *ContextsRequestBuilder) Get(ctx context.Context, config *ContextsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowCollectionResponseFromDiscriminatorValue[*ActivitySubscriptionModel](CreateActivitySubscriptionModelFromDiscriminatorValue), core.DefaultErrorMapping())
-	if err != nil {
-		return nil, err
-	}
-
-	if res == nil {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel]), nil
-}
-
-// ToGetRequestInformation creates a RequestInformation object for a GET request.
-func (rB *ContextsRequestBuilder) ToGetRequestInformation(ctx context.Context, config *ContextsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-
-	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
-
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return requestInfo, nil
 }

--- a/actsubapi/contexts_request_builder.go
+++ b/actsubapi/contexts_request_builder.go
@@ -1,6 +1,10 @@
 package actsubapi
 
 import (
+	"context"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -18,4 +22,20 @@ func NewContextsRequestBuilderInternal(pathParameters map[string]string, request
 	return &ContextsRequestBuilder{
 		newCollectionGetRequestBuilder(pathParameters, requestAdapter, contextsURLTemplate),
 	}
+}
+
+// Get sends a GET request to retrieve contexts.
+func (rB *ContextsRequestBuilder) Get(ctx context.Context, config *ContextsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.Get(ctx, config)
+}
+
+// ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve contexts.
+func (rB *ContextsRequestBuilder) ToGetRequestInformation(ctx context.Context, config *ContextsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/following_request_builder.go
+++ b/actsubapi/following_request_builder.go
@@ -1,6 +1,7 @@
-package actsubapi
+package actsubapi // nolint:dupl // FollowingItemRequestBuilder/SubscriberItemRequestBuilder's nil-guard wrapper methods are inherently near-identical (each depends on which specific outer type is nil, so it can't be extracted into the shared collectionGetRequestBuilder)
 
 import (
+	"context"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -47,4 +48,20 @@ func NewFollowingItemRequestBuilderInternal(pathParameters map[string]string, re
 	return &FollowingItemRequestBuilder{
 		newCollectionGetRequestBuilder(pathParameters, requestAdapter, followingItemURLTemplate),
 	}
+}
+
+// Get sends a GET request to retrieve following.
+func (rB *FollowingItemRequestBuilder) Get(ctx context.Context, config *FollowingsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.Get(ctx, config)
+}
+
+// ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve following.
+func (rB *FollowingItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *FollowingsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/following_request_builder.go
+++ b/actsubapi/following_request_builder.go
@@ -1,13 +1,10 @@
 package actsubapi
 
 import (
-	"context"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -40,7 +37,7 @@ func (rB *FollowingsRequestBuilder) ByFollower(follower string) *FollowingItemRe
 
 // FollowingItemRequestBuilder provides operations to manage following for a specific user.
 type FollowingItemRequestBuilder struct {
-	core.RequestBuilder
+	*collectionGetRequestBuilder
 }
 
 const followingItemURLTemplate = "{+baseurl}/api/now/v1/actsub/followings/{follower}"
@@ -48,45 +45,6 @@ const followingItemURLTemplate = "{+baseurl}/api/now/v1/actsub/followings/{follo
 // NewFollowingItemRequestBuilderInternal instantiates a new FollowingItemRequestBuilder.
 func NewFollowingItemRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *FollowingItemRequestBuilder {
 	return &FollowingItemRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, followingItemURLTemplate, pathParameters),
+		newCollectionGetRequestBuilder(pathParameters, requestAdapter, followingItemURLTemplate),
 	}
-}
-
-// Get sends a GET request to retrieve following.
-func (rB *FollowingItemRequestBuilder) Get(ctx context.Context, config *FollowingsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowCollectionResponseFromDiscriminatorValue[*ActivitySubscriptionModel](CreateActivitySubscriptionModelFromDiscriminatorValue), core.DefaultErrorMapping())
-	if err != nil {
-		return nil, err
-	}
-
-	if res == nil {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel]), nil
-}
-
-// ToGetRequestInformation creates a RequestInformation object for a GET request.
-func (rB *FollowingItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *FollowingsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-
-	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
-
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return requestInfo, nil
 }

--- a/actsubapi/preferences_request_builder.go
+++ b/actsubapi/preferences_request_builder.go
@@ -20,6 +20,8 @@ type PreferencesRequestBuilder struct {
 	core.RequestBuilder
 }
 
+var _ core.ItemPostRequestBuilder[*ActivitySubscriptionModel, abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*PreferencesRequestBuilder)(nil)
+
 // NewPreferencesRequestBuilderInternal instantiates a new PreferencesRequestBuilder.
 func NewPreferencesRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *PreferencesRequestBuilder {
 	return &PreferencesRequestBuilder{

--- a/actsubapi/sub_objects_request_builder.go
+++ b/actsubapi/sub_objects_request_builder.go
@@ -1,6 +1,10 @@
 package actsubapi
 
 import (
+	"context"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -18,4 +22,20 @@ func NewSubObjectsRequestBuilderInternal(pathParameters map[string]string, reque
 	return &SubObjectsRequestBuilder{
 		newCollectionGetRequestBuilder(pathParameters, requestAdapter, subObjectsURLTemplate),
 	}
+}
+
+// Get sends a GET request to retrieve subscribable objects.
+func (rB *SubObjectsRequestBuilder) Get(ctx context.Context, config *SubObjectsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.Get(ctx, config)
+}
+
+// ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve subscribable objects.
+func (rB *SubObjectsRequestBuilder) ToGetRequestInformation(ctx context.Context, config *SubObjectsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/sub_objects_request_builder.go
+++ b/actsubapi/sub_objects_request_builder.go
@@ -1,12 +1,6 @@
 package actsubapi
 
 import (
-	"context"
-
-	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,51 +10,12 @@ const (
 
 // SubObjectsRequestBuilder provides operations to manage subscribable objects.
 type SubObjectsRequestBuilder struct {
-	core.RequestBuilder
+	*collectionGetRequestBuilder
 }
 
 // NewSubObjectsRequestBuilderInternal instantiates a new SubObjectsRequestBuilder.
 func NewSubObjectsRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *SubObjectsRequestBuilder {
 	return &SubObjectsRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, subObjectsURLTemplate, pathParameters),
+		newCollectionGetRequestBuilder(pathParameters, requestAdapter, subObjectsURLTemplate),
 	}
-}
-
-// Get sends a GET request to retrieve subscribable objects.
-func (rB *SubObjectsRequestBuilder) Get(ctx context.Context, config *SubObjectsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowCollectionResponseFromDiscriminatorValue[*ActivitySubscriptionModel](CreateActivitySubscriptionModelFromDiscriminatorValue), core.DefaultErrorMapping())
-	if err != nil {
-		return nil, err
-	}
-
-	if res == nil {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel]), nil
-}
-
-// ToGetRequestInformation creates a RequestInformation object for a GET request.
-func (rB *SubObjectsRequestBuilder) ToGetRequestInformation(ctx context.Context, config *SubObjectsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-
-	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
-
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return requestInfo, nil
 }

--- a/actsubapi/subscribers_request_builder.go
+++ b/actsubapi/subscribers_request_builder.go
@@ -1,6 +1,7 @@
-package actsubapi
+package actsubapi // nolint:dupl // FollowingItemRequestBuilder/SubscriberItemRequestBuilder's nil-guard wrapper methods are inherently near-identical (each depends on which specific outer type is nil, so it can't be extracted into the shared collectionGetRequestBuilder)
 
 import (
+	"context"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -47,4 +48,20 @@ func NewSubscriberItemRequestBuilderInternal(pathParameters map[string]string, r
 	return &SubscriberItemRequestBuilder{
 		newCollectionGetRequestBuilder(pathParameters, requestAdapter, subscriberItemURLTemplate),
 	}
+}
+
+// Get sends a GET request to retrieve subscribers.
+func (rB *SubscriberItemRequestBuilder) Get(ctx context.Context, config *SubscribersRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.Get(ctx, config)
+}
+
+// ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve subscribers.
+func (rB *SubscriberItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *SubscribersRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/subscribers_request_builder.go
+++ b/actsubapi/subscribers_request_builder.go
@@ -1,13 +1,10 @@
 package actsubapi
 
 import (
-	"context"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -40,7 +37,7 @@ func (rB *SubscribersRequestBuilder) BySubObject(subObject string) *SubscriberIt
 
 // SubscriberItemRequestBuilder provides operations to manage subscribers for a specific object.
 type SubscriberItemRequestBuilder struct {
-	core.RequestBuilder
+	*collectionGetRequestBuilder
 }
 
 const subscriberItemURLTemplate = "{+baseurl}/api/now/v1/actsub/subscribers/{sub_object}"
@@ -48,45 +45,6 @@ const subscriberItemURLTemplate = "{+baseurl}/api/now/v1/actsub/subscribers/{sub
 // NewSubscriberItemRequestBuilderInternal instantiates a new SubscriberItemRequestBuilder.
 func NewSubscriberItemRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *SubscriberItemRequestBuilder {
 	return &SubscriberItemRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, subscriberItemURLTemplate, pathParameters),
+		newCollectionGetRequestBuilder(pathParameters, requestAdapter, subscriberItemURLTemplate),
 	}
-}
-
-// Get sends a GET request to retrieve subscribers.
-func (rB *SubscriberItemRequestBuilder) Get(ctx context.Context, config *SubscribersRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowCollectionResponseFromDiscriminatorValue[*ActivitySubscriptionModel](CreateActivitySubscriptionModelFromDiscriminatorValue), core.DefaultErrorMapping())
-	if err != nil {
-		return nil, err
-	}
-
-	if res == nil {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel]), nil
-}
-
-// ToGetRequestInformation creates a RequestInformation object for a GET request.
-func (rB *SubscriberItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *SubscribersRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-
-	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
-
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return requestInfo, nil
 }

--- a/actsubapi/subscriptions_request_builder.go
+++ b/actsubapi/subscriptions_request_builder.go
@@ -201,6 +201,8 @@ type SubscribeRequestBuilder struct {
 	core.RequestBuilder
 }
 
+var _ core.ItemPostRequestBuilder[*ActivitySubscriptionModel, abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*SubscribeRequestBuilder)(nil)
+
 const subscribeURLTemplate = "{+baseurl}/api/now/v1/actsub/subscriptions/{sub_obj_id}/subscribe"
 
 // NewSubscribeRequestBuilderInternal instantiates a new SubscribeRequestBuilder.
@@ -260,6 +262,8 @@ func (rB *SubscribeRequestBuilder) ToPostRequestInformation(ctx context.Context,
 type UnsubscribeRequestBuilder struct {
 	core.RequestBuilder
 }
+
+var _ core.ItemDeleteRequestBuilder[abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*UnsubscribeRequestBuilder)(nil)
 
 const unsubscribeURLTemplate = "{+baseurl}/api/now/v1/actsub/subscriptions/{sub_obj_id}/unsubscribe"
 

--- a/appointmentbookingapi/calendar_response.go
+++ b/appointmentbookingapi/calendar_response.go
@@ -1,4 +1,4 @@
-package appointmentbookingapi
+package appointmentbookingapi // nolint:dupl // shares field-count shape with UserTimeFormatModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"

--- a/appointmentbookingapi/rp_variable.go
+++ b/appointmentbookingapi/rp_variable.go
@@ -1,4 +1,4 @@
-package appointmentbookingapi
+package appointmentbookingapi // nolint:dupl // shares field-count shape with UserTimeFormatOptionsModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"

--- a/appointmentbookingapi/user_time_format.go
+++ b/appointmentbookingapi/user_time_format.go
@@ -1,4 +1,4 @@
-package appointmentbookingapi
+package appointmentbookingapi // nolint:dupl // shares field-count shape with CalendarResponseModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"

--- a/appointmentbookingapi/user_time_format_options.go
+++ b/appointmentbookingapi/user_time_format_options.go
@@ -1,4 +1,4 @@
-package appointmentbookingapi
+package appointmentbookingapi // nolint:dupl // shares field-count shape with RpVariableModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"

--- a/appserviceapi/create_request_builder.go
+++ b/appserviceapi/create_request_builder.go
@@ -3,6 +3,7 @@ package appserviceapi
 import (
 	"context"
 
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -20,10 +21,16 @@ func NewCreateRequestBuilderInternal(pathParameters map[string]string, requestAd
 
 // Post sends a POST request to create an application service.
 func (rB *CreateRequestBuilder) Post(ctx context.Context, body *CreateServiceRequest, config *CreateRequestConfiguration) (CreateServiceResponse, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.post(ctx, body, config)
 }
 
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *CreateRequestBuilder) ToPostRequestInformation(ctx context.Context, body *CreateServiceRequest, config *CreateRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.toPostRequestInformation(ctx, body, config)
 }

--- a/appserviceapi/create_request_builder.go
+++ b/appserviceapi/create_request_builder.go
@@ -3,61 +3,27 @@ package appserviceapi
 import (
 	"context"
 
-	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 // CreateRequestBuilder provides operations to create an application service.
 type CreateRequestBuilder struct {
-	core.RequestBuilder
+	*servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse]
 }
 
 // NewCreateRequestBuilderInternal instantiates a new CreateRequestBuilder.
 func NewCreateRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *CreateRequestBuilder {
 	return &CreateRequestBuilder{
-		RequestBuilder: core.NewBaseRequestBuilder(requestAdapter, createURLTemplate, pathParameters),
+		newServicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse](requestAdapter, createURLTemplate, pathParameters, CreateCreateServiceResponseFromDiscriminatorValue),
 	}
 }
 
 // Post sends a POST request to create an application service.
 func (rB *CreateRequestBuilder) Post(ctx context.Context, body *CreateServiceRequest, config *CreateRequestConfiguration) (CreateServiceResponse, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
-	if err != nil {
-		return nil, err
-	}
-	errorMapping := core.DefaultErrorMapping()
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateCreateServiceResponseFromDiscriminatorValue, errorMapping)
-	if err != nil {
-		return nil, err
-	}
-	if res == nil {
-		return nil, nil
-	}
-	return res.(CreateServiceResponse), nil
+	return rB.post(ctx, body, config)
 }
 
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *CreateRequestBuilder) ToPostRequestInformation(ctx context.Context, body *CreateServiceRequest, config *CreateRequestConfiguration) (*abstractions.RequestInformation, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-
-	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
-
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), body)
-	if err != nil {
-		return nil, err
-	}
-	return kiotaRequestInfo.RequestInformation, nil
+	return rB.toPostRequestInformation(ctx, body, config)
 }

--- a/appserviceapi/register_service_request_builder.go
+++ b/appserviceapi/register_service_request_builder.go
@@ -3,6 +3,7 @@ package appserviceapi
 import (
 	"context"
 
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -20,10 +21,16 @@ func NewRegisterServiceRequestBuilderInternal(pathParameters map[string]string, 
 
 // Post sends a POST request to register a service.
 func (rB *RegisterServiceRequestBuilder) Post(ctx context.Context, body *RegisterServiceRequest, config *RegisterServiceRequestConfiguration) (RegisterServiceResponse, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.post(ctx, body, config)
 }
 
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *RegisterServiceRequestBuilder) ToPostRequestInformation(ctx context.Context, body *RegisterServiceRequest, config *RegisterServiceRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.toPostRequestInformation(ctx, body, config)
 }

--- a/appserviceapi/register_service_request_builder.go
+++ b/appserviceapi/register_service_request_builder.go
@@ -3,61 +3,27 @@ package appserviceapi
 import (
 	"context"
 
-	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 // RegisterServiceRequestBuilder provides operations to register a CSDM service.
 type RegisterServiceRequestBuilder struct {
-	core.RequestBuilder
+	*servicePostRequestBuilder[*RegisterServiceRequest, RegisterServiceResponse]
 }
 
 // NewRegisterServiceRequestBuilderInternal instantiates a new RegisterServiceRequestBuilder.
 func NewRegisterServiceRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *RegisterServiceRequestBuilder {
 	return &RegisterServiceRequestBuilder{
-		RequestBuilder: core.NewBaseRequestBuilder(requestAdapter, registerServiceURLTemplate, pathParameters),
+		newServicePostRequestBuilder[*RegisterServiceRequest, RegisterServiceResponse](requestAdapter, registerServiceURLTemplate, pathParameters, CreateRegisterServiceResponseFromDiscriminatorValue),
 	}
 }
 
 // Post sends a POST request to register a service.
 func (rB *RegisterServiceRequestBuilder) Post(ctx context.Context, body *RegisterServiceRequest, config *RegisterServiceRequestConfiguration) (RegisterServiceResponse, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
-	if err != nil {
-		return nil, err
-	}
-	errorMapping := core.DefaultErrorMapping()
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateRegisterServiceResponseFromDiscriminatorValue, errorMapping)
-	if err != nil {
-		return nil, err
-	}
-	if res == nil {
-		return nil, nil
-	}
-	return res.(RegisterServiceResponse), nil
+	return rB.post(ctx, body, config)
 }
 
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *RegisterServiceRequestBuilder) ToPostRequestInformation(ctx context.Context, body *RegisterServiceRequest, config *RegisterServiceRequestConfiguration) (*abstractions.RequestInformation, error) {
-	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
-	}
-
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-
-	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
-
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), body)
-	if err != nil {
-		return nil, err
-	}
-	return kiotaRequestInfo.RequestInformation, nil
+	return rB.toPostRequestInformation(ctx, body, config)
 }

--- a/appserviceapi/service_post_request_builder.go
+++ b/appserviceapi/service_post_request_builder.go
@@ -1,0 +1,71 @@
+package appserviceapi
+
+import (
+	"context"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
+	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+)
+
+// servicePostRequestBuilder is the shared implementation behind every appserviceapi
+// request builder whose only operation is a POST with a Parsable body returning a
+// single response (Create, RegisterService) - they differ only in URL template,
+// body type, response type, and response factory.
+type servicePostRequestBuilder[TBody serialization.Parsable, TResponse any] struct {
+	core.RequestBuilder
+	responseFactory serialization.ParsableFactory
+}
+
+// newServicePostRequestBuilder instantiates a new servicePostRequestBuilder.
+func newServicePostRequestBuilder[TBody serialization.Parsable, TResponse any](requestAdapter abstractions.RequestAdapter, urlTemplate string, pathParameters map[string]string, responseFactory serialization.ParsableFactory) *servicePostRequestBuilder[TBody, TResponse] {
+	return &servicePostRequestBuilder[TBody, TResponse]{
+		RequestBuilder:  core.NewBaseRequestBuilder(requestAdapter, urlTemplate, pathParameters),
+		responseFactory: responseFactory,
+	}
+}
+
+// post sends a POST request with the given body and returns the decoded response.
+func (rB *servicePostRequestBuilder[TBody, TResponse]) post(ctx context.Context, body TBody, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (TResponse, error) {
+	var zero TResponse
+
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return zero, nil
+	}
+
+	requestInfo, err := rB.toPostRequestInformation(ctx, body, config)
+	if err != nil {
+		return zero, err
+	}
+	errorMapping := core.DefaultErrorMapping()
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, rB.responseFactory, errorMapping)
+	if err != nil {
+		return zero, err
+	}
+	if res == nil {
+		return zero, nil
+	}
+	return res.(TResponse), nil
+}
+
+// toPostRequestInformation creates a RequestInformation object for a POST request.
+func (rB *servicePostRequestBuilder[TBody, TResponse]) toPostRequestInformation(ctx context.Context, body TBody, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, nil
+	}
+
+	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
+	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
+
+	internal.ConfigureRequestInformation(kiotaRequestInfo, config)
+
+	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
+	err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	return kiotaRequestInfo.RequestInformation, nil
+}

--- a/appserviceapi/service_post_request_builder_test.go
+++ b/appserviceapi/service_post_request_builder_test.go
@@ -1,0 +1,120 @@
+package appserviceapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	jsonserialization "github.com/microsoft/kiota-serialization-json-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newTestServicePostRequestBuilder(adapter *mocking.MockRequestAdapter) *servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse] {
+	return newServicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse](
+		adapter,
+		createURLTemplate,
+		map[string]string{"baseurl": "https://example.com"},
+		CreateCreateServiceResponseFromDiscriminatorValue,
+	)
+}
+
+func TestServicePostRequestBuilder_Post(t *testing.T) {
+	tests := []struct {
+		name        string
+		nilBuilder  bool
+		nilInner    bool
+		setupMock   func(*mocking.MockRequestAdapter)
+		expectedErr error
+	}{
+		{
+			name: "Success",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(core.NewBaseServiceNowItemResponse[*CreateServiceResult](CreateCreateServiceResultFromDiscriminatorValue), nil)
+			},
+		},
+		{
+			name: "Error",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("post failed"))
+			},
+			expectedErr: errors.New("post failed"),
+		},
+		{
+			name: "Nil response",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			},
+		},
+		{
+			name:       "Nil builder",
+			nilBuilder: true,
+		},
+		{
+			name:     "Nil inner request builder",
+			nilInner: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var builder *servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse]
+
+			switch {
+			case tt.nilBuilder:
+				builder = nil
+			case tt.nilInner:
+				builder = &servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse]{}
+			default:
+				adapter := mocking.NewMockRequestAdapter()
+				adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+				tt.setupMock(adapter)
+				builder = newTestServicePostRequestBuilder(adapter)
+			}
+
+			resp, err := builder.post(context.Background(), NewCreateServiceRequest(), nil)
+
+			switch {
+			case tt.nilBuilder, tt.nilInner:
+				assert.NoError(t, err)
+				assert.Nil(t, resp)
+			case tt.expectedErr != nil:
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				assert.Nil(t, resp)
+			default:
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServicePostRequestBuilder_ToPostRequestInformation(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+
+	builder := newTestServicePostRequestBuilder(adapter)
+
+	reqInfo, err := builder.toPostRequestInformation(context.Background(), NewCreateServiceRequest(), nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, reqInfo)
+	assert.Equal(t, abstractions.POST, reqInfo.Method)
+	assert.Equal(t, createURLTemplate, reqInfo.UrlTemplate)
+
+	t.Run("Nil builder", func(t *testing.T) {
+		var builder *servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse]
+		reqInfo, err := builder.toPostRequestInformation(context.Background(), NewCreateServiceRequest(), nil)
+		assert.NoError(t, err)
+		assert.Nil(t, reqInfo)
+	})
+
+	t.Run("Nil inner request builder", func(t *testing.T) {
+		builder := &servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse]{}
+		reqInfo, err := builder.toPostRequestInformation(context.Background(), NewCreateServiceRequest(), nil)
+		assert.NoError(t, err)
+		assert.Nil(t, reqInfo)
+	})
+}

--- a/cdmapplicationsapi/collection_upload_request.go
+++ b/cdmapplicationsapi/collection_upload_request.go
@@ -1,4 +1,4 @@
-package cdmapplicationsapi
+package cdmapplicationsapi // nolint:dupl // shares field-count shape with ComponentUploadRequest/ExportStatusResult by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"

--- a/cdmapplicationsapi/component_upload_request.go
+++ b/cdmapplicationsapi/component_upload_request.go
@@ -1,4 +1,4 @@
-package cdmapplicationsapi
+package cdmapplicationsapi // nolint:dupl // shares field-count shape with CollectionUploadRequest/ExportStatusResult by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"

--- a/cdmapplicationsapi/export_status_result.go
+++ b/cdmapplicationsapi/export_status_result.go
@@ -1,4 +1,4 @@
-package cdmapplicationsapi
+package cdmapplicationsapi // nolint:dupl // shares field-count shape with CollectionUploadRequest/ComponentUploadRequest by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (
 	"github.com/michaeldcanady/servicenow-sdk-go/core"

--- a/cmdbinstanceapi/cmdb_class_request_builder.go
+++ b/cmdbinstanceapi/cmdb_class_request_builder.go
@@ -20,6 +20,8 @@ type CmdbClassRequestBuilder struct {
 	core.RequestBuilder
 }
 
+var _ core.ItemPostRequestBuilder[CmdbInstance, abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*CmdbClassRequestBuilder)(nil)
+
 // NewCmdbClassRequestBuilderInternal instantiates a new CmdbClassRequestBuilder.
 func NewCmdbClassRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *CmdbClassRequestBuilder {
 	return &CmdbClassRequestBuilder{

--- a/cmdbinstanceapi/cmdb_item_request_builder.go
+++ b/cmdbinstanceapi/cmdb_item_request_builder.go
@@ -20,6 +20,9 @@ type CmdbItemRequestBuilder struct {
 	core.RequestBuilder
 }
 
+var _ core.ItemGetRequestBuilder[CmdbInstance, abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*CmdbItemRequestBuilder)(nil)
+var _ core.ItemPatchRequestBuilder[CmdbInstance, abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*CmdbItemRequestBuilder)(nil)
+
 // NewCmdbItemRequestBuilderInternal instantiates a new CmdbItemRequestBuilder.
 func NewCmdbItemRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *CmdbItemRequestBuilder {
 	return &CmdbItemRequestBuilder{

--- a/cmdbinstanceapi/cmdb_relation_request_builder.go
+++ b/cmdbinstanceapi/cmdb_relation_request_builder.go
@@ -21,6 +21,8 @@ type CmdbRelationRequestBuilder struct {
 	core.RequestBuilder
 }
 
+var _ core.ItemPostRequestBuilder[CmdbInstance, abstractions.DefaultQueryParameters, abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]] = (*CmdbRelationRequestBuilder)(nil)
+
 // NewCmdbRelationRequestBuilderInternal instantiates a new CmdbRelationRequestBuilder.
 func NewCmdbRelationRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *CmdbRelationRequestBuilder {
 	return &CmdbRelationRequestBuilder{

--- a/core/request_builder_shapes.go
+++ b/core/request_builder_shapes.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"context"
+
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+)
+
+// requestConfigurationShape describes the field layout of abstractions.RequestConfiguration[Q]
+// (Headers, Options, QueryParameters *Q) as a ~-constraint, rather than naming
+// abstractions.RequestConfiguration[Q] directly - Go doesn't allow ~ on an instantiated
+// named generic type from another package, only on the type's underlying literal shape.
+//
+// This only matches request-configuration types built on the "typed QueryParameters"
+// convention (a type alias of abstractions.RequestConfiguration[Q], as actsubapi and
+// appserviceapi use). It intentionally does NOT match the other request-configuration
+// convention used elsewhere in this codebase (e.g. documentsapi's
+// VersionStateRequestBuilderGetRequestConfiguration), whose bespoke structs omit
+// QueryParameters entirely (Headers/Options, or Headers/Options/Data) - those are a
+// genuinely different shape, not just a differently-named one.
+type requestConfigurationShape[Q any] interface {
+	~struct {
+		Headers         *abstractions.RequestHeaders
+		Options         []abstractions.RequestOption
+		QueryParameters *Q
+	}
+}
+
+// C is the request-configuration type used by a given verb (e.g.
+// ActivitiesRequestBuilderGetRequestConfiguration). Every real builder in this codebase
+// takes *C, never C by value, so these interfaces take *C too.
+
+type CollectionGetRequestBuilder[T serialization.Parsable, Q any, C requestConfigurationShape[Q]] interface {
+	Get(ctx context.Context, requestConfiguration *C) (*BaseServiceNowCollectionResponse[T], error)
+	ToGetRequestInformation(ctx context.Context, requestConfiguration *C) (*abstractions.RequestInformation, error)
+}
+
+// Deliberately no CollectionPostRequestBuilder: no Post method anywhere in this codebase
+// returns a collection response - every real Post returns either a single item
+// (matched by ItemPostRequestBuilder below) or a bespoke response type outside this
+// taxonomy (e.g. appserviceapi's CreateServiceResponse).
+
+type ItemGetRequestBuilder[T serialization.Parsable, Q any, C requestConfigurationShape[Q]] interface {
+	Get(ctx context.Context, requestConfiguration *C) (*BaseServiceNowItemResponse[T], error)
+	ToGetRequestInformation(ctx context.Context, requestConfiguration *C) (*abstractions.RequestInformation, error)
+}
+
+type ItemPostRequestBuilder[T serialization.Parsable, Q any, C requestConfigurationShape[Q]] interface {
+	Post(ctx context.Context, body T, requestConfiguration *C) (*BaseServiceNowItemResponse[T], error)
+	ToPostRequestInformation(ctx context.Context, body T, requestConfiguration *C) (*abstractions.RequestInformation, error)
+}
+
+type ItemPatchRequestBuilder[T serialization.Parsable, Q any, C requestConfigurationShape[Q]] interface {
+	Patch(ctx context.Context, body T, requestConfiguration *C) (*BaseServiceNowItemResponse[T], error)
+	ToPatchRequestInformation(ctx context.Context, body T, requestConfiguration *C) (*abstractions.RequestInformation, error)
+}
+
+type ItemDeleteRequestBuilder[Q any, C requestConfigurationShape[Q]] interface {
+	Delete(ctx context.Context, requestConfiguration *C) error
+	ToDeleteRequestInformation(ctx context.Context, requestConfiguration *C) (*abstractions.RequestInformation, error)
+}

--- a/docs/snippets/attachments.go
+++ b/docs/snippets/attachments.go
@@ -168,7 +168,6 @@ func _() {
 	// [END attachment_std_file_create]
 
 	// [START attachment_upload_create]
-	// body := // TODO: how to make multipart body?
 	var body abstractions.MultipartBody
 
 	upload_config := &attachmentapi.AttachmentUploadRequestBuilderPostRequestConfiguration{

--- a/documentsapi/attach_request_builder.go
+++ b/documentsapi/attach_request_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -25,10 +26,16 @@ func NewAttachRequestBuilderInternal(pathParameters map[string]string, requestAd
 
 // Post attaches a document using the specified provider.
 func (rB *AttachRequestBuilder) Post(ctx context.Context, requestConfiguration *AttachRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *AttachRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *AttachRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/attach_request_builder.go
+++ b/documentsapi/attach_request_builder.go
@@ -4,9 +4,6 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,54 +13,22 @@ const (
 
 // AttachRequestBuilder provides operations to manage the attach endpoint.
 type AttachRequestBuilder struct {
-	core.RequestBuilder
+	*documentPostRequestBuilder
 }
 
 // NewAttachRequestBuilderInternal instantiates a new AttachRequestBuilder.
 func NewAttachRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *AttachRequestBuilder {
 	return &AttachRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, attachURLTemplate, pathParameters),
+		newDocumentPostRequestBuilder(requestAdapter, attachURLTemplate, pathParameters),
 	}
 }
 
 // Post attaches a document using the specified provider.
 func (rB *AttachRequestBuilder) Post(ctx context.Context, requestConfiguration *AttachRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
-	if conversion.IsNil(rB) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToPostRequestInformation(ctx, requestConfiguration)
-	if err != nil {
-		return nil, err
-	}
-
-	errorMapping := core.DefaultErrorMapping()
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowItemResponseFromDiscriminatorValue[Document](CreateDocumentFromDiscriminatorValue), errorMapping)
-	if err != nil {
-		return nil, err
-	}
-
-	if conversion.IsNil(res) {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowItemResponse[Document]), nil
+	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
-// ToPostRequestInformation ...
+// ToPostRequestInformation converts request configurations to Post request information.
 func (rB *AttachRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *AttachRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-	if !conversion.IsNil(requestConfiguration) {
-		kiotaRequestInfo.Headers.AddAll(requestConfiguration.Headers)
-		kiotaRequestInfo.AddRequestOptions(requestConfiguration.Options)
-		if data := requestConfiguration.Data; !conversion.IsNil(data) {
-			if err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), data); err != nil {
-				return nil, err
-			}
-		}
-	}
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return kiotaRequestInfo.RequestInformation, nil
+	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/create_document_request_builder.go
+++ b/documentsapi/create_document_request_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -25,10 +26,16 @@ func NewCreateDocumentRequestBuilderInternal(pathParameters map[string]string, r
 
 // Post creates or links a document from an attachment, DMS repo or cloud.
 func (rB *CreateDocumentRequestBuilder) Post(ctx context.Context, requestConfiguration *CreateDocumentRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *CreateDocumentRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *CreateDocumentRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/create_document_request_builder.go
+++ b/documentsapi/create_document_request_builder.go
@@ -4,9 +4,6 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,54 +13,22 @@ const (
 
 // CreateDocumentRequestBuilder provides operations to manage the createDocument endpoint.
 type CreateDocumentRequestBuilder struct {
-	core.RequestBuilder
+	*documentPostRequestBuilder
 }
 
 // NewCreateDocumentRequestBuilderInternal instantiates a new CreateDocumentRequestBuilder.
 func NewCreateDocumentRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *CreateDocumentRequestBuilder {
 	return &CreateDocumentRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, createDocumentURLTemplate, pathParameters),
+		newDocumentPostRequestBuilder(requestAdapter, createDocumentURLTemplate, pathParameters),
 	}
 }
 
 // Post creates or links a document from an attachment, DMS repo or cloud.
 func (rB *CreateDocumentRequestBuilder) Post(ctx context.Context, requestConfiguration *CreateDocumentRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
-	if conversion.IsNil(rB) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToPostRequestInformation(ctx, requestConfiguration)
-	if err != nil {
-		return nil, err
-	}
-
-	errorMapping := core.DefaultErrorMapping()
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowItemResponseFromDiscriminatorValue[Document](CreateDocumentFromDiscriminatorValue), errorMapping)
-	if err != nil {
-		return nil, err
-	}
-
-	if conversion.IsNil(res) {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowItemResponse[Document]), nil
+	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
-// ToPostRequestInformation ...
+// ToPostRequestInformation converts request configurations to Post request information.
 func (rB *CreateDocumentRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *CreateDocumentRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-	if !conversion.IsNil(requestConfiguration) {
-		kiotaRequestInfo.Headers.AddAll(requestConfiguration.Headers)
-		kiotaRequestInfo.AddRequestOptions(requestConfiguration.Options)
-		if data := requestConfiguration.Data; !conversion.IsNil(data) {
-			if err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), data); err != nil {
-				return nil, err
-			}
-		}
-	}
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return kiotaRequestInfo.RequestInformation, nil
+	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/create_request_builder.go
+++ b/documentsapi/create_request_builder.go
@@ -4,9 +4,6 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,54 +13,22 @@ const (
 
 // CreateRequestBuilder provides operations to manage the create endpoint.
 type CreateRequestBuilder struct {
-	core.RequestBuilder
+	*documentPostRequestBuilder
 }
 
 // NewCreateRequestBuilderInternal instantiates a new CreateRequestBuilder.
 func NewCreateRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *CreateRequestBuilder {
 	return &CreateRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, createURLTemplate, pathParameters),
+		newDocumentPostRequestBuilder(requestAdapter, createURLTemplate, pathParameters),
 	}
 }
 
 // Post creates a new document.
 func (rB *CreateRequestBuilder) Post(ctx context.Context, requestConfiguration *CreateRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
-	if conversion.IsNil(rB) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToPostRequestInformation(ctx, requestConfiguration)
-	if err != nil {
-		return nil, err
-	}
-
-	errorMapping := core.DefaultErrorMapping()
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowItemResponseFromDiscriminatorValue[Document](CreateDocumentFromDiscriminatorValue), errorMapping)
-	if err != nil {
-		return nil, err
-	}
-
-	if conversion.IsNil(res) {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowItemResponse[Document]), nil
+	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
-// ToPostRequestInformation ...
+// ToPostRequestInformation converts request configurations to Post request information.
 func (rB *CreateRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *CreateRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-	if !conversion.IsNil(requestConfiguration) {
-		kiotaRequestInfo.Headers.AddAll(requestConfiguration.Headers)
-		kiotaRequestInfo.AddRequestOptions(requestConfiguration.Options)
-		if data := requestConfiguration.Data; !conversion.IsNil(data) {
-			if err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), data); err != nil {
-				return nil, err
-			}
-		}
-	}
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return kiotaRequestInfo.RequestInformation, nil
+	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/create_request_builder.go
+++ b/documentsapi/create_request_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -25,10 +26,16 @@ func NewCreateRequestBuilderInternal(pathParameters map[string]string, requestAd
 
 // Post creates a new document.
 func (rB *CreateRequestBuilder) Post(ctx context.Context, requestConfiguration *CreateRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *CreateRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *CreateRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/document_get_request_builder.go
+++ b/documentsapi/document_get_request_builder.go
@@ -1,0 +1,71 @@
+package documentsapi
+
+import (
+	"context"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
+	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+)
+
+// documentGetRequestConfiguration is the shape shared by every documentsapi GET
+// request configuration used by a plain single-document GET (VersionState, Versions)
+// - they only differ by exported type name, so each one is convertible to this via
+// a pointer cast.
+type documentGetRequestConfiguration struct {
+	Headers *abstractions.RequestHeaders
+	Options []abstractions.RequestOption
+}
+
+// documentGetRequestBuilder is the shared implementation behind every documentsapi
+// request builder whose only operation is a GET returning a single Document
+// (VersionState, Versions) - they differ only in URL template.
+type documentGetRequestBuilder struct {
+	core.RequestBuilder
+}
+
+// newDocumentGetRequestBuilder instantiates a new documentGetRequestBuilder.
+func newDocumentGetRequestBuilder(requestAdapter abstractions.RequestAdapter, urlTemplate string, pathParameters map[string]string) *documentGetRequestBuilder {
+	return &documentGetRequestBuilder{
+		core.NewBaseRequestBuilder(requestAdapter, urlTemplate, pathParameters),
+	}
+}
+
+// get retrieves a Document.
+func (rB *documentGetRequestBuilder) get(ctx context.Context, requestConfiguration *documentGetRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+
+	requestInfo, err := rB.toGetRequestInformation(ctx, requestConfiguration)
+	if err != nil {
+		return nil, err
+	}
+
+	errorMapping := core.DefaultErrorMapping()
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowItemResponseFromDiscriminatorValue[Document](CreateDocumentFromDiscriminatorValue), errorMapping)
+	if err != nil {
+		return nil, err
+	}
+
+	if conversion.IsNil(res) {
+		return nil, nil
+	}
+
+	return res.(*core.BaseServiceNowItemResponse[Document]), nil
+}
+
+// toGetRequestInformation converts request configurations to Get request information.
+func (rB *documentGetRequestBuilder) toGetRequestInformation(_ context.Context, requestConfiguration *documentGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
+	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
+	if !conversion.IsNil(requestConfiguration) {
+		kiotaRequestInfo.Headers.AddAll(requestConfiguration.Headers)
+		kiotaRequestInfo.AddRequestOptions(requestConfiguration.Options)
+	}
+	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
+
+	return kiotaRequestInfo.RequestInformation, nil
+}

--- a/documentsapi/document_get_request_builder.go
+++ b/documentsapi/document_get_request_builder.go
@@ -59,6 +59,10 @@ func (rB *documentGetRequestBuilder) get(ctx context.Context, requestConfigurati
 
 // toGetRequestInformation converts request configurations to Get request information.
 func (rB *documentGetRequestBuilder) toGetRequestInformation(_ context.Context, requestConfiguration *documentGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
 	if !conversion.IsNil(requestConfiguration) {

--- a/documentsapi/document_get_request_builder_test.go
+++ b/documentsapi/document_get_request_builder_test.go
@@ -1,0 +1,143 @@
+package documentsapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDocumentGetRequestBuilder_Get(t *testing.T) {
+	tests := []struct {
+		name        string
+		nilBuilder  bool
+		setupMock   func(*mocking.MockRequestAdapter)
+		expectedErr error
+	}{
+		{
+			name: "Success",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				resp := core.NewBaseServiceNowItemResponse[Document](CreateDocumentFromDiscriminatorValue)
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp, nil)
+			},
+		},
+		{
+			name: "Error",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("get failed"))
+			},
+			expectedErr: errors.New("get failed"),
+		},
+		{
+			name: "Nil response",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			},
+		},
+		{
+			name:       "Nil builder",
+			nilBuilder: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var builder *documentGetRequestBuilder
+
+			if tt.nilBuilder {
+				builder = nil
+			} else {
+				adapter := &mocking.MockRequestAdapter{}
+				tt.setupMock(adapter)
+				builder = newDocumentGetRequestBuilder(adapter, versionStateURLTemplate, map[string]string{"baseurl": "https://example.com"})
+			}
+
+			resp, err := builder.get(context.Background(), &documentGetRequestConfiguration{})
+
+			if tt.nilBuilder {
+				assert.NoError(t, err)
+				assert.Nil(t, resp)
+				return
+			}
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				assert.Nil(t, resp)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestDocumentGetRequestBuilder_ToGetRequestInformation(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestConfig   *documentGetRequestConfiguration
+		expectedHeaders map[string][]string
+	}{
+		{
+			name:          "Nil config",
+			requestConfig: nil,
+			expectedHeaders: map[string][]string{
+				"accept": {"application/json"},
+			},
+		},
+		{
+			name: "With custom headers",
+			requestConfig: &documentGetRequestConfiguration{
+				Headers: func() *abstractions.RequestHeaders {
+					h := abstractions.NewRequestHeaders()
+					h.Add("custom-header", "custom-value")
+					return h
+				}(),
+			},
+			expectedHeaders: map[string][]string{
+				"accept":        {"application/json"},
+				"custom-header": {"custom-value"},
+			},
+		},
+		{
+			name: "With request options",
+			requestConfig: &documentGetRequestConfiguration{
+				Options: func() []abstractions.RequestOption {
+					opt := mocking.NewMockRequestOption()
+					opt.On("GetKey").Return(abstractions.RequestOptionKey{Key: "key"})
+					return []abstractions.RequestOption{opt}
+				}(),
+			},
+			expectedHeaders: map[string][]string{
+				"accept": {"application/json"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := &mocking.MockRequestAdapter{}
+			builder := newDocumentGetRequestBuilder(adapter, versionStateURLTemplate, map[string]string{"baseurl": "https://example.com"})
+
+			reqInfo, err := builder.toGetRequestInformation(context.Background(), tt.requestConfig)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, reqInfo)
+			assert.Equal(t, abstractions.GET, reqInfo.Method)
+			for k, v := range tt.expectedHeaders {
+				assert.Equal(t, v, reqInfo.Headers.Get(k))
+			}
+		})
+	}
+
+	t.Run("Nil builder", func(t *testing.T) {
+		var builder *documentGetRequestBuilder
+		reqInfo, err := builder.toGetRequestInformation(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Nil(t, reqInfo)
+	})
+}

--- a/documentsapi/document_post_request_builder.go
+++ b/documentsapi/document_post_request_builder.go
@@ -1,0 +1,76 @@
+package documentsapi
+
+import (
+	"context"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
+	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+)
+
+// documentPostRequestConfiguration is the shape shared by every documentsapi POST
+// request configuration (Attach, CreateDocument, Create, SyncDown) - they only
+// differ by exported type name, so each one is convertible to this via a pointer cast.
+type documentPostRequestConfiguration struct {
+	Headers *abstractions.RequestHeaders
+	Options []abstractions.RequestOption
+	Data    Document
+}
+
+// documentPostRequestBuilder is the shared implementation behind every documentsapi
+// request builder whose only operation is a POST returning a single Document
+// (Attach, CreateDocument, Create, SyncDown) - they differ only in URL template.
+type documentPostRequestBuilder struct {
+	core.RequestBuilder
+}
+
+// newDocumentPostRequestBuilder instantiates a new documentPostRequestBuilder.
+func newDocumentPostRequestBuilder(requestAdapter abstractions.RequestAdapter, urlTemplate string, pathParameters map[string]string) *documentPostRequestBuilder {
+	return &documentPostRequestBuilder{
+		core.NewBaseRequestBuilder(requestAdapter, urlTemplate, pathParameters),
+	}
+}
+
+// post sends a POST request to create or link a document.
+func (rB *documentPostRequestBuilder) post(ctx context.Context, requestConfiguration *documentPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+
+	requestInfo, err := rB.toPostRequestInformation(ctx, requestConfiguration)
+	if err != nil {
+		return nil, err
+	}
+
+	errorMapping := core.DefaultErrorMapping()
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowItemResponseFromDiscriminatorValue[Document](CreateDocumentFromDiscriminatorValue), errorMapping)
+	if err != nil {
+		return nil, err
+	}
+
+	if conversion.IsNil(res) {
+		return nil, nil
+	}
+
+	return res.(*core.BaseServiceNowItemResponse[Document]), nil
+}
+
+// toPostRequestInformation converts request configurations to Post request information.
+func (rB *documentPostRequestBuilder) toPostRequestInformation(ctx context.Context, requestConfiguration *documentPostRequestConfiguration) (*abstractions.RequestInformation, error) {
+	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
+	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
+	if !conversion.IsNil(requestConfiguration) {
+		kiotaRequestInfo.Headers.AddAll(requestConfiguration.Headers)
+		kiotaRequestInfo.AddRequestOptions(requestConfiguration.Options)
+		if data := requestConfiguration.Data; !conversion.IsNil(data) {
+			if err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), data); err != nil {
+				return nil, err
+			}
+		}
+	}
+	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
+
+	return kiotaRequestInfo.RequestInformation, nil
+}

--- a/documentsapi/document_post_request_builder.go
+++ b/documentsapi/document_post_request_builder.go
@@ -59,6 +59,10 @@ func (rB *documentPostRequestBuilder) post(ctx context.Context, requestConfigura
 
 // toPostRequestInformation converts request configurations to Post request information.
 func (rB *documentPostRequestBuilder) toPostRequestInformation(ctx context.Context, requestConfiguration *documentPostRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
+
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
 	if !conversion.IsNil(requestConfiguration) {

--- a/documentsapi/document_post_request_builder_test.go
+++ b/documentsapi/document_post_request_builder_test.go
@@ -1,0 +1,164 @@
+package documentsapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDocumentPostRequestBuilder_Post(t *testing.T) {
+	tests := []struct {
+		name        string
+		nilBuilder  bool
+		setupMock   func(*mocking.MockRequestAdapter)
+		expectedErr error
+	}{
+		{
+			name: "Success",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				resp := core.NewBaseServiceNowItemResponse[Document](CreateDocumentFromDiscriminatorValue)
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp, nil)
+			},
+		},
+		{
+			name: "Error",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("post failed"))
+			},
+			expectedErr: errors.New("post failed"),
+		},
+		{
+			name: "Nil response",
+			setupMock: func(m *mocking.MockRequestAdapter) {
+				m.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			},
+		},
+		{
+			name:       "Nil builder",
+			nilBuilder: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var builder *documentPostRequestBuilder
+
+			if tt.nilBuilder {
+				builder = nil
+			} else {
+				adapter := &mocking.MockRequestAdapter{}
+				tt.setupMock(adapter)
+				builder = newDocumentPostRequestBuilder(adapter, attachURLTemplate, map[string]string{"baseurl": "https://example.com"})
+			}
+
+			resp, err := builder.post(context.Background(), &documentPostRequestConfiguration{})
+
+			if tt.nilBuilder {
+				assert.NoError(t, err)
+				assert.Nil(t, resp)
+				return
+			}
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				assert.Nil(t, resp)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestDocumentPostRequestBuilder_ToPostRequestInformation(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestConfig   *documentPostRequestConfiguration
+		expectedHeaders map[string][]string
+	}{
+		{
+			name:          "Nil config",
+			requestConfig: nil,
+			expectedHeaders: map[string][]string{
+				"accept": {"application/json"},
+			},
+		},
+		{
+			name: "With custom headers",
+			requestConfig: &documentPostRequestConfiguration{
+				Headers: func() *abstractions.RequestHeaders {
+					h := abstractions.NewRequestHeaders()
+					h.Add("custom-header", "custom-value")
+					return h
+				}(),
+			},
+			expectedHeaders: map[string][]string{
+				"accept":        {"application/json"},
+				"custom-header": {"custom-value"},
+			},
+		},
+		{
+			name: "With request options",
+			requestConfig: &documentPostRequestConfiguration{
+				Options: func() []abstractions.RequestOption {
+					opt := mocking.NewMockRequestOption()
+					opt.On("GetKey").Return(abstractions.RequestOptionKey{Key: "key"})
+					return []abstractions.RequestOption{opt}
+				}(),
+			},
+			expectedHeaders: map[string][]string{
+				"accept": {"application/json"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := &mocking.MockRequestAdapter{}
+			builder := newDocumentPostRequestBuilder(adapter, attachURLTemplate, map[string]string{"baseurl": "https://example.com"})
+
+			reqInfo, err := builder.toPostRequestInformation(context.Background(), tt.requestConfig)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, reqInfo)
+			assert.Equal(t, abstractions.POST, reqInfo.Method)
+			for k, v := range tt.expectedHeaders {
+				assert.Equal(t, v, reqInfo.Headers.Get(k))
+			}
+		})
+	}
+
+	t.Run("With data", func(t *testing.T) {
+		adapter := &mocking.MockRequestAdapter{}
+		writer := mocking.NewMockSerializationWriter()
+		writer.On("WriteObjectValue", "", mock.Anything, mock.Anything).Return(nil)
+		writer.On("Close").Return(nil)
+		writer.On("GetSerializedContent").Return([]byte("{}"), nil)
+
+		factory := mocking.NewMockSerializationWriterFactory()
+		factory.On("GetSerializationWriter", "application/json").Return(writer, nil)
+		adapter.On("GetSerializationWriterFactory").Return(factory, nil)
+
+		builder := newDocumentPostRequestBuilder(adapter, attachURLTemplate, map[string]string{"baseurl": "https://example.com"})
+
+		reqInfo, err := builder.toPostRequestInformation(context.Background(), &documentPostRequestConfiguration{
+			Data: NewDocument(),
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, reqInfo)
+	})
+
+	t.Run("Nil builder", func(t *testing.T) {
+		var builder *documentPostRequestBuilder
+		reqInfo, err := builder.toPostRequestInformation(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Nil(t, reqInfo)
+	})
+}

--- a/documentsapi/sync_down_request_builder.go
+++ b/documentsapi/sync_down_request_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -25,10 +26,16 @@ func NewSyncDownRequestBuilderInternal(pathParameters map[string]string, request
 
 // Post synchronizes the specified document.
 func (rB *SyncDownRequestBuilder) Post(ctx context.Context, requestConfiguration *SyncDownRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *SyncDownRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *SyncDownRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/sync_down_request_builder.go
+++ b/documentsapi/sync_down_request_builder.go
@@ -4,9 +4,6 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,54 +13,22 @@ const (
 
 // SyncDownRequestBuilder provides operations to manage the syncDown endpoint.
 type SyncDownRequestBuilder struct {
-	core.RequestBuilder
+	*documentPostRequestBuilder
 }
 
 // NewSyncDownRequestBuilderInternal instantiates a new SyncDownRequestBuilder.
 func NewSyncDownRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *SyncDownRequestBuilder {
 	return &SyncDownRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, syncDownURLTemplate, pathParameters),
+		newDocumentPostRequestBuilder(requestAdapter, syncDownURLTemplate, pathParameters),
 	}
 }
 
 // Post synchronizes the specified document.
 func (rB *SyncDownRequestBuilder) Post(ctx context.Context, requestConfiguration *SyncDownRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
-	if conversion.IsNil(rB) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToPostRequestInformation(ctx, requestConfiguration)
-	if err != nil {
-		return nil, err
-	}
-
-	errorMapping := core.DefaultErrorMapping()
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowItemResponseFromDiscriminatorValue[Document](CreateDocumentFromDiscriminatorValue), errorMapping)
-	if err != nil {
-		return nil, err
-	}
-
-	if conversion.IsNil(res) {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowItemResponse[Document]), nil
+	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
 
-// ToPostRequestInformation ...
+// ToPostRequestInformation converts request configurations to Post request information.
 func (rB *SyncDownRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *SyncDownRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-	if !conversion.IsNil(requestConfiguration) {
-		kiotaRequestInfo.Headers.AddAll(requestConfiguration.Headers)
-		kiotaRequestInfo.AddRequestOptions(requestConfiguration.Options)
-		if data := requestConfiguration.Data; !conversion.IsNil(data) {
-			if err := kiotaRequestInfo.SetContentFromParsable(ctx, rB.GetRequestAdapter(), internalhttp.ContentTypeApplicationJSON.String(), data); err != nil {
-				return nil, err
-			}
-		}
-	}
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return kiotaRequestInfo.RequestInformation, nil
+	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/version_state_request_builder.go
+++ b/documentsapi/version_state_request_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -25,10 +26,16 @@ func NewVersionStateRequestBuilderInternal(pathParameters map[string]string, req
 
 // Get retrieves the state of the specified document version.
 func (rB *VersionStateRequestBuilder) Get(ctx context.Context, requestConfiguration *VersionStateRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.get(ctx, (*documentGetRequestConfiguration)(requestConfiguration))
 }
 
 // ToGetRequestInformation converts request configurations to Get request information.
 func (rB *VersionStateRequestBuilder) ToGetRequestInformation(ctx context.Context, requestConfiguration *VersionStateRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	if conversion.IsNil(rB) {
+		return nil, nil
+	}
 	return rB.toGetRequestInformation(ctx, (*documentGetRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/version_state_request_builder.go
+++ b/documentsapi/version_state_request_builder.go
@@ -4,9 +4,6 @@ import (
 	"context"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal"
-	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
-	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -16,49 +13,22 @@ const (
 
 // VersionStateRequestBuilder provides operations to manage the versionstate endpoint.
 type VersionStateRequestBuilder struct {
-	core.RequestBuilder
+	*documentGetRequestBuilder
 }
 
 // NewVersionStateRequestBuilderInternal instantiates a new VersionStateRequestBuilder.
 func NewVersionStateRequestBuilderInternal(pathParameters map[string]string, requestAdapter abstractions.RequestAdapter) *VersionStateRequestBuilder {
 	return &VersionStateRequestBuilder{
-		core.NewBaseRequestBuilder(requestAdapter, versionStateURLTemplate, pathParameters),
+		newDocumentGetRequestBuilder(requestAdapter, versionStateURLTemplate, pathParameters),
 	}
 }
 
 // Get retrieves the state of the specified document version.
 func (rB *VersionStateRequestBuilder) Get(ctx context.Context, requestConfiguration *VersionStateRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
-	if conversion.IsNil(rB) {
-		return nil, nil
-	}
-
-	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)
-	if err != nil {
-		return nil, err
-	}
-
-	errorMapping := core.DefaultErrorMapping()
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, core.ServiceNowItemResponseFromDiscriminatorValue[Document](CreateDocumentFromDiscriminatorValue), errorMapping)
-	if err != nil {
-		return nil, err
-	}
-
-	if conversion.IsNil(res) {
-		return nil, nil
-	}
-
-	return res.(*core.BaseServiceNowItemResponse[Document]), nil
+	return rB.get(ctx, (*documentGetRequestConfiguration)(requestConfiguration))
 }
 
 // ToGetRequestInformation converts request configurations to Get request information.
-func (rB *VersionStateRequestBuilder) ToGetRequestInformation(_ context.Context, requestConfiguration *VersionStateRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
-	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
-	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
-	if !conversion.IsNil(requestConfiguration) {
-		kiotaRequestInfo.Headers.AddAll(requestConfiguration.Headers)
-		kiotaRequestInfo.AddRequestOptions(requestConfiguration.Options)
-	}
-	kiotaRequestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-
-	return kiotaRequestInfo.RequestInformation, nil
+func (rB *VersionStateRequestBuilder) ToGetRequestInformation(ctx context.Context, requestConfiguration *VersionStateRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
+	return rB.toGetRequestInformation(ctx, (*documentGetRequestConfiguration)(requestConfiguration))
 }


### PR DESCRIPTION
## Summary
- Collapsed genuinely duplicated request-builder pairs (actsubapi's GET-collection cluster, documentsapi's POST/GET clusters, appserviceapi's POST pair) into shared, package-private implementations — no public API or behavior change.
- Left the remaining `dupl` findings (fixed-shape data models that coincidentally share a field count across distinct API concepts, e.g. `CalendarResponseModel` vs `UserTimeFormatModel`) as-is with a per-file `// nolint:dupl` explaining why, instead of a blanket path exclusion.
- Removed a stale leftover TODO in `docs/snippets/attachments.go`.
- Added `core.CollectionGetRequestBuilder`/`ItemGetRequestBuilder`/`ItemPostRequestBuilder`/`ItemPatchRequestBuilder`/`ItemDeleteRequestBuilder` — generic interfaces describing the request-builder verb shapes used by builders whose config is a type alias of `abstractions.RequestConfiguration[Q]`, each backed by a compile-time assertion against a real builder so drift fails the build.

## Test plan
- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -s -l .` — no files
- `go test ./...` — full suite passes
- `golangci-lint run ./...` — `dupl` fully resolved; only the pre-existing 3 `gocognit` findings in `attachmentapi` test functions remain (unrelated, not yet addressed)