### PR TITLE
chore: add SECURITY.md and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Fallback owner for everything
+* @michaeldcanady
+
+# Require owner review on CI/CD and automation changes
+/.github/ @michaeldcanady
+
+# Authentication and credential handling
+/credentials/ @michaeldcanady
+/internal/oauth2/ @michaeldcanady
+
+# Module dependency changes
+/go.mod @michaeldcanady
+/go.sum @michaeldcanady

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| 1.x     | Critical fixes only |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, report it privately via
+[GitHub's private vulnerability reporting](https://github.com/michaeldcanady/servicenow-sdk-go/security/advisories/new)
+for this repository.
+
+Include, where possible:
+
+- A description of the issue and its impact
+- Steps or a proof-of-concept to reproduce it
+- Affected package(s) and version(s)
+
+You can expect an acknowledgement within 7 days. Once a fix is available, the
+vulnerability will be disclosed via a GitHub security advisory and, where
+applicable, submitted to the [Go vulnerability database](https://vuln.go.dev/).
+
+## Scope notes
+
+This SDK handles ServiceNow credentials (basic auth and OAuth2 flows under
+`credentials/`). Issues involving credential leakage, token handling, TLS
+behavior, or request forgery are especially in scope.


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md`: private reporting via GitHub security advisories, a supported-versions table (2.x supported / 1.x critical-fixes-only, matching the launch policy proposed in issue 008), and scope notes for the credential-handling code.
- Adds `.github/CODEOWNERS`: owner review on `/.github/` (workflows), `/credentials/`, `internal/oauth2/`, and `go.mod`/`go.sum` — a backstop given Dependabot auto-merge is enabled in `pr.yml`.

Fixes issue 013 in `release-2.0-issues/`. Two follow-ups need repo settings (not files): enable GitHub private vulnerability reporting, and confirm branch protection's required checks match the current CI job names.

## Test plan
- Docs/config-only; no Go code touched. CODEOWNERS syntax follows GitHub's documented format (path + @owner).