### PR TITLE
docs: add 2.0 release-readiness review issues

### DIFF
--- a/release-2.0-issues/001-ci-test-failures-never-fail-the-build.md
+++ b/release-2.0-issues/001-ci-test-failures-never-fail-the-build.md
@@ -1,0 +1,37 @@
+# CI test failures never fail the build
+
+- **Priority:** P0 — release blocker
+- **Raised by:** Senior DevOps
+- **Area:** CI/CD
+
+## Problem
+
+`.github/scripts/report-tests.sh` always exits 0, so the `test-go` job in `ci.yml` is
+green even when tests fail. Every merge since this script was introduced has had an
+unenforced test gate.
+
+```bash
+TEST_EXIT_CODE=0
+go test -coverprofile=coverage.out -json -v ./... > test-output.json
+echo "exit: $?"          # consumes $? but never stores it
+...
+exit $TEST_EXIT_CODE     # always 0
+```
+
+`TEST_EXIT_CODE` is initialized to 0 and never reassigned. `set -o pipefail` does not
+help because the `go test` line has no pipe, and there is no `set -e`. The
+`if: failure()` steps that post the sticky failure comment can therefore never trigger
+either.
+
+Tests currently pass locally (`go test ./...` is clean on `release/2.0`), so nothing
+broken has slipped through *yet* — but the gate must be real before a 2.0 launch.
+
+## Recommendation
+
+```bash
+go test -coverprofile=coverage.out -json -v ./... > test-output.json
+TEST_EXIT_CODE=$?
+```
+
+Then keep `exit $TEST_EXIT_CODE` at the end. Add a deliberate failing-test dry run on a
+branch to confirm the job goes red and the sticky comment posts.

--- a/release-2.0-issues/002-no-release-path-from-release-2.0-to-v2.0.0-tag.md
+++ b/release-2.0-issues/002-no-release-path-from-release-2.0-to-v2.0.0-tag.md
@@ -1,0 +1,42 @@
+# No defined release path from `release/2.0` to a v2.0.0 tag
+
+- **Priority:** P0 — release blocker
+- **Raised by:** Senior DevOps + Senior Product Manager
+- **Area:** Release automation
+
+## Problem
+
+`stable-release.yml` runs release-please only on pushes to `main`. The 2.0 work lives on
+`release/2.0`, currently **90 commits ahead of main**, and nothing in the automation
+knows about that branch. There is no documented or automated way for this branch to
+become the `v2.0.0` tag.
+
+Two specific hazards when the merge to `main` happens:
+
+1. **Merge strategy determines what release-please parses.** With a merge commit,
+   release-please walks the individual commits — and the branch contains
+   non-conventional messages that will parse wrong or not at all:
+   - `d863ddb major` (not conventional at all)
+   - `7e31c01 fix: merge errors` (parses as a patch fix)
+   - `95ee5a9 refator: model accessor mutators use store (#474)` (typo — `refator` is
+     not a recognized type)
+2. **Nothing on the branch carries a `BREAKING CHANGE:` footer** (spot-check the 90
+   commits). Without one, release-please will compute a **minor** bump (v1.13.0), not
+   v2.0.0, and pkg.go.dev will index a breaking release under a v1 tag — the worst
+   possible outcome for consumers.
+
+Also note: PRs targeting `release/2.0` bypass `pr.yml` title lint (it filters
+`branches: [main]`), which is how the malformed titles got in.
+
+## Recommendation
+
+Write a short release runbook (can live in this directory) and follow it:
+
+1. Merge `release/2.0` into `main` via a **single squash PR** whose title is
+   conventional (e.g. `feat!: v2 rework`) and whose body carries a
+   `BREAKING CHANGE:` footer summarizing the v2 changes.
+2. Verify the resulting release-please PR proposes **2.0.0** before merging it.
+3. Sequence this with the `/v2` module-path change (see issue 003) — the tag must not
+   land before the module path is correct.
+4. Extend `pr.yml`'s branch filter to include `release/*` so future release branches get
+   title linting.

