### PR TITLE
fix(ci): propagate go test exit code so failures fail the build

### DIFF
--- a/.github/scripts/report-tests.sh
+++ b/.github/scripts/report-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -o pipefail
 
-TEST_EXIT_CODE=0
 go test -coverprofile=coverage.out -json -v ./... > test-output.json
-echo "exit: $?"
+TEST_EXIT_CODE=$?
+echo "exit: $TEST_EXIT_CODE"
 grep '"Action":"fail"' test-output.json
 
 cat test-output.json | go run scripts/generate_test_report.go > test-summary.md || true


### PR DESCRIPTION
## Summary
- `report-tests.sh` set `TEST_EXIT_CODE=0`, never captured `go test`'s exit status (the `echo "exit: $?"` consumed it), and exited 0 unconditionally — test failures could never fail the `test-go` CI job, and the failure sticky-comment steps could never trigger.
- Capture the exit code immediately after `go test` and propagate it.

Fixes issue 001 in `release-2.0-issues/`.

## Test plan
- Simulated both outcomes with a stubbed `go` binary: script now exits 0 on pass, 1 on failure (previously 0 in both cases).
- `go test ./...` on this branch passes, so CI stays green here.