### PR TITLE
fix(all)!: nil-receiver guards return ErrNilRequestBuilder instead of nil, nil

### DIFF
--- a/.claude/agents/api-module-consistency-reviewer.md
+++ b/.claude/agents/api-module-consistency-reviewer.md
@@ -19,10 +19,10 @@ should follow the same shape:
   standard nil-guard:
   ```go
   if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-      return nil, nil
+      return nil, snerrors.ErrNilRequestBuilder
   }
   if conversion.IsNil(rB.GetRequestAdapter()) {
-      return nil, errors.New("request adapter is nil")
+      return nil, snerrors.ErrNilRequestAdapter
   }
   ```
 - **Constructors** follow the triad: `New<X>RequestBuilderInternal` (takes

--- a/.claude/skills/new-api-module/SKILL.md
+++ b/.claude/skills/new-api-module/SKILL.md
@@ -77,10 +77,10 @@ simpler module, `policyapi/` shows a smaller single-resource shape.
    - Every method starts with the nil-guard pattern:
      ```go
      if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-         return nil, nil
+         return nil, snerrors.ErrNilRequestBuilder
      }
      if conversion.IsNil(rB.GetRequestAdapter()) {
-         return nil, errors.New("request adapter is nil")
+         return nil, snerrors.ErrNilRequestAdapter
      }
      ```
    - Use `internal/conversion`, `internal/http`, `internal/model` helpers rather

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ package follows:
 - **One method per HTTP verb** (`Get`/`Post`/`Patch`/`Put`/`Delete`), each starting with:
   ```go
   if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-      return nil, nil
+      return nil, snerrors.ErrNilRequestBuilder
   }
   if conversion.IsNil(rB.GetRequestAdapter()) {
       return nil, snerrors.ErrNilRequestAdapter   // see error-sentinel note below

--- a/accountapi/account_item_request_builder.go
+++ b/accountapi/account_item_request_builder.go
@@ -2,6 +2,7 @@ package accountapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -27,7 +28,7 @@ func NewAccountItemRequestBuilderInternal(pathParameters map[string]string, requ
 // Get sends a GET request to retrieve a single account.
 func (rB *AccountItemRequestBuilder) Get(ctx context.Context, config *AccountItemRequestBuilderGetRequestConfiguration) (AccountItemResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -51,7 +52,7 @@ func (rB *AccountItemRequestBuilder) Get(ctx context.Context, config *AccountIte
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *AccountItemRequestBuilder) ToGetRequestInformation(_ context.Context, config *AccountItemRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/accountapi/account_request_builder.go
+++ b/accountapi/account_request_builder.go
@@ -2,6 +2,7 @@ package accountapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -35,7 +36,7 @@ func (rB *AccountRequestBuilder) ByID(accountID string) *AccountItemRequestBuild
 // Get sends a GET request to retrieve a list of accounts.
 func (rB *AccountRequestBuilder) Get(ctx context.Context, config *AccountRequestBuilderGetRequestConfiguration) (AccountCollectionResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -59,7 +60,7 @@ func (rB *AccountRequestBuilder) Get(ctx context.Context, config *AccountRequest
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *AccountRequestBuilder) ToGetRequestInformation(_ context.Context, config *AccountRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/actsubapi/activities_request_builder.go
+++ b/actsubapi/activities_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewActivitiesRequestBuilderInternal(pathParameters map[string]string, reque
 // Get sends a GET request to retrieve activities.
 func (rB *ActivitiesRequestBuilder) Get(ctx context.Context, config *ActivitiesRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.Get(ctx, config)
 }
@@ -35,7 +36,7 @@ func (rB *ActivitiesRequestBuilder) Get(ctx context.Context, config *ActivitiesR
 // ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve activities.
 func (rB *ActivitiesRequestBuilder) ToGetRequestInformation(ctx context.Context, config *ActivitiesRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/collection_get_request_builder.go
+++ b/actsubapi/collection_get_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -30,7 +31,7 @@ func newCollectionGetRequestBuilder(pathParameters map[string]string, requestAda
 // Get sends a GET request to retrieve the collection.
 func (rB *collectionGetRequestBuilder) Get(ctx context.Context, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -53,7 +54,7 @@ func (rB *collectionGetRequestBuilder) Get(ctx context.Context, config *abstract
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *collectionGetRequestBuilder) ToGetRequestInformation(ctx context.Context, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/actsubapi/collection_get_request_builder_test.go
+++ b/actsubapi/collection_get_request_builder_test.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -65,7 +66,7 @@ func TestCollectionGetRequestBuilder_Get(t *testing.T) {
 
 			switch {
 			case tc.nilBuilder, tc.nilInner:
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, resp)
 			case tc.expectErr:
 				assert.Error(t, err)
@@ -110,7 +111,7 @@ func TestCollectionGetRequestBuilder_ToGetRequestInformation(t *testing.T) {
 			reqInfo, err := builder.ToGetRequestInformation(context.Background(), nil)
 
 			if tt.nilBuilder || tt.nilInner {
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, reqInfo)
 				return
 			}

--- a/actsubapi/contexts_request_builder.go
+++ b/actsubapi/contexts_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewContextsRequestBuilderInternal(pathParameters map[string]string, request
 // Get sends a GET request to retrieve contexts.
 func (rB *ContextsRequestBuilder) Get(ctx context.Context, config *ContextsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.Get(ctx, config)
 }
@@ -35,7 +36,7 @@ func (rB *ContextsRequestBuilder) Get(ctx context.Context, config *ContextsReque
 // ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve contexts.
 func (rB *ContextsRequestBuilder) ToGetRequestInformation(ctx context.Context, config *ContextsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/facets_request_builder.go
+++ b/actsubapi/facets_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -80,7 +81,7 @@ func NewFacetsInstanceRequestBuilderInternal(pathParameters map[string]string, r
 // Get sends a GET request to retrieve facets.
 func (rB *FacetsInstanceRequestBuilder) Get(ctx context.Context, config *FacetsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -103,7 +104,7 @@ func (rB *FacetsInstanceRequestBuilder) Get(ctx context.Context, config *FacetsR
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *FacetsInstanceRequestBuilder) ToGetRequestInformation(ctx context.Context, config *FacetsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/actsubapi/following_request_builder.go
+++ b/actsubapi/following_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi // nolint:dupl // FollowingItemRequestBuilder/SubscriberItemRe
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -53,7 +54,7 @@ func NewFollowingItemRequestBuilderInternal(pathParameters map[string]string, re
 // Get sends a GET request to retrieve following.
 func (rB *FollowingItemRequestBuilder) Get(ctx context.Context, config *FollowingsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.Get(ctx, config)
 }
@@ -61,7 +62,7 @@ func (rB *FollowingItemRequestBuilder) Get(ctx context.Context, config *Followin
 // ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve following.
 func (rB *FollowingItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *FollowingsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/preferences_request_builder.go
+++ b/actsubapi/preferences_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -32,7 +33,7 @@ func NewPreferencesRequestBuilderInternal(pathParameters map[string]string, requ
 // Post sends a POST request to create preferences.
 func (rB *PreferencesRequestBuilder) Post(ctx context.Context, body *ActivitySubscriptionModel, config *PreferencesRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -55,7 +56,7 @@ func (rB *PreferencesRequestBuilder) Post(ctx context.Context, body *ActivitySub
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *PreferencesRequestBuilder) ToPostRequestInformation(ctx context.Context, body *ActivitySubscriptionModel, config *PreferencesRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -103,7 +104,7 @@ func NewPreferenceItemRequestBuilderInternal(pathParameters map[string]string, r
 // Get sends a GET request to retrieve preferences.
 func (rB *PreferenceItemRequestBuilder) Get(ctx context.Context, config *PreferencesRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -126,7 +127,7 @@ func (rB *PreferenceItemRequestBuilder) Get(ctx context.Context, config *Prefere
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *PreferenceItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *PreferencesRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/actsubapi/sub_objects_request_builder.go
+++ b/actsubapi/sub_objects_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewSubObjectsRequestBuilderInternal(pathParameters map[string]string, reque
 // Get sends a GET request to retrieve subscribable objects.
 func (rB *SubObjectsRequestBuilder) Get(ctx context.Context, config *SubObjectsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.Get(ctx, config)
 }
@@ -35,7 +36,7 @@ func (rB *SubObjectsRequestBuilder) Get(ctx context.Context, config *SubObjectsR
 // ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve subscribable objects.
 func (rB *SubObjectsRequestBuilder) ToGetRequestInformation(ctx context.Context, config *SubObjectsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/subscribers_request_builder.go
+++ b/actsubapi/subscribers_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi // nolint:dupl // FollowingItemRequestBuilder/SubscriberItemRe
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -53,7 +54,7 @@ func NewSubscriberItemRequestBuilderInternal(pathParameters map[string]string, r
 // Get sends a GET request to retrieve subscribers.
 func (rB *SubscriberItemRequestBuilder) Get(ctx context.Context, config *SubscribersRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.Get(ctx, config)
 }
@@ -61,7 +62,7 @@ func (rB *SubscriberItemRequestBuilder) Get(ctx context.Context, config *Subscri
 // ToGetRequestInformation creates a RequestInformation object for a GET request to retrieve subscribers.
 func (rB *SubscriberItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *SubscribersRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.collectionGetRequestBuilder.ToGetRequestInformation(ctx, config)
 }

--- a/actsubapi/subscriptions_request_builder.go
+++ b/actsubapi/subscriptions_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -66,7 +67,7 @@ func NewSubscriptionItemRequestBuilderInternal(pathParameters map[string]string,
 // Get sends a GET request to retrieve a specific subscription.
 func (rB *SubscriptionItemRequestBuilder) Get(ctx context.Context, config *SubscriptionsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -89,7 +90,7 @@ func (rB *SubscriptionItemRequestBuilder) Get(ctx context.Context, config *Subsc
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *SubscriptionItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *SubscriptionsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -160,7 +161,7 @@ func NewIsSubscribedRequestBuilderInternal(pathParameters map[string]string, req
 // Get sends a GET request to check if the current user is subscribed.
 func (rB *IsSubscribedRequestBuilder) Get(ctx context.Context, config *IsSubscribedRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -183,7 +184,7 @@ func (rB *IsSubscribedRequestBuilder) Get(ctx context.Context, config *IsSubscri
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *IsSubscribedRequestBuilder) ToGetRequestInformation(ctx context.Context, config *IsSubscribedRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -215,7 +216,7 @@ func NewSubscribeRequestBuilderInternal(pathParameters map[string]string, reques
 // Post sends a POST request to subscribe to an object.
 func (rB *SubscribeRequestBuilder) Post(ctx context.Context, body *ActivitySubscriptionModel, config *SubscribeRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -238,7 +239,7 @@ func (rB *SubscribeRequestBuilder) Post(ctx context.Context, body *ActivitySubsc
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *SubscribeRequestBuilder) ToPostRequestInformation(ctx context.Context, body *ActivitySubscriptionModel, config *SubscribeRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -277,7 +278,7 @@ func NewUnsubscribeRequestBuilderInternal(pathParameters map[string]string, requ
 // Delete sends a DELETE request to unsubscribe from an object.
 func (rB *UnsubscribeRequestBuilder) Delete(ctx context.Context, config *UnsubscribeRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, config)
@@ -296,7 +297,7 @@ func (rB *UnsubscribeRequestBuilder) Delete(ctx context.Context, config *Unsubsc
 // ToDeleteRequestInformation creates a RequestInformation object for a DELETE request.
 func (rB *UnsubscribeRequestBuilder) ToDeleteRequestInformation(ctx context.Context, config *UnsubscribeRequestBuilderDeleteRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/actsubapi/user_stream_request_builder.go
+++ b/actsubapi/user_stream_request_builder.go
@@ -2,6 +2,7 @@ package actsubapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -55,7 +56,7 @@ func NewUserStreamItemRequestBuilderInternal(pathParameters map[string]string, r
 // Get sends a GET request to retrieve a specific user activity stream.
 func (rB *UserStreamItemRequestBuilder) Get(ctx context.Context, config *UserStreamRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -79,7 +80,7 @@ func (rB *UserStreamItemRequestBuilder) Get(ctx context.Context, config *UserStr
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *UserStreamItemRequestBuilder) ToGetRequestInformation(_ context.Context, config *UserStreamRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -95,7 +96,7 @@ func (rB *UserStreamItemRequestBuilder) ToGetRequestInformation(_ context.Contex
 // Put sends a PUT request to update a specific user activity stream.
 func (rB *UserStreamItemRequestBuilder) Put(ctx context.Context, body *ActivitySubscriptionModel, config *UserStreamRequestBuilderPutRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
@@ -119,7 +120,7 @@ func (rB *UserStreamItemRequestBuilder) Put(ctx context.Context, body *ActivityS
 // ToPutRequestInformation creates a RequestInformation object for a PUT request.
 func (rB *UserStreamItemRequestBuilder) ToPutRequestInformation(ctx context.Context, body *ActivitySubscriptionModel, config *UserStreamRequestBuilderPutRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/appointmentbookingapi/appointment_request_builder.go
+++ b/appointmentbookingapi/appointment_request_builder.go
@@ -2,6 +2,7 @@ package appointmentbookingapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -23,7 +24,7 @@ func NewAppointmentRequestBuilder(pathParameters map[string]string, requestAdapt
 // Post sends a POST request to book or reschedule an appointment.
 func (rB *AppointmentRequestBuilder) Post(ctx context.Context, body AppointmentRequest, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (AppointmentResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -46,7 +47,7 @@ func (rB *AppointmentRequestBuilder) Post(ctx context.Context, body AppointmentR
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *AppointmentRequestBuilder) ToPostRequestInformation(ctx context.Context, body AppointmentRequest, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/appointmentbookingapi/sub_request_builders.go
+++ b/appointmentbookingapi/sub_request_builders.go
@@ -2,6 +2,7 @@ package appointmentbookingapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -26,7 +27,7 @@ func NewAvailabilityRequestBuilder(pathParameters map[string]string, requestAdap
 // Post sends a POST request to get availability.
 func (rB *AvailabilityRequestBuilder) Post(ctx context.Context, body AvailabilityRequest, config *AvailabilityRequestBuilderPostRequestConfiguration) (AvailabilityResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -49,7 +50,7 @@ func (rB *AvailabilityRequestBuilder) Post(ctx context.Context, body Availabilit
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *AvailabilityRequestBuilder) ToPostRequestInformation(ctx context.Context, body AvailabilityRequest, config *AvailabilityRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -82,7 +83,7 @@ func NewCalendarRequestBuilder(pathParameters map[string]string, requestAdapter 
 // Get sends a GET request to retrieve calendar.
 func (rB *CalendarRequestBuilder) Get(ctx context.Context, config *CalendarRequestBuilderGetRequestConfiguration) (CalendarResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -105,7 +106,7 @@ func (rB *CalendarRequestBuilder) Get(ctx context.Context, config *CalendarReque
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *CalendarRequestBuilder) ToGetRequestInformation(ctx context.Context, config *CalendarRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -133,7 +134,7 @@ func NewConfigurationRequestBuilder(pathParameters map[string]string, requestAda
 // Get sends a GET request to retrieve configuration.
 func (rB *ConfigurationRequestBuilder) Get(ctx context.Context, config *ConfigurationRequestBuilderGetRequestConfiguration) (ConfigurationResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -156,7 +157,7 @@ func (rB *ConfigurationRequestBuilder) Get(ctx context.Context, config *Configur
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *ConfigurationRequestBuilder) ToGetRequestInformation(ctx context.Context, config *ConfigurationRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -184,7 +185,7 @@ func NewExecuteRuleConditionsRequestBuilder(pathParameters map[string]string, re
 // Post sends a POST request to execute rule conditions.
 func (rB *ExecuteRuleConditionsRequestBuilder) Post(ctx context.Context, body ExecuteRuleConditionsRequest, config *ExecuteRuleConditionsRequestBuilderPostRequestConfiguration) (ExecuteRuleConditionsResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -207,7 +208,7 @@ func (rB *ExecuteRuleConditionsRequestBuilder) Post(ctx context.Context, body Ex
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *ExecuteRuleConditionsRequestBuilder) ToPostRequestInformation(ctx context.Context, body ExecuteRuleConditionsRequest, config *ExecuteRuleConditionsRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -240,7 +241,7 @@ func NewUserWindowRequestBuilder(pathParameters map[string]string, requestAdapte
 // Post sends a POST request to get user window.
 func (rB *UserWindowRequestBuilder) Post(ctx context.Context, body any, config *UserWindowRequestBuilderPostRequestConfiguration) (AvailabilityResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -263,7 +264,7 @@ func (rB *UserWindowRequestBuilder) Post(ctx context.Context, body any, config *
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *UserWindowRequestBuilder) ToPostRequestInformation(ctx context.Context, body any, config *UserWindowRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/appserviceapi/appservice_request_builders.go
+++ b/appserviceapi/appservice_request_builders.go
@@ -2,6 +2,7 @@ package appserviceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -104,7 +105,7 @@ func NewPopulateServiceRequestBuilderInternal(pathParameters map[string]string, 
 // Put sends a PUT request to populate a service.
 func (rB *PopulateServiceRequestBuilder) Put(ctx context.Context, body *PopulateServiceRequest, config *PopulateServiceRequestConfiguration) (PopulateServiceResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
@@ -125,7 +126,7 @@ func (rB *PopulateServiceRequestBuilder) Put(ctx context.Context, body *Populate
 // ToPutRequestInformation creates a RequestInformation object for a PUT request.
 func (rB *PopulateServiceRequestBuilder) ToPutRequestInformation(ctx context.Context, body *PopulateServiceRequest, config *PopulateServiceRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -156,7 +157,7 @@ func NewServiceDetailsRequestBuilderInternal(pathParameters map[string]string, r
 // Put sends a PUT request to update service details.
 func (rB *ServiceDetailsRequestBuilder) Put(ctx context.Context, body *ServiceDetailsRequest, config *ServiceDetailsRequestConfiguration) (ServiceDetailsResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
@@ -177,7 +178,7 @@ func (rB *ServiceDetailsRequestBuilder) Put(ctx context.Context, body *ServiceDe
 // ToPutRequestInformation creates a RequestInformation object for a PUT request.
 func (rB *ServiceDetailsRequestBuilder) ToPutRequestInformation(ctx context.Context, body *ServiceDetailsRequest, config *ServiceDetailsRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/appserviceapi/create_request_builder.go
+++ b/appserviceapi/create_request_builder.go
@@ -2,6 +2,7 @@ package appserviceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
@@ -22,7 +23,7 @@ func NewCreateRequestBuilderInternal(pathParameters map[string]string, requestAd
 // Post sends a POST request to create an application service.
 func (rB *CreateRequestBuilder) Post(ctx context.Context, body *CreateServiceRequest, config *CreateRequestConfiguration) (CreateServiceResponse, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.post(ctx, body, config)
 }
@@ -30,7 +31,7 @@ func (rB *CreateRequestBuilder) Post(ctx context.Context, body *CreateServiceReq
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *CreateRequestBuilder) ToPostRequestInformation(ctx context.Context, body *CreateServiceRequest, config *CreateRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.toPostRequestInformation(ctx, body, config)
 }

--- a/appserviceapi/find_service_request_builder.go
+++ b/appserviceapi/find_service_request_builder.go
@@ -2,6 +2,7 @@ package appserviceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -25,7 +26,7 @@ func NewFindServiceRequestBuilderInternal(pathParameters map[string]string, requ
 // Get sends a GET request to find an application service.
 func (rB *FindServiceRequestBuilder) Get(ctx context.Context, config *FindServiceRequestConfiguration) (FindServiceResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -46,7 +47,7 @@ func (rB *FindServiceRequestBuilder) Get(ctx context.Context, config *FindServic
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *FindServiceRequestBuilder) ToGetRequestInformation(ctx context.Context, config *FindServiceRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/appserviceapi/register_service_request_builder.go
+++ b/appserviceapi/register_service_request_builder.go
@@ -2,6 +2,7 @@ package appserviceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
@@ -22,7 +23,7 @@ func NewRegisterServiceRequestBuilderInternal(pathParameters map[string]string, 
 // Post sends a POST request to register a service.
 func (rB *RegisterServiceRequestBuilder) Post(ctx context.Context, body *RegisterServiceRequest, config *RegisterServiceRequestConfiguration) (RegisterServiceResponse, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.post(ctx, body, config)
 }
@@ -30,7 +31,7 @@ func (rB *RegisterServiceRequestBuilder) Post(ctx context.Context, body *Registe
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *RegisterServiceRequestBuilder) ToPostRequestInformation(ctx context.Context, body *RegisterServiceRequest, config *RegisterServiceRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.toPostRequestInformation(ctx, body, config)
 }

--- a/appserviceapi/service_post_request_builder.go
+++ b/appserviceapi/service_post_request_builder.go
@@ -2,6 +2,7 @@ package appserviceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -33,7 +34,7 @@ func (rB *servicePostRequestBuilder[TBody, TResponse]) post(ctx context.Context,
 	var zero TResponse
 
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return zero, nil
+		return zero, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.toPostRequestInformation(ctx, body, config)
@@ -54,7 +55,7 @@ func (rB *servicePostRequestBuilder[TBody, TResponse]) post(ctx context.Context,
 // toPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *servicePostRequestBuilder[TBody, TResponse]) toPostRequestInformation(ctx context.Context, body TBody, config *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/appserviceapi/service_post_request_builder_test.go
+++ b/appserviceapi/service_post_request_builder_test.go
@@ -3,6 +3,7 @@ package appserviceapi
 import (
 	"context"
 	"errors"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -79,7 +80,7 @@ func TestServicePostRequestBuilder_Post(t *testing.T) {
 
 			switch {
 			case tt.nilBuilder, tt.nilInner:
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, resp)
 			case tt.expectedErr != nil:
 				assert.EqualError(t, err, tt.expectedErr.Error())
@@ -107,14 +108,14 @@ func TestServicePostRequestBuilder_ToPostRequestInformation(t *testing.T) {
 	t.Run("Nil builder", func(t *testing.T) {
 		var builder *servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse]
 		reqInfo, err := builder.toPostRequestInformation(context.Background(), NewCreateServiceRequest(), nil)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 		assert.Nil(t, reqInfo)
 	})
 
 	t.Run("Nil inner request builder", func(t *testing.T) {
 		builder := &servicePostRequestBuilder[*CreateServiceRequest, CreateServiceResponse]{}
 		reqInfo, err := builder.toPostRequestInformation(context.Background(), NewCreateServiceRequest(), nil)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 		assert.Nil(t, reqInfo)
 	})
 }

--- a/attachmentapi/attachment_file_request_builder.go
+++ b/attachmentapi/attachment_file_request_builder.go
@@ -53,7 +53,7 @@ func NewAttachmentFileRequestBuilder(
 // Post uploads provided content to Service-Now using provided parameters
 func (rB *AttachmentFileRequestBuilder) Post(ctx context.Context, media *Media, requestConfiguration *AttachmentFileRequestBuilderPostRequestConfiguration) (core.ServiceNowItemResponse[*File], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestConfiguration) {
@@ -120,7 +120,7 @@ func (rB *AttachmentFileRequestBuilder) Post(ctx context.Context, media *Media, 
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *AttachmentFileRequestBuilder) ToPostRequestInformation(_ context.Context, media *Media, requestConfiguration *AttachmentFileRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/attachmentapi/attachment_file_request_builder_test.go
+++ b/attachmentapi/attachment_file_request_builder_test.go
@@ -243,7 +243,7 @@ func TestAttachmentFileRequestBuilder_Post(t *testing.T) {
 
 			if tt.nilBuilder {
 				assert.Nil(t, res)
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				return
 			}
 
@@ -321,7 +321,7 @@ func assertAttachmentFilePostRequestInformation(t *testing.T, tt attachmentFileP
 
 	if tt.nilBuilder || tt.nilRequestBuilder {
 		assert.Nil(t, reqInfo)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 		return
 	}
 

--- a/attachmentapi/attachment_item_file_request_builder.go
+++ b/attachmentapi/attachment_item_file_request_builder.go
@@ -59,7 +59,7 @@ func NewAttachmentItemFileRequestBuilder(
 // Get returns file with content using provided parameters
 func (rB *AttachmentItemFileRequestBuilder) Get(ctx context.Context, requestConfiguration *AttachmentItemFileRequestBuilderGetRequestConfiguration) (*FileWithContent, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestConfiguration) {
@@ -128,7 +128,7 @@ func (rB *AttachmentItemFileRequestBuilder) Get(ctx context.Context, requestConf
 // ToGetRequestInformation converts request configurations to Get request information.
 func (rB *AttachmentItemFileRequestBuilder) ToGetRequestInformation(_ context.Context, requestConfiguration *AttachmentItemFileRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/attachmentapi/attachment_item_file_request_builder_test.go
+++ b/attachmentapi/attachment_item_file_request_builder_test.go
@@ -121,7 +121,7 @@ func assertAttachmentItemFileGetResult(t *testing.T, tt attachmentItemFileGetTes
 
 	if tt.nilBuilder {
 		assert.Nil(t, result)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 		return
 	}
 
@@ -232,7 +232,7 @@ func assertAttachmentItemFileToGetRequestInformation(t *testing.T, tt attachment
 
 	if tt.nilBuilder || tt.nilRequestBuilder {
 		assert.Nil(t, reqInfo)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 		return
 	}
 

--- a/attachmentapi/attachment_item_request_builder.go
+++ b/attachmentapi/attachment_item_request_builder.go
@@ -63,7 +63,7 @@ func (rB *AttachmentItemRequestBuilder) File() *AttachmentItemFileRequestBuilder
 // Get returns an Attachment using the provided arguments
 func (rB *AttachmentItemRequestBuilder) Get(ctx context.Context, requestConfiguration *AttachmentItemRequestBuilderGetRequestConfiguration) (core.ServiceNowItemResponse[*Attachment], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)
@@ -92,7 +92,7 @@ func (rB *AttachmentItemRequestBuilder) Get(ctx context.Context, requestConfigur
 // Delete removes the attachment item using the provided arguments
 func (rB *AttachmentItemRequestBuilder) Delete(ctx context.Context, requestConfiguration *AttachmentItemRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, requestConfiguration)
@@ -107,7 +107,7 @@ func (rB *AttachmentItemRequestBuilder) Delete(ctx context.Context, requestConfi
 // ToGetRequestInformation converts request configurations to Post request information.
 func (rB *AttachmentItemRequestBuilder) ToGetRequestInformation(_ context.Context, requestConfiguration *AttachmentItemRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -123,7 +123,7 @@ func (rB *AttachmentItemRequestBuilder) ToGetRequestInformation(_ context.Contex
 // ToDeleteRequestInformation converts request configurations to Delete request information.
 func (rB *AttachmentItemRequestBuilder) ToDeleteRequestInformation(_ context.Context, requestConfiguration *AttachmentItemRequestBuilderDeleteRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/attachmentapi/attachment_item_request_builder_test.go
+++ b/attachmentapi/attachment_item_request_builder_test.go
@@ -177,12 +177,12 @@ func TestAttachmentItemRequestBuilder_Get(t *testing.T) {
 		{
 			name:        "Nil inner model",
 			setupMocks:  func() *mocking.MockRequestBuilder { return &mocking.MockRequestBuilder{} }, // Mocking is not used here but to satisfy interface
-			expectedErr: nil,
+			expectedErr: snerrors.ErrNilRequestBuilder,
 		},
 		{
 			name:         "Nil model",
 			isNilBuilder: true,
-			expectedErr:  nil,
+			expectedErr:  snerrors.ErrNilRequestBuilder,
 		},
 	}
 
@@ -250,12 +250,12 @@ func TestAttachmentItemRequestBuilder_Delete(t *testing.T) {
 		{
 			name:        "Nil inner model",
 			setupMocks:  func() *mocking.MockRequestBuilder { return &mocking.MockRequestBuilder{} },
-			expectedErr: nil,
+			expectedErr: snerrors.ErrNilRequestBuilder,
 		},
 		{
 			name:         "Nil model",
 			isNilBuilder: true,
-			expectedErr:  nil,
+			expectedErr:  snerrors.ErrNilRequestBuilder,
 		},
 	}
 

--- a/attachmentapi/attachment_request_builder.go
+++ b/attachmentapi/attachment_request_builder.go
@@ -3,6 +3,7 @@ package attachmentapi
 import (
 	"context"
 	"errors"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -88,7 +89,7 @@ func (rB *AttachmentRequestBuilder) Upload() *AttachmentUploadRequestBuilder {
 // Get returns AttachmentCollectionResponse using provided arguments
 func (rB *AttachmentRequestBuilder) Get(ctx context.Context, requestConfiguration *AttachmentRequestBuilderGetRequestConfiguration) (*AttachmentCollectionResponse, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestConfiguration) {
@@ -128,7 +129,7 @@ func (rB *AttachmentRequestBuilder) Get(ctx context.Context, requestConfiguratio
 // Head sends an HTTP HEAD request and returns the response headers.
 func (rB *AttachmentRequestBuilder) Head(ctx context.Context, requestConfiguration *AttachmentRequestBuilderGetRequestConfiguration) (*abstractions.ResponseHeaders, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestConfiguration) {
@@ -155,7 +156,7 @@ func (rB *AttachmentRequestBuilder) Head(ctx context.Context, requestConfigurati
 // ToHeadRequestInformation converts request configurations to Head request information.
 func (rB *AttachmentRequestBuilder) ToHeadRequestInformation(_ context.Context, requestConfiguration *AttachmentRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.HEAD, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -171,7 +172,7 @@ func (rB *AttachmentRequestBuilder) ToHeadRequestInformation(_ context.Context, 
 // ToGetRequestInformation converts request configurations to Get request information.
 func (rB *AttachmentRequestBuilder) ToGetRequestInformation(_ context.Context, requestConfiguration *AttachmentRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/attachmentapi/attachment_upload_request_builder.go
+++ b/attachmentapi/attachment_upload_request_builder.go
@@ -53,7 +53,7 @@ func NewAttachmentUploadRequestBuilder(
 // Post Uploads the provided attachment using the provided arguments
 func (rB *AttachmentUploadRequestBuilder) Post(ctx context.Context, body abstractions.MultipartBody, requestConfiguration *AttachmentUploadRequestBuilderPostRequestConfiguration) (*File, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(body) {
@@ -115,7 +115,7 @@ func (rB *AttachmentUploadRequestBuilder) Post(ctx context.Context, body abstrac
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *AttachmentUploadRequestBuilder) ToPostRequestInformation(ctx context.Context, body abstractions.MultipartBody, requestConfiguration *AttachmentUploadRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/attachmentapi/attachment_upload_request_builder_test.go
+++ b/attachmentapi/attachment_upload_request_builder_test.go
@@ -3,6 +3,7 @@ package attachmentapi
 import (
 	"context"
 	"errors"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -294,7 +295,7 @@ func TestAttachmentUploadRequestBuilder_ToPostRequestInformation(t *testing.T) {
 
 			if tt.isNilBuilder {
 				assert.Nil(t, info)
-				assert.Nil(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedMethod, info.Method)

--- a/batchapi/batch_request_builder.go
+++ b/batchapi/batch_request_builder.go
@@ -47,7 +47,7 @@ func NewBatchRequestBuilder(
 // Head sends an HTTP HEAD request and returns the response headers.
 func (rB *BatchRequestBuilder) Head(ctx context.Context, requestConfiguration *BatchRequestBuilderGetRequestConfiguration) (*abstractions.ResponseHeaders, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestConfiguration) {
@@ -75,7 +75,7 @@ func (rB *BatchRequestBuilder) Head(ctx context.Context, requestConfiguration *B
 // ToHeadRequestInformation converts provided parameters into request information
 func (rB *BatchRequestBuilder) ToHeadRequestInformation(_ context.Context, requestConfiguration *BatchRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.HEAD, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -91,7 +91,7 @@ func (rB *BatchRequestBuilder) ToHeadRequestInformation(_ context.Context, reque
 // Post produces a batch response using the specified parameters
 func (rB *BatchRequestBuilder) Post(ctx context.Context, body BatchRequest, requestConfiguration *BatchRequestBuilderPostRequestConfiguration) (*BatchResponseModel, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(body) {
@@ -125,7 +125,7 @@ func (rB *BatchRequestBuilder) Post(ctx context.Context, body BatchRequest, requ
 // toPostRequestInformation converts provided parameters into request information
 func (rB *BatchRequestBuilder) toPostRequestInformation(ctx context.Context, body BatchRequest, requestConfiguration *BatchRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/batchapi/batch_request_builder_test.go
+++ b/batchapi/batch_request_builder_test.go
@@ -380,7 +380,7 @@ func TestBatchRequestBuilder_Post(t *testing.T) {
 
 				requestInformation, err := builder.Post(context.Background(), request, nil)
 
-				assert.Nil(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, requestInformation)
 			},
 		},
@@ -393,7 +393,7 @@ func TestBatchRequestBuilder_Post(t *testing.T) {
 
 				requestInformation, err := builder.Post(context.Background(), request, nil)
 
-				assert.Nil(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, requestInformation)
 			},
 		},
@@ -623,7 +623,7 @@ func TestBatchRequestBuilder_toPostRequestInformation(t *testing.T) {
 
 				requestInformation, err := builder.toPostRequestInformation(context.Background(), request, nil)
 
-				assert.Nil(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, requestInformation)
 			},
 		},
@@ -636,7 +636,7 @@ func TestBatchRequestBuilder_toPostRequestInformation(t *testing.T) {
 
 				requestInformation, err := builder.toPostRequestInformation(context.Background(), request, nil)
 
-				assert.Nil(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, requestInformation)
 			},
 		},

--- a/caseapi/case_request_builder.go
+++ b/caseapi/case_request_builder.go
@@ -2,6 +2,7 @@ package caseapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -48,7 +49,7 @@ func (rB *CaseRequestBuilder) FieldValues(fieldName string) *CaseFieldValuesRequ
 // Get sends a GET request to search cases.
 func (rB *CaseRequestBuilder) Get(ctx context.Context, config *CaseRequestBuilderGetRequestConfiguration) (CaseCollectionResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
@@ -70,7 +71,7 @@ func (rB *CaseRequestBuilder) Get(ctx context.Context, config *CaseRequestBuilde
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *CaseRequestBuilder) ToGetRequestInformation(ctx context.Context, config *CaseRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
@@ -84,7 +85,7 @@ func (rB *CaseRequestBuilder) ToGetRequestInformation(ctx context.Context, confi
 // Post sends a POST request to create a case.
 func (rB *CaseRequestBuilder) Post(ctx context.Context, body CaseResult, config *CaseRequestBuilderPostRequestConfiguration) (CaseItemResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
 	if err != nil {
@@ -106,7 +107,7 @@ func (rB *CaseRequestBuilder) Post(ctx context.Context, body CaseResult, config 
 // ToPostRequestInformation creates a RequestInformation object for a POST request.
 func (rB *CaseRequestBuilder) ToPostRequestInformation(ctx context.Context, body CaseResult, config *CaseRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}

--- a/caseapi/sub_request_builders.go
+++ b/caseapi/sub_request_builders.go
@@ -2,6 +2,7 @@ package caseapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -50,7 +51,7 @@ func (rB *CaseItemRequestBuilder) FieldValues(fieldName string) *CaseFieldValues
 // Get sends a GET request to retrieve a single case.
 func (rB *CaseItemRequestBuilder) Get(ctx context.Context, config *CaseItemRequestBuilderGetRequestConfiguration) (CaseItemResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
@@ -72,7 +73,7 @@ func (rB *CaseItemRequestBuilder) Get(ctx context.Context, config *CaseItemReque
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *CaseItemRequestBuilder) ToGetRequestInformation(ctx context.Context, config *CaseItemRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
@@ -86,7 +87,7 @@ func (rB *CaseItemRequestBuilder) ToGetRequestInformation(ctx context.Context, c
 // Put sends a PUT request to update an existing case.
 func (rB *CaseItemRequestBuilder) Put(ctx context.Context, body CaseResult, config *CaseItemRequestBuilderPutRequestConfiguration) (CaseItemResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
 	if err != nil {
@@ -108,7 +109,7 @@ func (rB *CaseItemRequestBuilder) Put(ctx context.Context, body CaseResult, conf
 // ToPutRequestInformation creates a RequestInformation object for a PUT request.
 func (rB *CaseItemRequestBuilder) ToPutRequestInformation(ctx context.Context, body CaseResult, config *CaseItemRequestBuilderPutRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
@@ -138,7 +139,7 @@ func NewCaseActivitiesRequestBuilderInternal(pathParameters map[string]string, r
 // Get sends a GET request to retrieve case activities.
 func (rB *CaseActivitiesRequestBuilder) Get(ctx context.Context, config *CaseActivitiesRequestBuilderGetRequestConfiguration) (ActivitiesResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
@@ -160,7 +161,7 @@ func (rB *CaseActivitiesRequestBuilder) Get(ctx context.Context, config *CaseAct
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *CaseActivitiesRequestBuilder) ToGetRequestInformation(ctx context.Context, config *CaseActivitiesRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}
@@ -191,7 +192,7 @@ func NewItemFieldValuesRequestBuilderInternal(pathParameters map[string]string, 
 // Get sends a GET request to retrieve field values.
 func (rB *CaseFieldValuesRequestBuilder) Get(ctx context.Context, config *CaseFieldValuesRequestBuilderGetRequestConfiguration) (FieldValuesResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
@@ -213,7 +214,7 @@ func (rB *CaseFieldValuesRequestBuilder) Get(ctx context.Context, config *CaseFi
 // ToGetRequestInformation creates a RequestInformation object for a GET request.
 func (rB *CaseFieldValuesRequestBuilder) ToGetRequestInformation(ctx context.Context, config *CaseFieldValuesRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	kiotaRequestInfo := &internal.KiotaRequestInformation{RequestInformation: requestInfo}

--- a/cmdbinstanceapi/cmdb_class_request_builder.go
+++ b/cmdbinstanceapi/cmdb_class_request_builder.go
@@ -2,6 +2,7 @@ package cmdbinstanceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -32,7 +33,7 @@ func NewCmdbClassRequestBuilderInternal(pathParameters map[string]string, reques
 // Get queries records for a CMDB class.
 func (rB *CmdbClassRequestBuilder) Get(ctx context.Context, config *CmdbClassRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -56,7 +57,7 @@ func (rB *CmdbClassRequestBuilder) Get(ctx context.Context, config *CmdbClassReq
 // Post creates a record with associated relations.
 func (rB *CmdbClassRequestBuilder) Post(ctx context.Context, body CmdbInstance, config *CmdbClassRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)

--- a/cmdbinstanceapi/cmdb_item_request_builder.go
+++ b/cmdbinstanceapi/cmdb_item_request_builder.go
@@ -2,6 +2,7 @@ package cmdbinstanceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -33,7 +34,7 @@ func NewCmdbItemRequestBuilderInternal(pathParameters map[string]string, request
 // Get queries attributes and relationship information for a specific record.
 func (rB *CmdbItemRequestBuilder) Get(ctx context.Context, config *CmdbItemRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
@@ -57,7 +58,7 @@ func (rB *CmdbItemRequestBuilder) Get(ctx context.Context, config *CmdbItemReque
 // Put replaces a CI record.
 func (rB *CmdbItemRequestBuilder) Put(ctx context.Context, body CmdbInstance, config *CmdbItemRequestBuilderPutRequestConfiguration) (*core.BaseServiceNowItemResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
@@ -81,7 +82,7 @@ func (rB *CmdbItemRequestBuilder) Put(ctx context.Context, body CmdbInstance, co
 // Patch updates a CI record.
 func (rB *CmdbItemRequestBuilder) Patch(ctx context.Context, body CmdbInstance, config *CmdbItemRequestBuilderPatchRequestConfiguration) (*core.BaseServiceNowItemResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPatchRequestInformation(ctx, body, config)

--- a/cmdbinstanceapi/cmdb_relation_item_request_builder.go
+++ b/cmdbinstanceapi/cmdb_relation_item_request_builder.go
@@ -2,6 +2,7 @@ package cmdbinstanceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -28,7 +29,7 @@ func NewCmdbRelationItemRequestBuilderInternal(pathParameters map[string]string,
 // Delete deletes a specific Relation for the CI.
 func (rB *CmdbRelationItemRequestBuilder) Delete(ctx context.Context, config *CmdbRelationItemRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, config)

--- a/cmdbinstanceapi/cmdb_relation_request_builder.go
+++ b/cmdbinstanceapi/cmdb_relation_request_builder.go
@@ -2,6 +2,7 @@ package cmdbinstanceapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -33,7 +34,7 @@ func NewCmdbRelationRequestBuilderInternal(pathParameters map[string]string, req
 // Post creates a Relation for the CI.
 func (rB *CmdbRelationRequestBuilder) Post(ctx context.Context, body CmdbInstance, config *CmdbRelationRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)

--- a/core/base_request_builder.go
+++ b/core/base_request_builder.go
@@ -51,7 +51,7 @@ func (rB *BaseRequestBuilder) GetPathParameters() map[string]string {
 
 func (rB *BaseRequestBuilder) SetPathParameters(pathParameters map[string]string) error {
 	if conversion.IsNil(rB) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(pathParameters) {
@@ -72,7 +72,7 @@ func (rB *BaseRequestBuilder) GetRequestAdapter() abstractions.RequestAdapter {
 
 func (rB *BaseRequestBuilder) SetRequestAdapter(requestAdapter abstractions.RequestAdapter) error {
 	if conversion.IsNil(rB) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestAdapter) {
@@ -93,7 +93,7 @@ func (rB *BaseRequestBuilder) GetURLTemplate() string {
 
 func (rB *BaseRequestBuilder) SetURLTemplate(urlTemplate string) error {
 	if conversion.IsNil(rB) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	urlTemplate = strings.TrimSpace(urlTemplate)

--- a/core/base_request_builder_test.go
+++ b/core/base_request_builder_test.go
@@ -75,7 +75,7 @@ func TestBaseRequestBuilder_SetPathParameters(t *testing.T) {
 	}{
 		{"Ok", rb, params, nil},
 		{"NilParams", rb, nil, snerrors.ErrNilPathParameters},
-		{"NilRB", nilRB, params, nil},
+		{"NilRB", nilRB, params, snerrors.ErrNilRequestBuilder},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestBaseRequestBuilder_SetRequestAdapter(t *testing.T) {
 	}{
 		{"Ok", rb, ra, nil},
 		{"NilRA", rb, nil, snerrors.ErrNilRequestAdapter},
-		{"NilRB", nilRB, ra, nil},
+		{"NilRB", nilRB, ra, snerrors.ErrNilRequestBuilder},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestBaseRequestBuilder_SetURLTemplate(t *testing.T) {
 	}{
 		{"Ok", rb, "t", nil},
 		{"Empty", rb, "", errors.New("urlTemplate is empty")},
-		{"NilRB", nilRB, "t", nil},
+		{"NilRB", nilRB, "t", snerrors.ErrNilRequestBuilder},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/documentsapi/action_request_builder.go
+++ b/documentsapi/action_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -68,7 +69,7 @@ func NewVersionActionRequestBuilderInternal(pathParameters map[string]string, re
 // Patch executes the specified action on the document version.
 func (rB *VersionActionRequestBuilder) Patch(ctx context.Context, requestConfiguration *VersionActionRequestBuilderPatchRequestConfiguration) error {
 	if conversion.IsNil(rB) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToPatchRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/attach_request_builder.go
+++ b/documentsapi/attach_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewAttachRequestBuilderInternal(pathParameters map[string]string, requestAd
 // Post attaches a document using the specified provider.
 func (rB *AttachRequestBuilder) Post(ctx context.Context, requestConfiguration *AttachRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
@@ -35,7 +36,7 @@ func (rB *AttachRequestBuilder) Post(ctx context.Context, requestConfiguration *
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *AttachRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *AttachRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/content_request_builder.go
+++ b/documentsapi/content_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -29,7 +30,7 @@ func NewContentRequestBuilderInternal(pathParameters map[string]string, requestA
 // Get fetches and streams the default version attachment for the document.
 func (rB *ContentRequestBuilder) Get(ctx context.Context, requestConfiguration *ContentRequestBuilderGetRequestConfiguration) ([]byte, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/create_document_request_builder.go
+++ b/documentsapi/create_document_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewCreateDocumentRequestBuilderInternal(pathParameters map[string]string, r
 // Post creates or links a document from an attachment, DMS repo or cloud.
 func (rB *CreateDocumentRequestBuilder) Post(ctx context.Context, requestConfiguration *CreateDocumentRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
@@ -35,7 +36,7 @@ func (rB *CreateDocumentRequestBuilder) Post(ctx context.Context, requestConfigu
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *CreateDocumentRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *CreateDocumentRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/create_request_builder.go
+++ b/documentsapi/create_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewCreateRequestBuilderInternal(pathParameters map[string]string, requestAd
 // Post creates a new document.
 func (rB *CreateRequestBuilder) Post(ctx context.Context, requestConfiguration *CreateRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
@@ -35,7 +36,7 @@ func (rB *CreateRequestBuilder) Post(ctx context.Context, requestConfiguration *
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *CreateRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *CreateRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/delete_request_builder.go
+++ b/documentsapi/delete_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -29,7 +30,7 @@ func NewDeleteRequestBuilderInternal(pathParameters map[string]string, requestAd
 // Delete removes a document.
 func (rB *DeleteRequestBuilder) Delete(ctx context.Context, requestConfiguration *DeleteRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/document_get_request_builder.go
+++ b/documentsapi/document_get_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -36,7 +37,7 @@ func newDocumentGetRequestBuilder(requestAdapter abstractions.RequestAdapter, ur
 // get retrieves a Document.
 func (rB *documentGetRequestBuilder) get(ctx context.Context, requestConfiguration *documentGetRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.toGetRequestInformation(ctx, requestConfiguration)
@@ -60,7 +61,7 @@ func (rB *documentGetRequestBuilder) get(ctx context.Context, requestConfigurati
 // toGetRequestInformation converts request configurations to Get request information.
 func (rB *documentGetRequestBuilder) toGetRequestInformation(_ context.Context, requestConfiguration *documentGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/documentsapi/document_get_request_builder_test.go
+++ b/documentsapi/document_get_request_builder_test.go
@@ -3,6 +3,7 @@ package documentsapi
 import (
 	"context"
 	"errors"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -60,7 +61,7 @@ func TestDocumentGetRequestBuilder_Get(t *testing.T) {
 			resp, err := builder.get(context.Background(), &documentGetRequestConfiguration{})
 
 			if tt.nilBuilder {
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, resp)
 				return
 			}
@@ -137,7 +138,7 @@ func TestDocumentGetRequestBuilder_ToGetRequestInformation(t *testing.T) {
 	t.Run("Nil builder", func(t *testing.T) {
 		var builder *documentGetRequestBuilder
 		reqInfo, err := builder.toGetRequestInformation(context.Background(), nil)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 		assert.Nil(t, reqInfo)
 	})
 }

--- a/documentsapi/document_post_request_builder.go
+++ b/documentsapi/document_post_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -36,7 +37,7 @@ func newDocumentPostRequestBuilder(requestAdapter abstractions.RequestAdapter, u
 // post sends a POST request to create or link a document.
 func (rB *documentPostRequestBuilder) post(ctx context.Context, requestConfiguration *documentPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.toPostRequestInformation(ctx, requestConfiguration)
@@ -60,7 +61,7 @@ func (rB *documentPostRequestBuilder) post(ctx context.Context, requestConfigura
 // toPostRequestInformation converts request configurations to Post request information.
 func (rB *documentPostRequestBuilder) toPostRequestInformation(ctx context.Context, requestConfiguration *documentPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/documentsapi/document_post_request_builder_test.go
+++ b/documentsapi/document_post_request_builder_test.go
@@ -3,6 +3,7 @@ package documentsapi
 import (
 	"context"
 	"errors"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -60,7 +61,7 @@ func TestDocumentPostRequestBuilder_Post(t *testing.T) {
 			resp, err := builder.post(context.Background(), &documentPostRequestConfiguration{})
 
 			if tt.nilBuilder {
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, resp)
 				return
 			}
@@ -158,7 +159,7 @@ func TestDocumentPostRequestBuilder_ToPostRequestInformation(t *testing.T) {
 	t.Run("Nil builder", func(t *testing.T) {
 		var builder *documentPostRequestBuilder
 		reqInfo, err := builder.toPostRequestInformation(context.Background(), nil)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 		assert.Nil(t, reqInfo)
 	})
 }

--- a/documentsapi/explore_request_builder.go
+++ b/documentsapi/explore_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -29,7 +30,7 @@ func NewExploreRequestBuilderInternal(pathParameters map[string]string, requestA
 // Get retrieves folder and document metadata with filters, sorting, and pagination.
 func (rB *ExploreRequestBuilder) Get(ctx context.Context, requestConfiguration *ExploreRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/sync_down_request_builder.go
+++ b/documentsapi/sync_down_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewSyncDownRequestBuilderInternal(pathParameters map[string]string, request
 // Post synchronizes the specified document.
 func (rB *SyncDownRequestBuilder) Post(ctx context.Context, requestConfiguration *SyncDownRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.post(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }
@@ -35,7 +36,7 @@ func (rB *SyncDownRequestBuilder) Post(ctx context.Context, requestConfiguration
 // ToPostRequestInformation converts request configurations to Post request information.
 func (rB *SyncDownRequestBuilder) ToPostRequestInformation(ctx context.Context, requestConfiguration *SyncDownRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.toPostRequestInformation(ctx, (*documentPostRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/version_state_request_builder.go
+++ b/documentsapi/version_state_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
@@ -27,7 +28,7 @@ func NewVersionStateRequestBuilderInternal(pathParameters map[string]string, req
 // Get retrieves the state of the specified document version.
 func (rB *VersionStateRequestBuilder) Get(ctx context.Context, requestConfiguration *VersionStateRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.get(ctx, (*documentGetRequestConfiguration)(requestConfiguration))
 }
@@ -35,7 +36,7 @@ func (rB *VersionStateRequestBuilder) Get(ctx context.Context, requestConfigurat
 // ToGetRequestInformation converts request configurations to Get request information.
 func (rB *VersionStateRequestBuilder) ToGetRequestInformation(ctx context.Context, requestConfiguration *VersionStateRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 	return rB.toGetRequestInformation(ctx, (*documentGetRequestConfiguration)(requestConfiguration))
 }

--- a/documentsapi/versions_request_builder.go
+++ b/documentsapi/versions_request_builder.go
@@ -2,6 +2,7 @@ package documentsapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
@@ -29,7 +30,7 @@ func NewVersionsRequestBuilderInternal(pathParameters map[string]string, request
 // Get retrieves the versions of the specified document.
 func (rB *VersionsRequestBuilder) Get(ctx context.Context, requestConfiguration *VersionsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[Document], error) {
 	if conversion.IsNil(rB) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -5,6 +5,7 @@ import "errors"
 // Standard sentinel errors for consistent error handling.
 var (
 	ErrNilRequestAdapter       = errors.New("requestAdapter cannot be nil")
+	ErrNilRequestBuilder       = errors.New("request builder is nil")
 	ErrNilResponse             = errors.New("response cannot be nil")
 	ErrNilContext              = errors.New("context cannot be nil")
 	ErrNilConfig               = errors.New("config is nil")

--- a/policyapi/policies_mappings_request_builder.go
+++ b/policyapi/policies_mappings_request_builder.go
@@ -42,7 +42,7 @@ func (rB *PoliciesMappingsRequestBuilder) Inputs() *PoliciesMappingsInputsReques
 
 func (rB *PoliciesMappingsRequestBuilder) Delete(ctx context.Context, requestConfiguration *PoliciesMappingsRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestConfiguration) {
@@ -81,7 +81,7 @@ func (rB *PoliciesMappingsRequestBuilder) Delete(ctx context.Context, requestCon
 
 func (rB *PoliciesMappingsRequestBuilder) Post(ctx context.Context, requestConfiguration *PoliciesMappingsRequestBuilderPostRequestConfiguration) (core.ServiceNowItemResponse[*PoliciesMapping], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(requestConfiguration) {
@@ -134,7 +134,7 @@ func (rB *PoliciesMappingsRequestBuilder) Post(ctx context.Context, requestConfi
 
 func (rB *PoliciesMappingsRequestBuilder) ToPostRequestInformation(_ context.Context, requestConfiguration *PoliciesMappingsRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -148,7 +148,7 @@ func (rB *PoliciesMappingsRequestBuilder) ToPostRequestInformation(_ context.Con
 
 func (rB *PoliciesMappingsRequestBuilder) ToDeleteRequestInformation(_ context.Context, requestConfiguration *PoliciesMappingsRequestBuilderDeleteRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/policyapi/policies_mappings_request_builder_test.go
+++ b/policyapi/policies_mappings_request_builder_test.go
@@ -2,6 +2,7 @@ package policyapi
 
 import (
 	"context"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -99,9 +100,10 @@ func TestPoliciesMappingsRequestBuilder_Delete(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "Nil_RequestBuilder",
-			nilRB:   true,
-			wantErr: false,
+			name:       "Nil_RequestBuilder",
+			nilRB:      true,
+			wantErr:    true,
+			errMessage: "request builder is nil",
 		},
 		{
 			name:           "Nil_Configuration",
@@ -210,7 +212,7 @@ func TestPoliciesMappingsRequestBuilder_ToDeleteRequestInformation(t *testing.T)
 
 			if tt.nilRB {
 				assert.Nil(t, requestInfo)
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 			} else {
 				assert.NotNil(t, requestInfo)
 				assert.NoError(t, err)
@@ -247,9 +249,10 @@ func TestPoliciesMappingsRequestBuilder_Post(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "Nil_RequestBuilder",
-			nilRB:   true,
-			wantErr: false,
+			name:       "Nil_RequestBuilder",
+			nilRB:      true,
+			wantErr:    true,
+			errMessage: "request builder is nil",
 		},
 		{
 			name:           "Nil_Configuration",
@@ -362,7 +365,7 @@ func TestPoliciesMappingsRequestBuilder_ToPostRequestInformation(t *testing.T) {
 
 			if tt.nilRB {
 				assert.Nil(t, requestInfo)
-				assert.NoError(t, err)
+				assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 			} else {
 				assert.NotNil(t, requestInfo)
 				assert.NoError(t, err)

--- a/statsapi/stats_request_builder.go
+++ b/statsapi/stats_request_builder.go
@@ -50,7 +50,7 @@ func NewStatsRequestBuilder(
 // Get sends an HTTP GET request and returns the aggregate statistics for the table.
 func (rB *StatsRequestBuilder) Get(ctx context.Context, requestConfiguration *StatsRequestBuilderGetRequestConfiguration) (core.ServiceNowItemResponse[*StatsResultModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -87,7 +87,7 @@ func (rB *StatsRequestBuilder) Get(ctx context.Context, requestConfiguration *St
 // ToGetRequestInformation converts provided parameters into request information
 func (rB *StatsRequestBuilder) ToGetRequestInformation(_ context.Context, requestConfiguration *StatsRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/statsapi/stats_request_builder_test.go
+++ b/statsapi/stats_request_builder_test.go
@@ -32,7 +32,7 @@ func TestStatsRequestBuilder_Get(t *testing.T) {
 			name:      "nil builder",
 			builder:   nil,
 			setupMock: func(m *mocking.MockRequestAdapter) {},
-			err:       nil,
+			err:       snerrors.ErrNilRequestBuilder,
 		},
 		{
 			name:      "nil request adapter",
@@ -107,6 +107,6 @@ func TestStatsRequestBuilder_ToGetRequestInformation_NilBuilder(t *testing.T) {
 
 	requestInfo, err := builder.ToGetRequestInformation(context.Background(), nil)
 
-	require.NoError(t, err)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 	assert.Nil(t, requestInfo)
 }

--- a/tableapi/table_item_request_builder.go
+++ b/tableapi/table_item_request_builder.go
@@ -66,7 +66,7 @@ func NewTableItemRequestBuilder[T model.ServiceNowItem](
 // Get sends an HTTP GET request and returns the single table record.
 func (rB *TableItemRequestBuilder[T]) Get(ctx context.Context, requestConfiguration *TableItemRequestBuilderGetRequestConfiguration) (core.ServiceNowItemResponse[T], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -99,7 +99,7 @@ func (rB *TableItemRequestBuilder[T]) Get(ctx context.Context, requestConfigurat
 // Delete sends an HTTP DELETE request to remove the single table record.
 func (rB *TableItemRequestBuilder[T]) Delete(ctx context.Context, requestConfiguration *TableItemRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil
+		return snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -118,7 +118,7 @@ func (rB *TableItemRequestBuilder[T]) Delete(ctx context.Context, requestConfigu
 // Put updates a table item using an HTTP PUT request, replacing the entire record.
 func (rB *TableItemRequestBuilder[T]) Put(ctx context.Context, body T, requestConfiguration *TableItemRequestBuilderPutRequestConfiguration) (core.ServiceNowItemResponse[T], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -155,7 +155,7 @@ func (rB *TableItemRequestBuilder[T]) Put(ctx context.Context, body T, requestCo
 // Patch updates a table item using an HTTP PATCH request, applying partial updates.
 func (rB *TableItemRequestBuilder[T]) Patch(ctx context.Context, body T, requestConfiguration *TableItemRequestBuilderPatchRequestConfiguration) (core.ServiceNowItemResponse[T], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -192,7 +192,7 @@ func (rB *TableItemRequestBuilder[T]) Patch(ctx context.Context, body T, request
 // ToGetRequestInformation converts provided parameters into request information
 func (rB *TableItemRequestBuilder[T]) ToGetRequestInformation(_ context.Context, requestConfiguration *TableItemRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -208,7 +208,7 @@ func (rB *TableItemRequestBuilder[T]) ToGetRequestInformation(_ context.Context,
 // ToDeleteRequestInformation converts provided parameters into request information
 func (rB *TableItemRequestBuilder[T]) ToDeleteRequestInformation(_ context.Context, requestConfiguration *TableItemRequestBuilderDeleteRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -224,7 +224,7 @@ func (rB *TableItemRequestBuilder[T]) ToDeleteRequestInformation(_ context.Conte
 // ToPutRequestInformation converts provided parameters into request information
 func (rB *TableItemRequestBuilder[T]) ToPutRequestInformation(ctx context.Context, body T, requestConfiguration *TableItemRequestBuilderPutRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -246,7 +246,7 @@ func (rB *TableItemRequestBuilder[T]) ToPutRequestInformation(ctx context.Contex
 // ToPatchRequestInformation converts provided parameters into request information
 func (rB *TableItemRequestBuilder[T]) ToPatchRequestInformation(ctx context.Context, body T, requestConfiguration *TableItemRequestBuilderPatchRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PATCH, rB.GetURLTemplate(), rB.GetPathParameters())

--- a/tableapi/table_request_builder.go
+++ b/tableapi/table_request_builder.go
@@ -73,7 +73,7 @@ func NewTableRequestBuilder[T model.ServiceNowItem](
 // Get sends an HTTP GET request and returns a collection of table records.
 func (rB *TableRequestBuilder[T]) Get(ctx context.Context, requestConfiguration *TableRequestBuilderGetRequestConfiguration) (core.ServiceNowCollectionResponse[T], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -117,7 +117,7 @@ func (rB *TableRequestBuilder[T]) Get(ctx context.Context, requestConfiguration 
 // Post sends an HTTP POST request to create a new table record and returns the created record.
 func (rB *TableRequestBuilder[T]) Post(ctx context.Context, body T, requestConfiguration *TableRequestBuilderPostRequestConfiguration) (core.ServiceNowItemResponse[T], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -161,7 +161,7 @@ func (rB *TableRequestBuilder[T]) ByID(sysId string) *TableItemRequestBuilder[T]
 // Head sends an HTTP HEAD request and returns the response headers.
 func (rB *TableRequestBuilder[T]) Head(ctx context.Context, requestConfiguration *TableRequestBuilderGetRequestConfiguration) (*abstractions.ResponseHeaders, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	if conversion.IsNil(rB.GetRequestAdapter()) {
@@ -192,7 +192,7 @@ func (rB *TableRequestBuilder[T]) Head(ctx context.Context, requestConfiguration
 // ToGetRequestInformation converts provided parameters into request information
 func (rB *TableRequestBuilder[T]) ToGetRequestInformation(_ context.Context, requestConfiguration *TableRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -208,7 +208,7 @@ func (rB *TableRequestBuilder[T]) ToGetRequestInformation(_ context.Context, req
 // ToPostRequestInformation converts provided parameters into request information
 func (rB *TableRequestBuilder[T]) ToPostRequestInformation(ctx context.Context, body T, requestConfiguration *TableRequestBuilderPostRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
@@ -230,7 +230,7 @@ func (rB *TableRequestBuilder[T]) ToPostRequestInformation(ctx context.Context, 
 // ToHeadRequestInformation converts provided parameters into request information
 func (rB *TableRequestBuilder[T]) ToHeadRequestInformation(_ context.Context, requestConfiguration *TableRequestBuilderGetRequestConfiguration) (*abstractions.RequestInformation, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
-		return nil, nil
+		return nil, snerrors.ErrNilRequestBuilder
 	}
 
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.HEAD, rB.GetURLTemplate(), rB.GetPathParameters())


### PR DESCRIPTION
## Summary
- Every request-builder verb method guarded a nil receiver with `return nil, nil` — no result **and no error** — so a caller holding a nil builder saw silent success and crashed later, far from the actual mistake. `Delete`/`Patch` variants returning only `error` swallowed the condition entirely with `return nil`.
- Adds `snerrors.ErrNilRequestBuilder` and converts all nil-receiver guards (49 source files: every `*api` package, `core.BaseRequestBuilder` setters, and the generic `appserviceapi` post builder's `return zero, nil`) to return it.
- Tests now assert the sentinel via `errors.Is`, locking the contract for consumers (the start of issue 005's sentinel-identity test coverage).
- Updates the documented pattern in CLAUDE.md, the `new-api-module` skill, and the `api-module-consistency-reviewer` agent so new modules follow the corrected shape.
- Deliberately unchanged: navigation methods returning a bare `*Builder` (single non-error return), post-`Send` `res == nil` no-content semantics, and `ElementValue`/`element_visitor` null-element semantics.

**Breaking change** — intentionally landed inside the v2 window (this contract can't change again until v3). Fixes issue 004 (and part of 005) in `release-2.0-issues/`.

## Test plan
- `go test ./...` — full suite passes (updated nil-builder cases in actsubapi, appserviceapi, attachmentapi, batchapi, core, documentsapi, policyapi, statsapi).
- `SN_OFFLINE=true go test -tags integration ./tests/integration/...` — passes.
- `go test -tags preview.query ./internal/` — passes.
- `golangci-lint run ./...` — 0 issues.