--- a/release-2.0-issues/003-v2-module-path-runbook.md
+++ b/release-2.0-issues/003-v2-module-path-runbook.md
@@ -1,0 +1,37 @@
+# `/v2` module path bump — release-day runbook item
+
+- **Priority:** P0 — release blocker (deliberately deferred; must not be forgotten)
+- **Raised by:** Senior Principal Engineer
+- **Area:** Go module semantics
+
+## Problem
+
+Go's semantic import versioning requires the module path to end in `/v2` for any
+`v2.x.y` tag. `go.mod` still declares
+`module github.com/michaeldcanady/servicenow-sdk-go`. This deferral is **intentional**
+(to keep the branch mergeable during development), but if the v2.0.0 tag is cut before
+the path changes, `go get` of the tagged version will fail module verification and the
+tag is burned permanently — tags can't be re-pointed once the proxy caches them.
+
+## Recommendation
+
+Execute immediately before the release merge (issue 002), as one commit:
+
+1. `go.mod`: `module github.com/michaeldcanady/servicenow-sdk-go/v2`
+2. Rewrite **every** internal self-import (all packages import siblings by full module
+   path — `core`, `internal/...`, every `*api` package, `credentials`, `query`, tests):
+   ```bash
+   grep -rl 'michaeldcanady/servicenow-sdk-go' --include='*.go' . \
+     | xargs sed -i 's|michaeldcanady/servicenow-sdk-go|michaeldcanady/servicenow-sdk-go/v2|g'
+   go build ./... && go test ./...
+   ```
+   (Guard against double-applying `/v2/v2`; a `mod upgrade` tool like
+   `github.com/marwan-at-work/mod` does this safely.)
+3. Update `release-please-config.json` `package-name` to the `/v2` path (both configs —
+   stable and weekly).
+4. Update install instructions in `Readme.md` and `docs/` to `go get .../v2`.
+5. Only then merge to `main` and let release-please tag `v2.0.0`.
+
+## Cross-references
+
+- Depends on / sequenced with: issue 002 (release path).

--- a/release-2.0-issues/004-nil-receiver-guards-return-nil-nil.md
+++ b/release-2.0-issues/004-nil-receiver-guards-return-nil-nil.md
@@ -1,0 +1,43 @@
+# Nil-receiver guards return `nil, nil`, silently swallowing bugs
+
+- **Priority:** P1 — API design; 2.0 is the only window to fix it
+- **Raised by:** Senior Principal Engineer
+- **Area:** SDK design / public API contract
+
+## Problem
+
+The standard verb-method preamble across every `*api` package is:
+
+```go
+if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+    return nil, nil
+}
+```
+
+(e.g. `tableapi/table_request_builder.go:76`, `:120`, `:164`; the pattern is
+codified in CLAUDE.md and repeated in dozens of builders.)
+
+A caller who accidentally holds a nil builder gets `(nil, nil)` — no result **and no
+error**. The inevitable outcome is a confusing downstream nil-pointer dereference far
+from the actual mistake, or worse, code that treats "no error" as success. This
+violates the Go convention that a nil error means the operation succeeded and the
+result is usable.
+
+The adapter guard right next to it already does the right thing
+(`return nil, snerrors.ErrNilRequestAdapter`), so the codebase is internally
+inconsistent about how nil-guards behave.
+
+## Recommendation
+
+Since 2.0 is a breaking release, change the contract now:
+
+1. Add a shared sentinel to `errors/errors.go` (e.g. `ErrNilRequestBuilder` — check
+   whether one already exists before adding, per the sentinel-duplication issue 005).
+2. Replace every `return nil, nil` nil-receiver guard with
+   `return nil, snerrors.ErrNilRequestBuilder`.
+3. Update the corresponding tests (many currently assert `nil, nil`).
+4. Update CLAUDE.md and the `new-api-module` skill / `api-module-consistency-reviewer`
+   agent so new modules follow the corrected pattern.
+
+This is mechanical but wide; a scripted sweep plus the consistency-reviewer agent can
+verify completeness.

--- a/release-2.0-issues/005-consolidate-error-sentinels.md
+++ b/release-2.0-issues/005-consolidate-error-sentinels.md
@@ -1,0 +1,34 @@
+# Consolidate the three error-sentinel locations before the API freezes
+
+- **Priority:** P1 — breaking-change window closes at 2.0
+- **Raised by:** Senior Principal Engineer
+- **Area:** SDK design / error handling
+
+## Problem
+
+Sentinel errors live in three places with similar-but-different wording:
+
+1. Root `errors.go` (`package servicenowsdkgo`) — client-config sentinels.
+2. `errors/errors.go` (`snerrors`) — the intended shared set (`ErrNilRequestAdapter`,
+   `ErrNilResponse`, `ErrNilConfig`, `ErrNilBody`, ...).
+3. Package-local files such as `tableapi/errors.go` with their own variants.
+
+On top of that, many historical call sites return a fresh `errors.New("...")` with text
+matching a sentinel instead of the sentinel itself, which breaks `errors.Is` for
+callers. Once v2.0.0 ships, removing or re-homing any exported sentinel is a new
+breaking change, so this cleanup is now-or-wait-for-v3.
+
+## Recommendation
+
+1. Inventory: `grep -rn 'errors.New(' --include='*.go' . | grep -v _test` and diff the
+   messages against `errors/errors.go`.
+2. Make `errors/errors.go` the single home for cross-package sentinels; deprecate (or
+   delete, since v2 may break) duplicates in `tableapi/errors.go` and friends — keep
+   package-local sentinels only where the condition is genuinely package-specific.
+3. Replace inline `errors.New` duplicates with the shared sentinel by identity.
+4. Add a unit test that asserts, for each public verb-method failure mode, that
+   `errors.Is(err, snerrors.ErrX)` holds — locking the contract for consumers.
+
+## Cross-references
+
+- Issue 004 adds `ErrNilRequestBuilder`; do these together to avoid two sweeps.

--- a/release-2.0-issues/006-repo-hygiene-stray-working-files.md
+++ b/release-2.0-issues/006-repo-hygiene-stray-working-files.md
@@ -1,0 +1,35 @@
+# Repo hygiene: development scratch files committed at the root
+
+- **Priority:** P1 — first-impression / professionalism at launch
+- **Raised by:** Senior Product Manager (with Principal Engineer)
+- **Area:** Repository quality
+
+## Problem
+
+The repo root — the first thing every evaluating engineer sees on GitHub and the
+directory listing pkg.go.dev links to — contains committed working artifacts:
+
+| File | What it is |
+| --- | --- |
+| `coverage.html`, `coverage.out` | generated coverage output |
+| `files_to_fix.txt` | a scratch worklist from a past refactor |
+| `fix_error_mappings.py` | a one-off migration script (references `files_to_fix.txt`) |
+| `GEMINI.md` | assistant context file, duplicative of CLAUDE.md |
+| `placeholder-plugin.yaml` | placeholder |
+| `specs/001…006` | internal planning docs for the v2 effort |
+| `mocking.go` at root | test helper living in the public root package |
+
+`spec/` (ServiceNow OpenAPI specs) is arguably legitimate reference material but should
+be distinguished from `specs/` (internal planning) — the near-identical names invite
+confusion.
+
+## Recommendation
+
+1. Delete `coverage.html`, `coverage.out`, `files_to_fix.txt`, `fix_error_mappings.py`,
+   `placeholder-plugin.yaml`; add `coverage.*` to `.gitignore`.
+2. Decide on `GEMINI.md`: delete or fold into CLAUDE.md.
+3. Move `specs/` planning docs to `docs/design/` or delete if historical; consider
+   renaming `spec/` → `api-specs/` for clarity.
+4. Audit root-package exported surface: `mocking.go` in `package servicenowsdkgo`
+   ships mock helpers to every consumer — move under `internal/mocking` or a clearly
+   named `snmock` package if it's meant to be public.

--- a/release-2.0-issues/007-readme-links-all-broken.md
+++ b/release-2.0-issues/007-readme-links-all-broken.md
@@ -1,0 +1,32 @@
+# Readme API table links point to directories that no longer exist
+
+- **Priority:** P1 — launch-facing documentation
+- **Raised by:** Senior Product Manager
+- **Area:** Documentation
+
+## Problem
+
+Every entry in the "Supported Service-Now APIs" table in `Readme.md` links to the old
+hyphenated directory layout (`account-api`, `actsub-api`, `table-api`,
+`documents-api`, ...). Those directories were renamed to the current unhyphenated form
+(`accountapi`, `actsubapi`, `tableapi`, ...), so **all 15 links 404**. The table is
+also missing modules added since (`statsapi`, and possibly others), and the links point
+at `tree/main/...` even though 2.0 content is what will ship.
+
+Verified:
+
+```
+$ ls account-api actsub-api table-api
+ls: cannot access 'account-api': No such file or directory  (all three)
+```
+
+## Recommendation
+
+1. Regenerate the table from the actual `*api` directories; link to each package's
+   `Readme.md`.
+2. Add the missing modules and remove any that no longer ship in v2.
+3. Update the quick-start snippet to the v2 fluent API
+   (`client.Now().Table("incident")...`) and — once issue 003 lands — the `/v2` import
+   path.
+4. Add a CI-friendly link check (e.g. `lychee` or `markdown-link-check` on `Readme.md`
+   and `docs/`) so this class of rot is caught automatically.

--- a/release-2.0-issues/008-v2-migration-guide-and-launch-comms.md
+++ b/release-2.0-issues/008-v2-migration-guide-and-launch-comms.md
@@ -1,0 +1,31 @@
+# v2 migration guide, deprecation policy, and launch communications
+
+- **Priority:** P1 — product readiness
+- **Raised by:** Senior Product Manager
+- **Area:** Product / documentation
+
+## Problem
+
+v2 is a ground-up breaking rework (backing-store models, new fluent chaining, renamed
+packages, new error contracts). There is currently no consumer-facing artifact that
+answers: *"I'm on v1.12 — what do I do?"* Without it, existing users will pin v1
+forever or churn, and the GitHub issue tracker becomes the migration guide.
+
+There is also no stated support policy for the v1.x line, and the weekly preview
+release channel's fate post-2.0 is undefined.
+
+## Recommendation
+
+1. **Migration guide** (`docs/migration-v2.md`, linked from Readme and the release
+   notes): side-by-side v1→v2 examples for the top journeys — client construction,
+   table CRUD, queries (`query.Field(...)`), attachments, pagination
+   (`core.PageIterator`), error handling (`errors.Is` with `snerrors` sentinels),
+   authentication via `credentials/`.
+2. **v1 support statement**: e.g. "v1.x receives critical fixes only for N months; no
+   new features." Put it in the Readme and the v2.0.0 release notes.
+3. **Release notes**: hand-curate the v2.0.0 GitHub release body (release-please's
+   generated changelog for a 90-commit squash will not tell the story).
+4. **Preview channel**: decide whether the weekly preview continues (as `v2.x-preview`)
+   or is retired at GA (see issue 011).
+5. **Launch checklist**: verify pkg.go.dev renders the `/v2` docs, badges in Readme
+   still resolve, and the docs site (mkdocs) reflects v2 before announcing.

--- a/release-2.0-issues/009-ci-coverage-gaps.md
+++ b/release-2.0-issues/009-ci-coverage-gaps.md
@@ -1,0 +1,37 @@
+# CI coverage gaps: integration tests, vuln scanning, pinned lint version
+
+- **Priority:** P1
+- **Raised by:** Senior DevOps
+- **Area:** CI/CD
+
+## Problem
+
+Several classes of verification exist in the repo but never run in CI, and some CI
+inputs are nondeterministic:
+
+1. **Integration tests never run in CI.** `tests/integration/` (godog + httpmock, no
+   live instance needed — explicitly designed to be CI-safe) is behind
+   `//go:build integration`, and no workflow passes `-tags integration`. The entire BDD
+   suite is dead weight unless someone runs it locally.
+2. **The `preview.query` build tag is linted but never tested.** `.golangci.yml` sets
+   `build-tags: [preview.query]`, but `go test` in CI runs without tags, so
+   tag-gated code is compiled by the linter and never exercised by tests.
+3. **No vulnerability scanning for Go deps.** CodeQL runs, but `govulncheck` (which
+   checks the actual call graph against the Go vuln DB) does not. For an SDK whose
+   consumers inherit its dependency tree, this is table stakes.
+4. **`golangci-lint-action` uses `version: latest`** — lint results change under your
+   feet when a new linter version releases; PRs go red for reasons unrelated to their
+   diff. Same for `go install github.com/mfridman/tparse@latest` in the test job.
+5. **Stale lint exclusions**: `.golangci.yml` excludes `dupl` for
+   `(actsub-api|documents-api|table-api)/.*` — paths that no longer exist after the
+   directory renames, so the exclusion is dead config.
+
+## Recommendation
+
+1. Add an `integration-test` job: `go test -tags integration ./tests/integration/...`
+   (Linux-only is fine; it's mocked).
+2. Add a unit-test matrix leg or extra step with `-tags preview.query`.
+3. Add a `govulncheck ./...` job (weekly schedule + per-PR).
+4. Pin `golangci-lint` to a released version and bump via Dependabot/renovate;
+   pin `tparse` with a version suffix.
+5. Delete the dead `dupl` path exclusion or update it to the current directory names.

--- a/release-2.0-issues/010-docs-pipeline-inefficiencies.md
+++ b/release-2.0-issues/010-docs-pipeline-inefficiencies.md
@@ -1,0 +1,32 @@
+# Docs pipeline: stale filter reference, redundant deploy rebuild
+
+- **Priority:** P2
+- **Raised by:** Senior DevOps
+- **Area:** CI/CD (docs)
+
+## Problem
+
+In `.github/workflows/docs.yml`:
+
+1. The `changes-docs` filter lists `.github/workflows/pages.yml` as a watched file, but
+   the workflow file is `docs.yml` — `pages.yml` doesn't exist. Changes to `docs.yml`
+   itself therefore don't mark docs as changed in the filter (the `on.push.paths`
+   trigger catches it, but the job-level filter then reports no docs changes and jobs
+   skip).
+2. The `deploy` job downloads the built `site` artifact **and then runs
+   `mkdocs gh-deploy`**, which rebuilds the site from scratch anyway — the artifact
+   download and the earlier build/cache steps buy nothing for deploy. Either deploy the
+   prebuilt artifact (e.g. `actions/deploy-pages` or `ghp-import site`) or drop the
+   artifact plumbing.
+3. The site cache keyed on `site-${{ github.sha }}` with `restore-keys: site-` can
+   restore a *previous commit's* site and then skip the build entirely
+   (`if: cache-hit != 'true'` only checks exact hit — partial restores do rebuild, so
+   this one is mostly benign, but the cache adds little for an mkdocs build measured in
+   seconds).
+
+## Recommendation
+
+Simplify: build once (`mkdocs build --strict`), upload artifact, deploy the artifact
+with `actions/upload-pages-artifact` + `actions/deploy-pages` (the modern Pages flow —
+the `id-token: write` permission is already declared but unused by `gh-deploy`). Fix or
+remove the `pages.yml` filter entry and drop the cache.

--- a/release-2.0-issues/011-dual-release-please-channels.md
+++ b/release-2.0-issues/011-dual-release-please-channels.md
@@ -1,0 +1,38 @@
+# Stable and weekly-preview release-please channels can fight each other
+
+- **Priority:** P2 — decide before GA
+- **Raised by:** Senior DevOps
+- **Area:** Release automation
+
+## Problem
+
+Two release-please workflows operate on the same branch (`main`), same package, same
+`CHANGELOG.md`, and same tag namespace:
+
+- `stable-release.yml` — every push to `main`, `release-please-config.json`.
+- `weekly-release.yml` — Mondays 3 AM, `weekly-release-please-config.json` with
+  `"prerelease": true`.
+
+Because both configs share `changelog-path` and version files, they generate competing
+release PRs proposing different versions from the same commit range; whichever merges
+second rebases the other's changelog edits, and prerelease tags interleave with stable
+tags in one sequence. Additionally, `weekly-release.yml` grants `contents: write` at
+the workflow level to *both* jobs (detect-changes only needs read — it re-declares
+read, which is fine, but the release job inherits broad top-level grants).
+
+For a Go module this weekly prerelease channel has limited value anyway: Go consumers
+can already get `main` via `go get ...@main` pseudo-versions, and prerelease tags
+(`v2.1.0-pre.1`) are opt-in-only for `go get`.
+
+## Recommendation
+
+Pick one:
+
+- **Retire the weekly preview at GA** (simplest; recommend this). Pseudo-versions
+  cover the "try latest" use case.
+- Or keep it, but move preview releases to a dedicated branch/tag prefix so the two
+  channels never propose PRs against the same changelog, and document the channel in
+  the Readme.
+
+Either way, do it before v2.0.0 so launch week doesn't start with a Monday 3 AM
+prerelease PR colliding with the GA release PR.

--- a/release-2.0-issues/012-go-directive-and-test-deps.md
+++ b/release-2.0-issues/012-go-directive-and-test-deps.md
@@ -20,10 +20,19 @@
    trigger consumers' dependency scanners (a godog CVE would page every consumer's
    security team), and show on pkg.go.dev's imports list.
 
+## Status update (2026-07-18)
+
+Item 1 was attempted and is **not actionable**: `kiota-http-go` (and its otel
+dependencies) declare `go 1.25.0`, so `go mod tidy` forces the directive back to
+1.25.0. The floor can only drop by downgrading kiota-http-go, which isn't worth it.
+Item 2 (nested test module) remains open.
+
 ## Recommendation
 
-1. Choose and document a support policy — e.g. "the two most recent Go releases" — and
-   set the go directive to the older of the two (drop the patch suffix: `go 1.24`).
+1. ~~Choose and document a support policy — e.g. "the two most recent Go releases" — and
+   set the go directive to the older of the two (drop the patch suffix: `go 1.24`).~~
+   Blocked by kiota-http-go's own `go 1.25.0` requirement; document "requires Go ≥ 1.25"
+   in the Readme instead.
 2. Move `tests/integration` and `tests/e2e` into their own nested module
    (`tests/go.mod`) with a `replace` or workspace (`go.work`) for local dev. That
    removes godog/godotenv/httpmock from the SDK's module. `testify` stays (used by

--- a/release-2.0-issues/012-go-directive-and-test-deps.md
+++ b/release-2.0-issues/012-go-directive-and-test-deps.md
@@ -1,0 +1,31 @@
+# Consumer-facing go.mod: minimum Go version and test-only dependencies
+
+- **Priority:** P2
+- **Raised by:** Senior Principal Engineer
+- **Area:** SDK design / dependency hygiene
+
+## Problem
+
+1. **`go 1.25.0` minimum.** The go.mod directive forces every consumer onto Go ≥ 1.25.
+   Enterprise ServiceNow shops (the target audience) often trail several releases.
+   Unless the code needs a 1.25 language feature or stdlib API, a lower directive
+   (matching CI's `oldstable`, and ideally one more back) widens adoption at zero cost.
+   Note the CI matrix already tests `oldstable`, so the floor should be an explicit,
+   tested decision, not whatever the dev machine had.
+
+2. **Test-only dependencies in the main module's require block**: `cucumber/godog`,
+   `jarcoal/httpmock`, `joho/godotenv` exist solely for `tests/` (build-tag-gated) and
+   unit-test mocks. Since Go 1.17 module-graph pruning, consumers don't *build* these,
+   but they still appear in the SDK's go.mod/go.sum, inflate `go mod graph` output,
+   trigger consumers' dependency scanners (a godog CVE would page every consumer's
+   security team), and show on pkg.go.dev's imports list.
+
+## Recommendation
+
+1. Choose and document a support policy — e.g. "the two most recent Go releases" — and
+   set the go directive to the older of the two (drop the patch suffix: `go 1.24`).
+2. Move `tests/integration` and `tests/e2e` into their own nested module
+   (`tests/go.mod`) with a `replace` or workspace (`go.work`) for local dev. That
+   removes godog/godotenv/httpmock from the SDK's module. `testify` stays (used by
+   co-located unit tests — acceptable and conventional).
+3. Add the nested module to CI's tidy-check and test jobs (see issue 009).

--- a/release-2.0-issues/013-missing-security-and-governance-files.md
+++ b/release-2.0-issues/013-missing-security-and-governance-files.md
@@ -1,0 +1,32 @@
+# Missing SECURITY.md and CODEOWNERS; ancient dependabot-merge action
+
+- **Priority:** P2
+- **Raised by:** Senior DevOps (with Senior Product Manager)
+- **Area:** Governance / supply chain
+
+## Problem
+
+1. **No `SECURITY.md`.** An SDK that handles ServiceNow credentials (OAuth2 flows, JWT
+   bearer, ROPC in `credentials/`) should tell researchers how to report a
+   vulnerability privately. GitHub surfaces the absence on the repo's Security tab.
+2. **No `CODEOWNERS`.** With auto-merge enabled for Dependabot PRs (`pr.yml`), there is
+   no required-reviewer backstop on workflow or credential-path changes.
+3. **`dependabot/fetch-metadata@v3.1.0`** in `pr.yml` is several major versions old
+   (current is v2.x under the new versioning... verify — the action renumbered; v3.1.0
+   predates the consolidation). While auditing: the auto-merge rule merges anything
+   non-semver-major, including GitHub Actions bumps, with **no passing-checks
+   requirement expressed in the workflow** — it relies entirely on branch protection
+   requiring status checks. Confirm branch protection actually requires the CI jobs,
+   otherwise a red Dependabot PR can auto-merge (and note issue 001 means the test
+   check was never a real gate anyway).
+
+## Recommendation
+
+1. Add `SECURITY.md` with a private-reporting channel (GitHub private vulnerability
+   reporting is one click to enable) and the supported-versions table (v2.x supported;
+   v1.x critical-fixes-only per issue 008).
+2. Add `.github/CODEOWNERS` covering at minimum `/.github/`, `/credentials/`, and
+   `go.mod`.
+3. Bump `fetch-metadata`, and verify branch-protection required checks match the
+   current CI job names (they changed names during the v2 rework — a renamed job
+   silently stops being "required").

--- a/release-2.0-issues/014-public-api-surface-audit.md
+++ b/release-2.0-issues/014-public-api-surface-audit.md
@@ -1,0 +1,39 @@
+# Pre-GA public API surface audit
+
+- **Priority:** P1 — the surface freezes at v2.0.0
+- **Raised by:** Senior Principal Engineer
+- **Area:** SDK design
+
+## Problem
+
+Everything exported at tag time is frozen under Go 1 compatibility expectations until
+v3. The v2 rework was large (90 commits) and fast; a deliberate final pass over what is
+actually exported has not happened. Known smells worth a look:
+
+- `mocking.go` in the root package exports test doubles to consumers (see issue 006).
+- The constructor triad (`New<X>RequestBuilderInternal` / `NewDefault<X>RequestBuilder`
+  / `New<X>RequestBuilder`) exposes `...Internal` constructors publicly in every
+  package — if they're internal, the name says so but the export doesn't.
+- Backing-store accessor/mutator plumbing: verify `internal/store` types don't leak
+  through exported signatures (a consumer should never need to name an `internal` type;
+  the compiler forbids importing them, so a leaked one makes the API uncallable).
+- Deprecated v1 surfaces: confirm nothing marked `// Deprecated:` in v1 survived into
+  v2 exports unintentionally.
+- Response envelopes (`core.ServiceNowItemResponse[T]` etc.): check the generic
+  constraints and method sets read as intended final API, since generics choices are
+  especially hard to walk back.
+
+## Recommendation
+
+1. Generate the surface: `go doc -all ./...` or
+   `golang.org/x/exp/cmd/apidiff` v1-tag → release/2.0 to see exactly what changed and
+   what's new.
+2. Review with the rule "unexported by default; export only what a consumer journey
+   needs." Demote `...Internal` constructors if feasible (or document why they must be
+   public — Kiota-style cross-package construction may genuinely need them; then say so
+   in doc comments).
+3. Ensure every exported identifier has a doc comment (`staticcheck`'s ST1000/ST1020
+   family or `revive`'s exported rule can enforce; currently not enabled in
+   `.golangci.yml`).
+4. Run the `api-module-consistency-reviewer` agent across all `*api` packages as the
+   final consistency gate.

--- a/release-2.0-issues/README.md
+++ b/release-2.0-issues/README.md
@@ -5,6 +5,13 @@ Senior DevOps) of the `release/2.0` branch, conducted 2026-07-17. Current state 
 review time: branch is 90 commits ahead of `main`, `go build ./...` clean,
 `go test ./...` passing locally, version at 1.12.0.
 
+## Status (2026-07-18)
+
+Fix PRs are open against `release/2.0`:
+#481 (001), #482+part of 002 (009), #483 (010), #484 (006), #485 (007), #486 (013), #487 (004 + part of 005).
+Issue 012's go-directive item is blocked by kiota-http-go's own `go 1.25.0` floor (see the issue file).
+Still open: 002/003 (release-day runbooks), 005 (remaining sentinel consolidation), 008, 011 (decision), 012 (test-module split), 014.
+
 ## Release blockers (P0)
 
 | # | Issue | Owner role |

--- a/release-2.0-issues/README.md
+++ b/release-2.0-issues/README.md
@@ -1,0 +1,49 @@
+# 2.0 Release Readiness Review — Issue Tracker
+
+Findings from a three-role review (Senior Product Manager, Senior Principal Engineer,
+Senior DevOps) of the `release/2.0` branch, conducted 2026-07-17. Current state at
+review time: branch is 90 commits ahead of `main`, `go build ./...` clean,
+`go test ./...` passing locally, version at 1.12.0.
+
+## Release blockers (P0)
+
+| # | Issue | Owner role |
+| --- | --- | --- |
+| [001](001-ci-test-failures-never-fail-the-build.md) | CI test failures never fail the build (`report-tests.sh` always exits 0) | DevOps |
+| [002](002-no-release-path-from-release-2.0-to-v2.0.0-tag.md) | No defined path from `release/2.0` to a v2.0.0 tag; non-conventional commits and missing `BREAKING CHANGE` footer would yield v1.13.0 | DevOps + PM |
+| [003](003-v2-module-path-runbook.md) | `/v2` module path bump — deferred by design, needs a release-day runbook so the tag isn't burned | Engineering |
+
+## High priority (P1) — do before GA
+
+| # | Issue | Owner role |
+| --- | --- | --- |
+| [004](004-nil-receiver-guards-return-nil-nil.md) | `return nil, nil` nil-receiver guards silently swallow bugs; fix the contract while breaking changes are free | Engineering |
+| [005](005-consolidate-error-sentinels.md) | Three error-sentinel locations + inline `errors.New` duplicates break `errors.Is` | Engineering |
+| [006](006-repo-hygiene-stray-working-files.md) | Scratch files (`coverage.html`, `fix_error_mappings.py`, `files_to_fix.txt`, ...) committed at repo root | PM + Engineering |
+| [007](007-readme-links-all-broken.md) | Every Readme API-table link 404s (old hyphenated directory names) | PM |
+| [008](008-v2-migration-guide-and-launch-comms.md) | No v1→v2 migration guide, v1 support policy, or launch checklist | PM |
+| [009](009-ci-coverage-gaps.md) | Integration tests never run in CI; no govulncheck; unpinned lint/tool versions; stale lint exclusions | DevOps |
+| [014](014-public-api-surface-audit.md) | Final exported-surface audit before the API freezes at v2.0.0 | Engineering |
+
+## Medium priority (P2) — decide before GA, fix opportunistically
+
+| # | Issue | Owner role |
+| --- | --- | --- |
+| [010](010-docs-pipeline-inefficiencies.md) | Docs workflow: stale `pages.yml` filter, deploy rebuilds instead of using its artifact | DevOps |
+| [011](011-dual-release-please-channels.md) | Weekly-preview and stable release-please channels share one changelog/tag namespace | DevOps |
+| [012](012-go-directive-and-test-deps.md) | `go 1.25.0` floor limits adoption; godog/httpmock/godotenv pollute consumer-visible go.mod | Engineering |
+| [013](013-missing-security-and-governance-files.md) | No SECURITY.md/CODEOWNERS; verify Dependabot auto-merge is gated by required checks | DevOps + PM |
+
+## Suggested sequencing
+
+1. **Now:** 001 (real test gate) → then everything else merges against honest CI.
+2. **In parallel:** 004+005 (one error-contract sweep), 006, 007, 009, 014.
+3. **Product track:** 008 (migration guide + support policy), 011 decision, 013.
+4. **Release day:** 003 then 002, in that order, per their runbooks.
+
+## What we deliberately did not flag
+
+- The Kiota-style hand-written builder pattern itself — it's consistent, tested, and
+  matches the msgraph-sdk-go idiom the project intentionally targets.
+- `VERSION`/`CHANGELOG.md` automation — release-please wiring is correct for the
+  steady state; only the 2.0 transition (002/003) and channel overlap (011) need work.


### PR DESCRIPTION
## Summary
- Adds `release-2.0-issues/` — 14 prioritized findings (3× P0, 7× P1, 4× P2) from a PM / principal-engineer / DevOps review of the `release/2.0` branch, with a README index, owners, and release-day sequencing.
- P0s: CI test gate never fails (`report-tests.sh`), no defined release path from `release/2.0` to a v2.0.0 tag, and the deferred `/v2` module-path bump needs a runbook.

## Test plan
- Docs-only change; no Go code touched.