### PR TITLE
fix(appointmentbookingapi): export model setters so request bodies can be built

### DIFF
--- a/appointmentbookingapi/appointment_booking_request_builder_test.go
+++ b/appointmentbookingapi/appointment_booking_request_builder_test.go
@@ -77,7 +77,7 @@ func TestExecuteRuleConditionsRequestBuilder_Post(t *testing.T) {
 	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
 	builder := NewExecuteRuleConditionsRequestBuilder(map[string]string{"baseurl": "https://example.com"}, adapter)
 
-	mockRes := core.NewBaseServiceNowItemResponse[*ExecuteRuleConditionsResultModel](CreateExecuteRuleConditionsResultFromDiscriminatorValue)
+	mockRes := core.NewBaseServiceNowItemResponse[*ExecuteRuleConditionsResult](CreateExecuteRuleConditionsResultFromDiscriminatorValue)
 	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockRes, nil)
 
 	resp, err := builder.Post(context.Background(), NewExecuteRuleConditionsRequest(), nil)

--- a/appointmentbookingapi/appointment_request.go
+++ b/appointmentbookingapi/appointment_request.go
@@ -15,31 +15,31 @@ type AppointmentRequest interface {
 	kiotaStore.BackedModel
 
 	GetActualEndDate() (*string, error)
-	setActualEndDate(*string) error
+	SetActualEndDate(*string) error
 	GetActualStartDate() (*string, error)
-	setActualStartDate(*string) error
+	SetActualStartDate(*string) error
 	GetCatalogId() (*string, error)
-	setCatalogId(*string) error
+	SetCatalogId(*string) error
 	GetEndDateUTC() (*string, error)
-	setEndDateUTC(*string) error
+	SetEndDateUTC(*string) error
 	GetLocation() (*string, error)
-	setLocation(*string) error
+	SetLocation(*string) error
 	GetOpenedFor() (*string, error)
-	setOpenedFor(*string) error
+	SetOpenedFor(*string) error
 	GetReschedule() (*bool, error)
-	setReschedule(*bool) error
+	SetReschedule(*bool) error
 	GetServiceConfigRule() (*string, error)
-	setServiceConfigRule(*string) error
+	SetServiceConfigRule(*string) error
 	GetStartDateUTC() (*string, error)
-	setStartDateUTC(*string) error
+	SetStartDateUTC(*string) error
 	GetTaskId() (*string, error)
-	setTaskId(*string) error
+	SetTaskId(*string) error
 	GetTaskTable() (*string, error)
-	setTaskTable(*string) error
+	SetTaskTable(*string) error
 	GetTimezone() (*string, error)
-	setTimezone(*string) error
+	SetTimezone(*string) error
 	GetValidateRequest() (*bool, error)
-	setValidateRequest(*bool) error
+	SetValidateRequest(*bool) error
 }
 
 type AppointmentRequestModel struct {
@@ -77,97 +77,97 @@ func (m *AppointmentRequestModel) Serialize(writer serialization.SerializationWr
 
 func (m *AppointmentRequestModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		actualEndDateKey:     internalSerialization.DeserializeStringFunc(m.setActualEndDate),
-		actualStartDateKey:   internalSerialization.DeserializeStringFunc(m.setActualStartDate),
-		catalogIDKey:         internalSerialization.DeserializeStringFunc(m.setCatalogId),
-		endDateUTCKey:        internalSerialization.DeserializeStringFunc(m.setEndDateUTC),
-		locationKey:          internalSerialization.DeserializeStringFunc(m.setLocation),
-		openedForKey:         internalSerialization.DeserializeStringFunc(m.setOpenedFor),
-		rescheduleKey:        internalSerialization.DeserializeBoolFunc(m.setReschedule),
-		serviceConfigRuleKey: internalSerialization.DeserializeStringFunc(m.setServiceConfigRule),
-		startDateUTCKey:      internalSerialization.DeserializeStringFunc(m.setStartDateUTC),
-		taskIDKey:            internalSerialization.DeserializeStringFunc(m.setTaskId),
-		taskTableKey:         internalSerialization.DeserializeStringFunc(m.setTaskTable),
-		timezoneKey:          internalSerialization.DeserializeStringFunc(m.setTimezone),
-		validateRequestKey:   internalSerialization.DeserializeBoolFunc(m.setValidateRequest),
+		actualEndDateKey:     internalSerialization.DeserializeStringFunc(m.SetActualEndDate),
+		actualStartDateKey:   internalSerialization.DeserializeStringFunc(m.SetActualStartDate),
+		catalogIDKey:         internalSerialization.DeserializeStringFunc(m.SetCatalogId),
+		endDateUTCKey:        internalSerialization.DeserializeStringFunc(m.SetEndDateUTC),
+		locationKey:          internalSerialization.DeserializeStringFunc(m.SetLocation),
+		openedForKey:         internalSerialization.DeserializeStringFunc(m.SetOpenedFor),
+		rescheduleKey:        internalSerialization.DeserializeBoolFunc(m.SetReschedule),
+		serviceConfigRuleKey: internalSerialization.DeserializeStringFunc(m.SetServiceConfigRule),
+		startDateUTCKey:      internalSerialization.DeserializeStringFunc(m.SetStartDateUTC),
+		taskIDKey:            internalSerialization.DeserializeStringFunc(m.SetTaskId),
+		taskTableKey:         internalSerialization.DeserializeStringFunc(m.SetTaskTable),
+		timezoneKey:          internalSerialization.DeserializeStringFunc(m.SetTimezone),
+		validateRequestKey:   internalSerialization.DeserializeBoolFunc(m.SetValidateRequest),
 	}
 }
 
 func (m *AppointmentRequestModel) GetActualEndDate() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, actualEndDateKey)
 }
-func (m *AppointmentRequestModel) setActualEndDate(val *string) error {
+func (m *AppointmentRequestModel) SetActualEndDate(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, actualEndDateKey, val)
 }
 func (m *AppointmentRequestModel) GetActualStartDate() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, actualStartDateKey)
 }
-func (m *AppointmentRequestModel) setActualStartDate(val *string) error {
+func (m *AppointmentRequestModel) SetActualStartDate(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, actualStartDateKey, val)
 }
 func (m *AppointmentRequestModel) GetCatalogId() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, catalogIDKey)
 }
-func (m *AppointmentRequestModel) setCatalogId(val *string) error {
+func (m *AppointmentRequestModel) SetCatalogId(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, catalogIDKey, val)
 }
 func (m *AppointmentRequestModel) GetEndDateUTC() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, endDateUTCKey)
 }
-func (m *AppointmentRequestModel) setEndDateUTC(val *string) error {
+func (m *AppointmentRequestModel) SetEndDateUTC(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, endDateUTCKey, val)
 }
 func (m *AppointmentRequestModel) GetLocation() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, locationKey)
 }
-func (m *AppointmentRequestModel) setLocation(val *string) error {
+func (m *AppointmentRequestModel) SetLocation(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, locationKey, val)
 }
 func (m *AppointmentRequestModel) GetOpenedFor() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, openedForKey)
 }
-func (m *AppointmentRequestModel) setOpenedFor(val *string) error {
+func (m *AppointmentRequestModel) SetOpenedFor(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, openedForKey, val)
 }
 func (m *AppointmentRequestModel) GetReschedule() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *bool](m, rescheduleKey)
 }
-func (m *AppointmentRequestModel) setReschedule(val *bool) error {
+func (m *AppointmentRequestModel) SetReschedule(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, rescheduleKey, val)
 }
 func (m *AppointmentRequestModel) GetServiceConfigRule() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, serviceConfigRuleKey)
 }
-func (m *AppointmentRequestModel) setServiceConfigRule(val *string) error {
+func (m *AppointmentRequestModel) SetServiceConfigRule(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, serviceConfigRuleKey, val)
 }
 func (m *AppointmentRequestModel) GetStartDateUTC() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, startDateUTCKey)
 }
-func (m *AppointmentRequestModel) setStartDateUTC(val *string) error {
+func (m *AppointmentRequestModel) SetStartDateUTC(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, startDateUTCKey, val)
 }
 func (m *AppointmentRequestModel) GetTaskId() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, taskIDKey)
 }
-func (m *AppointmentRequestModel) setTaskId(val *string) error {
+func (m *AppointmentRequestModel) SetTaskId(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, taskIDKey, val)
 }
 func (m *AppointmentRequestModel) GetTaskTable() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, taskTableKey)
 }
-func (m *AppointmentRequestModel) setTaskTable(val *string) error {
+func (m *AppointmentRequestModel) SetTaskTable(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, taskTableKey, val)
 }
 func (m *AppointmentRequestModel) GetTimezone() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *string](m, timezoneKey)
 }
-func (m *AppointmentRequestModel) setTimezone(val *string) error {
+func (m *AppointmentRequestModel) SetTimezone(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, timezoneKey, val)
 }
 func (m *AppointmentRequestModel) GetValidateRequest() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentRequestModel, *bool](m, validateRequestKey)
 }
-func (m *AppointmentRequestModel) setValidateRequest(val *bool) error {
+func (m *AppointmentRequestModel) SetValidateRequest(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, validateRequestKey, val)
 }

--- a/appointmentbookingapi/appointment_request_test.go
+++ b/appointmentbookingapi/appointment_request_test.go
@@ -16,19 +16,19 @@ func TestAppointmentRequestModel_GettersSetters(t *testing.T) {
 		getter func() (interface{}, error)
 		value  interface{}
 	}{
-		{"ActualEndDate", func(v interface{}) error { return model.setActualEndDate(v.(*string)) }, func() (interface{}, error) { return model.GetActualEndDate() }, internal.ToPointer("val")},
-		{"ActualStartDate", func(v interface{}) error { return model.setActualStartDate(v.(*string)) }, func() (interface{}, error) { return model.GetActualStartDate() }, internal.ToPointer("val")},
-		{"CatalogId", func(v interface{}) error { return model.setCatalogId(v.(*string)) }, func() (interface{}, error) { return model.GetCatalogId() }, internal.ToPointer("val")},
-		{"EndDateUTC", func(v interface{}) error { return model.setEndDateUTC(v.(*string)) }, func() (interface{}, error) { return model.GetEndDateUTC() }, internal.ToPointer("val")},
-		{"Location", func(v interface{}) error { return model.setLocation(v.(*string)) }, func() (interface{}, error) { return model.GetLocation() }, internal.ToPointer("val")},
-		{"OpenedFor", func(v interface{}) error { return model.setOpenedFor(v.(*string)) }, func() (interface{}, error) { return model.GetOpenedFor() }, internal.ToPointer("val")},
-		{"Reschedule", func(v interface{}) error { return model.setReschedule(v.(*bool)) }, func() (interface{}, error) { return model.GetReschedule() }, internal.ToPointer(true)},
-		{"ServiceConfigRule", func(v interface{}) error { return model.setServiceConfigRule(v.(*string)) }, func() (interface{}, error) { return model.GetServiceConfigRule() }, internal.ToPointer("val")},
-		{"StartDateUTC", func(v interface{}) error { return model.setStartDateUTC(v.(*string)) }, func() (interface{}, error) { return model.GetStartDateUTC() }, internal.ToPointer("val")},
-		{"TaskId", func(v interface{}) error { return model.setTaskId(v.(*string)) }, func() (interface{}, error) { return model.GetTaskId() }, internal.ToPointer("val")},
-		{"TaskTable", func(v interface{}) error { return model.setTaskTable(v.(*string)) }, func() (interface{}, error) { return model.GetTaskTable() }, internal.ToPointer("val")},
-		{"Timezone", func(v interface{}) error { return model.setTimezone(v.(*string)) }, func() (interface{}, error) { return model.GetTimezone() }, internal.ToPointer("val")},
-		{"ValidateRequest", func(v interface{}) error { return model.setValidateRequest(v.(*bool)) }, func() (interface{}, error) { return model.GetValidateRequest() }, internal.ToPointer(true)},
+		{"ActualEndDate", func(v interface{}) error { return model.SetActualEndDate(v.(*string)) }, func() (interface{}, error) { return model.GetActualEndDate() }, internal.ToPointer("val")},
+		{"ActualStartDate", func(v interface{}) error { return model.SetActualStartDate(v.(*string)) }, func() (interface{}, error) { return model.GetActualStartDate() }, internal.ToPointer("val")},
+		{"CatalogId", func(v interface{}) error { return model.SetCatalogId(v.(*string)) }, func() (interface{}, error) { return model.GetCatalogId() }, internal.ToPointer("val")},
+		{"EndDateUTC", func(v interface{}) error { return model.SetEndDateUTC(v.(*string)) }, func() (interface{}, error) { return model.GetEndDateUTC() }, internal.ToPointer("val")},
+		{"Location", func(v interface{}) error { return model.SetLocation(v.(*string)) }, func() (interface{}, error) { return model.GetLocation() }, internal.ToPointer("val")},
+		{"OpenedFor", func(v interface{}) error { return model.SetOpenedFor(v.(*string)) }, func() (interface{}, error) { return model.GetOpenedFor() }, internal.ToPointer("val")},
+		{"Reschedule", func(v interface{}) error { return model.SetReschedule(v.(*bool)) }, func() (interface{}, error) { return model.GetReschedule() }, internal.ToPointer(true)},
+		{"ServiceConfigRule", func(v interface{}) error { return model.SetServiceConfigRule(v.(*string)) }, func() (interface{}, error) { return model.GetServiceConfigRule() }, internal.ToPointer("val")},
+		{"StartDateUTC", func(v interface{}) error { return model.SetStartDateUTC(v.(*string)) }, func() (interface{}, error) { return model.GetStartDateUTC() }, internal.ToPointer("val")},
+		{"TaskId", func(v interface{}) error { return model.SetTaskId(v.(*string)) }, func() (interface{}, error) { return model.GetTaskId() }, internal.ToPointer("val")},
+		{"TaskTable", func(v interface{}) error { return model.SetTaskTable(v.(*string)) }, func() (interface{}, error) { return model.GetTaskTable() }, internal.ToPointer("val")},
+		{"Timezone", func(v interface{}) error { return model.SetTimezone(v.(*string)) }, func() (interface{}, error) { return model.GetTimezone() }, internal.ToPointer("val")},
+		{"ValidateRequest", func(v interface{}) error { return model.SetValidateRequest(v.(*bool)) }, func() (interface{}, error) { return model.GetValidateRequest() }, internal.ToPointer(true)},
 	}
 
 	for _, tt := range tests {

--- a/appointmentbookingapi/appointment_response.go
+++ b/appointmentbookingapi/appointment_response.go
@@ -24,13 +24,13 @@ type AppointmentResult interface {
 	kiotaStore.BackedModel
 
 	GetData() (*string, error)
-	setData(*string) error
+	SetData(*string) error
 	GetMessage() (*string, error)
-	setMessage(*string) error
+	SetMessage(*string) error
 	GetReason() (*string, error)
-	setReason(*string) error
+	SetReason(*string) error
 	GetSuccess() (*bool, error)
-	setSuccess(*bool) error
+	SetSuccess(*bool) error
 }
 
 type AppointmentResultModel struct {
@@ -59,34 +59,34 @@ func (m *AppointmentResultModel) Serialize(writer serialization.SerializationWri
 
 func (m *AppointmentResultModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		dataKey:    internalSerialization.DeserializeStringFunc(m.setData),
-		messageKey: internalSerialization.DeserializeStringFunc(m.setMessage),
-		reasonKey:  internalSerialization.DeserializeStringFunc(m.setReason),
-		successKey: internalSerialization.DeserializeBoolFunc(m.setSuccess),
+		dataKey:    internalSerialization.DeserializeStringFunc(m.SetData),
+		messageKey: internalSerialization.DeserializeStringFunc(m.SetMessage),
+		reasonKey:  internalSerialization.DeserializeStringFunc(m.SetReason),
+		successKey: internalSerialization.DeserializeBoolFunc(m.SetSuccess),
 	}
 }
 
 func (m *AppointmentResultModel) GetData() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentResultModel, *string](m, dataKey)
 }
-func (m *AppointmentResultModel) setData(val *string) error {
+func (m *AppointmentResultModel) SetData(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, dataKey, val)
 }
 func (m *AppointmentResultModel) GetMessage() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentResultModel, *string](m, messageKey)
 }
-func (m *AppointmentResultModel) setMessage(val *string) error {
+func (m *AppointmentResultModel) SetMessage(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, messageKey, val)
 }
 func (m *AppointmentResultModel) GetReason() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentResultModel, *string](m, reasonKey)
 }
-func (m *AppointmentResultModel) setReason(val *string) error {
+func (m *AppointmentResultModel) SetReason(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, reasonKey, val)
 }
 func (m *AppointmentResultModel) GetSuccess() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AppointmentResultModel, *bool](m, successKey)
 }
-func (m *AppointmentResultModel) setSuccess(val *bool) error {
+func (m *AppointmentResultModel) SetSuccess(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, successKey, val)
 }

--- a/appointmentbookingapi/availability_request.go
+++ b/appointmentbookingapi/availability_request.go
@@ -15,35 +15,35 @@ type AvailabilityRequest interface {
 	kiotaStore.BackedModel
 
 	GetCatalogId() (*string, error)
-	setCatalogId(*string) error
+	SetCatalogId(*string) error
 	GetEndDate() (*string, error)
-	setEndDate(*string) error
+	SetEndDate(*string) error
 	GetFetchDaysSlot() (*bool, error)
-	setFetchDaysSlot(*bool) error
+	SetFetchDaysSlot(*bool) error
 	GetFullDay() (*bool, error)
-	setFullDay(*bool) error
+	SetFullDay(*bool) error
 	GetGetNextAvailableSlot() (*bool, error)
-	setGetNextAvailableSlot(*bool) error
+	SetGetNextAvailableSlot(*bool) error
 	GetLimit() (*int32, error)
-	setLimit(*int32) error
+	SetLimit(*int32) error
 	GetLocation() (*string, error)
-	setLocation(*string) error
+	SetLocation(*string) error
 	GetOpenedFor() (*string, error)
-	setOpenedFor(*string) error
+	SetOpenedFor(*string) error
 	GetOtherInputs() (any, error)
-	setOtherInputs(any) error
+	SetOtherInputs(any) error
 	GetServiceConfigRule() (*string, error)
-	setServiceConfigRule(*string) error
+	SetServiceConfigRule(*string) error
 	GetStartDate() (*string, error)
-	setStartDate(*string) error
+	SetStartDate(*string) error
 	GetTaskId() (*string, error)
-	setTaskId(*string) error
+	SetTaskId(*string) error
 	GetTaskTable() (*string, error)
-	setTaskTable(*string) error
+	SetTaskTable(*string) error
 	GetUseReadReplica() (*bool, error)
-	setUseReadReplica(*bool) error
+	SetUseReadReplica(*bool) error
 	GetView() (*string, error)
-	setView(*string) error
+	SetView(*string) error
 }
 
 type AvailabilityRequestModel struct {
@@ -83,111 +83,111 @@ func (m *AvailabilityRequestModel) Serialize(writer serialization.SerializationW
 
 func (m *AvailabilityRequestModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		catalogIDKey:            internalSerialization.DeserializeStringFunc(m.setCatalogId),
-		endDateKey:              internalSerialization.DeserializeStringFunc(m.setEndDate),
-		fetchDaysSlotKey:        internalSerialization.DeserializeBoolFunc(m.setFetchDaysSlot),
-		fullDayKey:              internalSerialization.DeserializeBoolFunc(m.setFullDay),
-		getNextAvailableSlotKey: internalSerialization.DeserializeBoolFunc(m.setGetNextAvailableSlot),
-		limitKey:                internalSerialization.DeserializeInt32Func(m.setLimit),
-		locationKey:             internalSerialization.DeserializeStringFunc(m.setLocation),
-		openedForKey:            internalSerialization.DeserializeStringFunc(m.setOpenedFor),
-		otherInputsKey:          internalSerialization.DeserializeAnyFunc(m.setOtherInputs),
-		serviceConfigRuleKey:    internalSerialization.DeserializeStringFunc(m.setServiceConfigRule),
-		startDateKey:            internalSerialization.DeserializeStringFunc(m.setStartDate),
-		taskIDKey:               internalSerialization.DeserializeStringFunc(m.setTaskId),
-		taskTableKey:            internalSerialization.DeserializeStringFunc(m.setTaskTable),
-		useReadReplicaKey:       internalSerialization.DeserializeBoolFunc(m.setUseReadReplica),
-		viewKey:                 internalSerialization.DeserializeStringFunc(m.setView),
+		catalogIDKey:            internalSerialization.DeserializeStringFunc(m.SetCatalogId),
+		endDateKey:              internalSerialization.DeserializeStringFunc(m.SetEndDate),
+		fetchDaysSlotKey:        internalSerialization.DeserializeBoolFunc(m.SetFetchDaysSlot),
+		fullDayKey:              internalSerialization.DeserializeBoolFunc(m.SetFullDay),
+		getNextAvailableSlotKey: internalSerialization.DeserializeBoolFunc(m.SetGetNextAvailableSlot),
+		limitKey:                internalSerialization.DeserializeInt32Func(m.SetLimit),
+		locationKey:             internalSerialization.DeserializeStringFunc(m.SetLocation),
+		openedForKey:            internalSerialization.DeserializeStringFunc(m.SetOpenedFor),
+		otherInputsKey:          internalSerialization.DeserializeAnyFunc(m.SetOtherInputs),
+		serviceConfigRuleKey:    internalSerialization.DeserializeStringFunc(m.SetServiceConfigRule),
+		startDateKey:            internalSerialization.DeserializeStringFunc(m.SetStartDate),
+		taskIDKey:               internalSerialization.DeserializeStringFunc(m.SetTaskId),
+		taskTableKey:            internalSerialization.DeserializeStringFunc(m.SetTaskTable),
+		useReadReplicaKey:       internalSerialization.DeserializeBoolFunc(m.SetUseReadReplica),
+		viewKey:                 internalSerialization.DeserializeStringFunc(m.SetView),
 	}
 }
 
 func (m *AvailabilityRequestModel) GetCatalogId() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, catalogIDKey)
 }
-func (m *AvailabilityRequestModel) setCatalogId(val *string) error {
+func (m *AvailabilityRequestModel) SetCatalogId(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, catalogIDKey, val)
 }
 func (m *AvailabilityRequestModel) GetEndDate() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, endDateKey)
 }
-func (m *AvailabilityRequestModel) setEndDate(val *string) error {
+func (m *AvailabilityRequestModel) SetEndDate(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, endDateKey, val)
 }
 func (m *AvailabilityRequestModel) GetFetchDaysSlot() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *bool](m, fetchDaysSlotKey)
 }
-func (m *AvailabilityRequestModel) setFetchDaysSlot(val *bool) error {
+func (m *AvailabilityRequestModel) SetFetchDaysSlot(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, fetchDaysSlotKey, val)
 }
 func (m *AvailabilityRequestModel) GetFullDay() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *bool](m, fullDayKey)
 }
-func (m *AvailabilityRequestModel) setFullDay(val *bool) error {
+func (m *AvailabilityRequestModel) SetFullDay(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, fullDayKey, val)
 }
 func (m *AvailabilityRequestModel) GetGetNextAvailableSlot() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *bool](m, getNextAvailableSlotKey)
 }
-func (m *AvailabilityRequestModel) setGetNextAvailableSlot(val *bool) error {
+func (m *AvailabilityRequestModel) SetGetNextAvailableSlot(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, getNextAvailableSlotKey, val)
 }
 func (m *AvailabilityRequestModel) GetLimit() (*int32, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *int32](m, limitKey)
 }
-func (m *AvailabilityRequestModel) setLimit(val *int32) error {
+func (m *AvailabilityRequestModel) SetLimit(val *int32) error {
 	return store.DefaultBackedModelMutatorFunc(m, limitKey, val)
 }
 func (m *AvailabilityRequestModel) GetLocation() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, locationKey)
 }
-func (m *AvailabilityRequestModel) setLocation(val *string) error {
+func (m *AvailabilityRequestModel) SetLocation(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, locationKey, val)
 }
 func (m *AvailabilityRequestModel) GetOpenedFor() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, openedForKey)
 }
-func (m *AvailabilityRequestModel) setOpenedFor(val *string) error {
+func (m *AvailabilityRequestModel) SetOpenedFor(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, openedForKey, val)
 }
 func (m *AvailabilityRequestModel) GetOtherInputs() (any, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, any](m, otherInputsKey)
 }
-func (m *AvailabilityRequestModel) setOtherInputs(val any) error {
+func (m *AvailabilityRequestModel) SetOtherInputs(val any) error {
 	return store.DefaultBackedModelMutatorFunc(m, otherInputsKey, val)
 }
 func (m *AvailabilityRequestModel) GetServiceConfigRule() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, serviceConfigRuleKey)
 }
-func (m *AvailabilityRequestModel) setServiceConfigRule(val *string) error {
+func (m *AvailabilityRequestModel) SetServiceConfigRule(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, serviceConfigRuleKey, val)
 }
 func (m *AvailabilityRequestModel) GetStartDate() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, startDateKey)
 }
-func (m *AvailabilityRequestModel) setStartDate(val *string) error {
+func (m *AvailabilityRequestModel) SetStartDate(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, startDateKey, val)
 }
 func (m *AvailabilityRequestModel) GetTaskId() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, taskIDKey)
 }
-func (m *AvailabilityRequestModel) setTaskId(val *string) error {
+func (m *AvailabilityRequestModel) SetTaskId(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, taskIDKey, val)
 }
 func (m *AvailabilityRequestModel) GetTaskTable() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, taskTableKey)
 }
-func (m *AvailabilityRequestModel) setTaskTable(val *string) error {
+func (m *AvailabilityRequestModel) SetTaskTable(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, taskTableKey, val)
 }
 func (m *AvailabilityRequestModel) GetUseReadReplica() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *bool](m, useReadReplicaKey)
 }
-func (m *AvailabilityRequestModel) setUseReadReplica(val *bool) error {
+func (m *AvailabilityRequestModel) SetUseReadReplica(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, useReadReplicaKey, val)
 }
 func (m *AvailabilityRequestModel) GetView() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityRequestModel, *string](m, viewKey)
 }
-func (m *AvailabilityRequestModel) setView(val *string) error {
+func (m *AvailabilityRequestModel) SetView(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, viewKey, val)
 }

--- a/appointmentbookingapi/availability_request_test.go
+++ b/appointmentbookingapi/availability_request_test.go
@@ -16,21 +16,21 @@ func TestAvailabilityRequestModel_GettersSetters(t *testing.T) {
 		getter func() (interface{}, error)
 		value  interface{}
 	}{
-		{"CatalogId", func(v interface{}) error { return model.setCatalogId(v.(*string)) }, func() (interface{}, error) { return model.GetCatalogId() }, internal.ToPointer("val")},
-		{"EndDate", func(v interface{}) error { return model.setEndDate(v.(*string)) }, func() (interface{}, error) { return model.GetEndDate() }, internal.ToPointer("val")},
-		{"FetchDaysSlot", func(v interface{}) error { return model.setFetchDaysSlot(v.(*bool)) }, func() (interface{}, error) { return model.GetFetchDaysSlot() }, internal.ToPointer(true)},
-		{"FullDay", func(v interface{}) error { return model.setFullDay(v.(*bool)) }, func() (interface{}, error) { return model.GetFullDay() }, internal.ToPointer(true)},
-		{"GetNextAvailableSlot", func(v interface{}) error { return model.setGetNextAvailableSlot(v.(*bool)) }, func() (interface{}, error) { return model.GetGetNextAvailableSlot() }, internal.ToPointer(true)},
-		{"Limit", func(v interface{}) error { return model.setLimit(v.(*int32)) }, func() (interface{}, error) { return model.GetLimit() }, internal.ToPointer(int32(10))},
-		{"Location", func(v interface{}) error { return model.setLocation(v.(*string)) }, func() (interface{}, error) { return model.GetLocation() }, internal.ToPointer("val")},
-		{"OpenedFor", func(v interface{}) error { return model.setOpenedFor(v.(*string)) }, func() (interface{}, error) { return model.GetOpenedFor() }, internal.ToPointer("val")},
-		{"OtherInputs", func(v interface{}) error { return model.setOtherInputs(v) }, func() (interface{}, error) { return model.GetOtherInputs() }, "val"},
-		{"ServiceConfigRule", func(v interface{}) error { return model.setServiceConfigRule(v.(*string)) }, func() (interface{}, error) { return model.GetServiceConfigRule() }, internal.ToPointer("val")},
-		{"StartDate", func(v interface{}) error { return model.setStartDate(v.(*string)) }, func() (interface{}, error) { return model.GetStartDate() }, internal.ToPointer("val")},
-		{"TaskId", func(v interface{}) error { return model.setTaskId(v.(*string)) }, func() (interface{}, error) { return model.GetTaskId() }, internal.ToPointer("val")},
-		{"TaskTable", func(v interface{}) error { return model.setTaskTable(v.(*string)) }, func() (interface{}, error) { return model.GetTaskTable() }, internal.ToPointer("val")},
-		{"UseReadReplica", func(v interface{}) error { return model.setUseReadReplica(v.(*bool)) }, func() (interface{}, error) { return model.GetUseReadReplica() }, internal.ToPointer(true)},
-		{"View", func(v interface{}) error { return model.setView(v.(*string)) }, func() (interface{}, error) { return model.GetView() }, internal.ToPointer("val")},
+		{"CatalogId", func(v interface{}) error { return model.SetCatalogId(v.(*string)) }, func() (interface{}, error) { return model.GetCatalogId() }, internal.ToPointer("val")},
+		{"EndDate", func(v interface{}) error { return model.SetEndDate(v.(*string)) }, func() (interface{}, error) { return model.GetEndDate() }, internal.ToPointer("val")},
+		{"FetchDaysSlot", func(v interface{}) error { return model.SetFetchDaysSlot(v.(*bool)) }, func() (interface{}, error) { return model.GetFetchDaysSlot() }, internal.ToPointer(true)},
+		{"FullDay", func(v interface{}) error { return model.SetFullDay(v.(*bool)) }, func() (interface{}, error) { return model.GetFullDay() }, internal.ToPointer(true)},
+		{"GetNextAvailableSlot", func(v interface{}) error { return model.SetGetNextAvailableSlot(v.(*bool)) }, func() (interface{}, error) { return model.GetGetNextAvailableSlot() }, internal.ToPointer(true)},
+		{"Limit", func(v interface{}) error { return model.SetLimit(v.(*int32)) }, func() (interface{}, error) { return model.GetLimit() }, internal.ToPointer(int32(10))},
+		{"Location", func(v interface{}) error { return model.SetLocation(v.(*string)) }, func() (interface{}, error) { return model.GetLocation() }, internal.ToPointer("val")},
+		{"OpenedFor", func(v interface{}) error { return model.SetOpenedFor(v.(*string)) }, func() (interface{}, error) { return model.GetOpenedFor() }, internal.ToPointer("val")},
+		{"OtherInputs", func(v interface{}) error { return model.SetOtherInputs(v) }, func() (interface{}, error) { return model.GetOtherInputs() }, "val"},
+		{"ServiceConfigRule", func(v interface{}) error { return model.SetServiceConfigRule(v.(*string)) }, func() (interface{}, error) { return model.GetServiceConfigRule() }, internal.ToPointer("val")},
+		{"StartDate", func(v interface{}) error { return model.SetStartDate(v.(*string)) }, func() (interface{}, error) { return model.GetStartDate() }, internal.ToPointer("val")},
+		{"TaskId", func(v interface{}) error { return model.SetTaskId(v.(*string)) }, func() (interface{}, error) { return model.GetTaskId() }, internal.ToPointer("val")},
+		{"TaskTable", func(v interface{}) error { return model.SetTaskTable(v.(*string)) }, func() (interface{}, error) { return model.GetTaskTable() }, internal.ToPointer("val")},
+		{"UseReadReplica", func(v interface{}) error { return model.SetUseReadReplica(v.(*bool)) }, func() (interface{}, error) { return model.GetUseReadReplica() }, internal.ToPointer(true)},
+		{"View", func(v interface{}) error { return model.SetView(v.(*string)) }, func() (interface{}, error) { return model.GetView() }, internal.ToPointer("val")},
 	}
 
 	for _, tt := range tests {

--- a/appointmentbookingapi/availability_response.go
+++ b/appointmentbookingapi/availability_response.go
@@ -24,19 +24,19 @@ type AvailabilityResult interface {
 	kiotaStore.BackedModel
 
 	GetAvailability() ([]AvailabilitySlot, error)
-	setAvailability([]AvailabilitySlot) error
+	SetAvailability([]AvailabilitySlot) error
 	GetHasMore() (*bool, error)
-	setHasMore(*bool) error
+	SetHasMore(*bool) error
 	GetNextAvailableSlot() (any, error)
-	setNextAvailableSlot(any) error
+	SetNextAvailableSlot(any) error
 	GetNoApptAvailable() (*bool, error)
-	setNoApptAvailable(*bool) error
+	SetNoApptAvailable(*bool) error
 	GetSuccess() (*bool, error)
-	setSuccess(*bool) error
+	SetSuccess(*bool) error
 	GetTimeZone() (*string, error)
-	setTimeZone(*string) error
+	SetTimeZone(*string) error
 	GetTimeZoneDisplayValue() (*string, error)
-	setTimeZoneDisplayValue(*string) error
+	SetTimeZoneDisplayValue(*string) error
 }
 
 type AvailabilityResultModel struct {
@@ -68,56 +68,56 @@ func (m *AvailabilityResultModel) Serialize(writer serialization.SerializationWr
 
 func (m *AvailabilityResultModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		availabilityKey:         internalSerialization.DeserializeCollectionOfObjectValuesFunc[AvailabilitySlot](CreateAvailabilitySlotFromDiscriminatorValue, m.setAvailability),
-		hasMoreKey:              internalSerialization.DeserializeBoolFunc(m.setHasMore),
-		nextAvailableSlotKey:    internalSerialization.DeserializeAnyFunc(m.setNextAvailableSlot),
-		noApptAvailableKey:      internalSerialization.DeserializeBoolFunc(m.setNoApptAvailable),
-		successKey:              internalSerialization.DeserializeBoolFunc(m.setSuccess),
-		timeZoneKey:             internalSerialization.DeserializeStringFunc(m.setTimeZone),
-		timeZoneDisplayValueKey: internalSerialization.DeserializeStringFunc(m.setTimeZoneDisplayValue),
+		availabilityKey:         internalSerialization.DeserializeCollectionOfObjectValuesFunc[AvailabilitySlot](CreateAvailabilitySlotFromDiscriminatorValue, m.SetAvailability),
+		hasMoreKey:              internalSerialization.DeserializeBoolFunc(m.SetHasMore),
+		nextAvailableSlotKey:    internalSerialization.DeserializeAnyFunc(m.SetNextAvailableSlot),
+		noApptAvailableKey:      internalSerialization.DeserializeBoolFunc(m.SetNoApptAvailable),
+		successKey:              internalSerialization.DeserializeBoolFunc(m.SetSuccess),
+		timeZoneKey:             internalSerialization.DeserializeStringFunc(m.SetTimeZone),
+		timeZoneDisplayValueKey: internalSerialization.DeserializeStringFunc(m.SetTimeZoneDisplayValue),
 	}
 }
 
 func (m *AvailabilityResultModel) GetAvailability() ([]AvailabilitySlot, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityResultModel, []AvailabilitySlot](m, availabilityKey)
 }
-func (m *AvailabilityResultModel) setAvailability(val []AvailabilitySlot) error {
+func (m *AvailabilityResultModel) SetAvailability(val []AvailabilitySlot) error {
 	return store.DefaultBackedModelMutatorFunc(m, availabilityKey, val)
 }
 func (m *AvailabilityResultModel) GetHasMore() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityResultModel, *bool](m, hasMoreKey)
 }
-func (m *AvailabilityResultModel) setHasMore(val *bool) error {
+func (m *AvailabilityResultModel) SetHasMore(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, hasMoreKey, val)
 }
 func (m *AvailabilityResultModel) GetNextAvailableSlot() (any, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityResultModel, any](m, nextAvailableSlotKey)
 }
-func (m *AvailabilityResultModel) setNextAvailableSlot(val any) error {
+func (m *AvailabilityResultModel) SetNextAvailableSlot(val any) error {
 	return store.DefaultBackedModelMutatorFunc(m, nextAvailableSlotKey, val)
 }
 func (m *AvailabilityResultModel) GetNoApptAvailable() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityResultModel, *bool](m, noApptAvailableKey)
 }
-func (m *AvailabilityResultModel) setNoApptAvailable(val *bool) error {
+func (m *AvailabilityResultModel) SetNoApptAvailable(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, noApptAvailableKey, val)
 }
 func (m *AvailabilityResultModel) GetSuccess() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityResultModel, *bool](m, successKey)
 }
-func (m *AvailabilityResultModel) setSuccess(val *bool) error {
+func (m *AvailabilityResultModel) SetSuccess(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, successKey, val)
 }
 func (m *AvailabilityResultModel) GetTimeZone() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityResultModel, *string](m, timeZoneKey)
 }
-func (m *AvailabilityResultModel) setTimeZone(val *string) error {
+func (m *AvailabilityResultModel) SetTimeZone(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, timeZoneKey, val)
 }
 func (m *AvailabilityResultModel) GetTimeZoneDisplayValue() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*AvailabilityResultModel, *string](m, timeZoneDisplayValueKey)
 }
-func (m *AvailabilityResultModel) setTimeZoneDisplayValue(val *string) error {
+func (m *AvailabilityResultModel) SetTimeZoneDisplayValue(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, timeZoneDisplayValueKey, val)
 }
 

--- a/appointmentbookingapi/calendar_response.go
+++ b/appointmentbookingapi/calendar_response.go
@@ -7,26 +7,15 @@ import (
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/store"
 
 	"github.com/microsoft/kiota-abstractions-go/serialization"
-	kiotaStore "github.com/microsoft/kiota-abstractions-go/store"
 )
 
-// CalendarResponse represents the calendar response.
-type CalendarResponse interface {
-	serialization.Parsable
-	kiotaStore.BackedModel
-	GetRangeEnd() (*string, error)
-	setRangeEnd(*string) error
-	GetRangeStart() (*string, error)
-	setRangeStart(*string) error
-}
-
-// CalendarResponseModel implementation of CalendarResponse
-type CalendarResponseModel struct {
+// CalendarResponse implementation of CalendarResponse
+type CalendarResponse struct {
 	core.BaseModel
 }
 
-func NewCalendarResponse() *CalendarResponseModel {
-	return &CalendarResponseModel{
+func NewCalendarResponse() *CalendarResponse {
+	return &CalendarResponse{
 		BaseModel: *core.NewBaseModel(),
 	}
 }
@@ -35,7 +24,7 @@ func CreateCalendarResponseFromDiscriminatorValue(_ serialization.ParseNode) (se
 	return NewCalendarResponse(), nil
 }
 
-func (m *CalendarResponseModel) Serialize(writer serialization.SerializationWriter) error {
+func (m *CalendarResponse) Serialize(writer serialization.SerializationWriter) error {
 	if conversion.IsNil(m) {
 		return nil
 	}
@@ -45,25 +34,25 @@ func (m *CalendarResponseModel) Serialize(writer serialization.SerializationWrit
 	)
 }
 
-func (m *CalendarResponseModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
+func (m *CalendarResponse) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		rangeEndKey:   internalSerialization.DeserializeStringFunc(m.setRangeEnd),
-		rangeStartKey: internalSerialization.DeserializeStringFunc(m.setRangeStart),
+		rangeEndKey:   internalSerialization.DeserializeStringFunc(m.SetRangeEnd),
+		rangeStartKey: internalSerialization.DeserializeStringFunc(m.SetRangeStart),
 	}
 }
 
-func (m *CalendarResponseModel) GetRangeEnd() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*CalendarResponseModel, *string](m, rangeEndKey)
+func (m *CalendarResponse) GetRangeEnd() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*CalendarResponse, *string](m, rangeEndKey)
 }
 
-func (m *CalendarResponseModel) setRangeEnd(val *string) error {
+func (m *CalendarResponse) SetRangeEnd(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, rangeEndKey, val)
 }
 
-func (m *CalendarResponseModel) GetRangeStart() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*CalendarResponseModel, *string](m, rangeStartKey)
+func (m *CalendarResponse) GetRangeStart() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*CalendarResponse, *string](m, rangeStartKey)
 }
 
-func (m *CalendarResponseModel) setRangeStart(val *string) error {
+func (m *CalendarResponse) SetRangeStart(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, rangeStartKey, val)
 }

--- a/appointmentbookingapi/configuration_response.go
+++ b/appointmentbookingapi/configuration_response.go
@@ -11,57 +11,24 @@ import (
 )
 
 // ConfigurationResponse represents the configuration response.
-type ConfigurationResponse = core.ServiceNowItemResponse[*ConfigurationResultModel]
+type ConfigurationResponse = core.ServiceNowItemResponse[*ConfigurationResult]
 
 // CreateConfigurationResponseFromDiscriminatorValue is a factory for creating a ConfigurationResponse.
 func CreateConfigurationResponseFromDiscriminatorValue(_ serialization.ParseNode) (serialization.Parsable, error) {
-	return core.NewBaseServiceNowItemResponse[*ConfigurationResultModel](CreateConfigurationResultFromDiscriminatorValue), nil
+	return core.NewBaseServiceNowItemResponse[*ConfigurationResult](CreateConfigurationResultFromDiscriminatorValue), nil
 }
 
 // ConfigurationResponseModel is the implementation of ConfigurationResponse.
-type ConfigurationResponseModel = core.BaseServiceNowItemResponse[*ConfigurationResultModel]
+type ConfigurationResponseModel = core.BaseServiceNowItemResponse[*ConfigurationResult]
 
 // ConfigurationResult represents the result object in configuration response.
-type ConfigurationResult interface {
-	serialization.Parsable
-	kiotaStore.BackedModel
-
-	GetActive() (*bool, error)
-	setActive(*bool) error
-	GetActiveString() (*string, error)
-	setActiveString(*string) error
-	GetAdvancedCalendarViewPortal() (*bool, error)
-	setAdvancedCalendarViewPortal(*bool) error
-	GetAutoAcceptance() (*bool, error)
-	setAutoAcceptance(*bool) error
-	GetLocaleLanguage() (*string, error)
-	setLocaleLanguage(*string) error
-	GetServiceConfig() (ServiceConfig, error)
-	setServiceConfig(ServiceConfig) error
-	GetTaskTable() (*string, error)
-	setTaskTable(*string) error
-	GetTranslations() (map[string]interface{}, error)
-	setTranslations(map[string]interface{}) error
-	GetUserDateFormatOptions() (UserDateFormatOptions, error)
-	setUserDateFormatOptions(UserDateFormatOptions) error
-	GetUseRR() (*bool, error)
-	setUseRR(*bool) error
-	GetUserTimeFormat() (UserTimeFormat, error)
-	setUserTimeFormat(UserTimeFormat) error
-	GetUserTimeFormatOptions() (UserTimeFormatOptions, error)
-	setUserTimeFormatOptions(UserTimeFormatOptions) error
-	GetViewScale() (*string, error)
-	setViewScale(*string) error
-}
-
-// ConfigurationResultModel implementation of ConfigurationResult
-type ConfigurationResultModel struct {
+type ConfigurationResult struct {
 	core.BaseModel
 }
 
 // NewConfigurationResult creates a new instance of ConfigurationResultModel
-func NewConfigurationResult() *ConfigurationResultModel {
-	return &ConfigurationResultModel{
+func NewConfigurationResult() *ConfigurationResult {
+	return &ConfigurationResult{
 		BaseModel: *core.NewBaseModel(),
 	}
 }
@@ -72,7 +39,7 @@ func CreateConfigurationResultFromDiscriminatorValue(_ serialization.ParseNode) 
 }
 
 // Serialize writes the objects properties to the current writer.
-func (m *ConfigurationResultModel) Serialize(writer serialization.SerializationWriter) error {
+func (m *ConfigurationResult) Serialize(writer serialization.SerializationWriter) error {
 	if conversion.IsNil(m) {
 		return nil
 	}
@@ -83,112 +50,112 @@ func (m *ConfigurationResultModel) Serialize(writer serialization.SerializationW
 		internalSerialization.SerializeBoolFunc(advancedCalendarViewPortalKey, m.GetAdvancedCalendarViewPortal),
 		internalSerialization.SerializeBoolFunc(autoAcceptanceKey, m.GetAutoAcceptance),
 		internalSerialization.SerializeStringFunc(localeLanguageKey, m.GetLocaleLanguage),
-		internalSerialization.SerializeObjectValueFunc[ServiceConfig](serviceConfigKey, m.GetServiceConfig),
+		internalSerialization.SerializeObjectValueFunc(serviceConfigKey, m.GetServiceConfig),
 		internalSerialization.SerializeStringFunc(taskTableKey, m.GetTaskTable),
 		internalSerialization.SerializeAnyFunc(translationsKey, m.GetTranslations),
-		internalSerialization.SerializeObjectValueFunc[UserDateFormatOptions](userDateFormatOptionsKey, m.GetUserDateFormatOptions),
+		internalSerialization.SerializeObjectValueFunc(userDateFormatOptionsKey, m.GetUserDateFormatOptions),
 		internalSerialization.SerializeBoolFunc(useRRKey, m.GetUseRR),
-		internalSerialization.SerializeObjectValueFunc[UserTimeFormat](userTimeFormatKey, m.GetUserTimeFormat),
-		internalSerialization.SerializeObjectValueFunc[UserTimeFormatOptions](userTimeFormatOptionsKey, m.GetUserTimeFormatOptions),
+		internalSerialization.SerializeObjectValueFunc(userTimeFormatKey, m.GetUserTimeFormat),
+		internalSerialization.SerializeObjectValueFunc(userTimeFormatOptionsKey, m.GetUserTimeFormatOptions),
 		internalSerialization.SerializeStringFunc(viewScaleKey, m.GetViewScale),
 	)
 }
 
 // GetFieldDeserializers returns the deserialization information for this object.
-func (m *ConfigurationResultModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
+func (m *ConfigurationResult) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		activeKey:                     internalSerialization.DeserializeBoolFunc(m.setActive),
-		activeStringKey:               internalSerialization.DeserializeStringFunc(m.setActiveString),
-		advancedCalendarViewPortalKey: internalSerialization.DeserializeBoolFunc(m.setAdvancedCalendarViewPortal),
-		autoAcceptanceKey:             internalSerialization.DeserializeBoolFunc(m.setAutoAcceptance),
-		localeLanguageKey:             internalSerialization.DeserializeStringFunc(m.setLocaleLanguage),
-		serviceConfigKey:              internalSerialization.DeserializeObjectValueFunc[ServiceConfig](CreateServiceConfigFromDiscriminatorValue, m.setServiceConfig),
-		taskTableKey:                  internalSerialization.DeserializeStringFunc(m.setTaskTable),
-		translationsKey:               internalSerialization.DeserializeAnyFunc(m.setTranslations),
-		userDateFormatOptionsKey:      internalSerialization.DeserializeObjectValueFunc[UserDateFormatOptions](CreateUserDateFormatOptionsFromDiscriminatorValue, m.setUserDateFormatOptions),
-		useRRKey:                      internalSerialization.DeserializeBoolFunc(m.setUseRR),
-		userTimeFormatKey:             internalSerialization.DeserializeObjectValueFunc[UserTimeFormat](CreateUserTimeFormatFromDiscriminatorValue, m.setUserTimeFormat),
-		userTimeFormatOptionsKey:      internalSerialization.DeserializeObjectValueFunc[UserTimeFormatOptions](CreateUserTimeFormatOptionsFromDiscriminatorValue, m.setUserTimeFormatOptions),
-		viewScaleKey:                  internalSerialization.DeserializeStringFunc(m.setViewScale),
+		activeKey:                     internalSerialization.DeserializeBoolFunc(m.SetActive),
+		activeStringKey:               internalSerialization.DeserializeStringFunc(m.SetActiveString),
+		advancedCalendarViewPortalKey: internalSerialization.DeserializeBoolFunc(m.SetAdvancedCalendarViewPortal),
+		autoAcceptanceKey:             internalSerialization.DeserializeBoolFunc(m.SetAutoAcceptance),
+		localeLanguageKey:             internalSerialization.DeserializeStringFunc(m.SetLocaleLanguage),
+		serviceConfigKey:              internalSerialization.DeserializeObjectValueFunc(CreateServiceConfigFromDiscriminatorValue, m.SetServiceConfig),
+		taskTableKey:                  internalSerialization.DeserializeStringFunc(m.SetTaskTable),
+		translationsKey:               internalSerialization.DeserializeAnyFunc(m.SetTranslations),
+		userDateFormatOptionsKey:      internalSerialization.DeserializeObjectValueFunc(CreateUserDateFormatOptionsFromDiscriminatorValue, m.SetUserDateFormatOptions),
+		useRRKey:                      internalSerialization.DeserializeBoolFunc(m.SetUseRR),
+		userTimeFormatKey:             internalSerialization.DeserializeObjectValueFunc(CreateUserTimeFormatFromDiscriminatorValue, m.SetUserTimeFormat),
+		userTimeFormatOptionsKey:      internalSerialization.DeserializeObjectValueFunc(CreateUserTimeFormatOptionsFromDiscriminatorValue, m.SetUserTimeFormatOptions),
+		viewScaleKey:                  internalSerialization.DeserializeStringFunc(m.SetViewScale),
 	}
 }
 
-func (m *ConfigurationResultModel) GetActive() (*bool, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *bool](m, activeKey)
+func (m *ConfigurationResult) GetActive() (*bool, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *bool](m, activeKey)
 }
-func (m *ConfigurationResultModel) setActive(val *bool) error {
+func (m *ConfigurationResult) SetActive(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, activeKey, val)
 }
-func (m *ConfigurationResultModel) GetActiveString() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *string](m, activeStringKey)
+func (m *ConfigurationResult) GetActiveString() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *string](m, activeStringKey)
 }
-func (m *ConfigurationResultModel) setActiveString(val *string) error {
+func (m *ConfigurationResult) SetActiveString(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, activeStringKey, val)
 }
-func (m *ConfigurationResultModel) GetAdvancedCalendarViewPortal() (*bool, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *bool](m, advancedCalendarViewPortalKey)
+func (m *ConfigurationResult) GetAdvancedCalendarViewPortal() (*bool, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *bool](m, advancedCalendarViewPortalKey)
 }
-func (m *ConfigurationResultModel) setAdvancedCalendarViewPortal(val *bool) error {
+func (m *ConfigurationResult) SetAdvancedCalendarViewPortal(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, advancedCalendarViewPortalKey, val)
 }
-func (m *ConfigurationResultModel) GetAutoAcceptance() (*bool, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *bool](m, autoAcceptanceKey)
+func (m *ConfigurationResult) GetAutoAcceptance() (*bool, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *bool](m, autoAcceptanceKey)
 }
-func (m *ConfigurationResultModel) setAutoAcceptance(val *bool) error {
+func (m *ConfigurationResult) SetAutoAcceptance(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, autoAcceptanceKey, val)
 }
-func (m *ConfigurationResultModel) GetLocaleLanguage() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *string](m, localeLanguageKey)
+func (m *ConfigurationResult) GetLocaleLanguage() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *string](m, localeLanguageKey)
 }
-func (m *ConfigurationResultModel) setLocaleLanguage(val *string) error {
+func (m *ConfigurationResult) SetLocaleLanguage(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, localeLanguageKey, val)
 }
-func (m *ConfigurationResultModel) GetServiceConfig() (ServiceConfig, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, ServiceConfig](m, serviceConfigKey)
+func (m *ConfigurationResult) GetServiceConfig() (ServiceConfig, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, ServiceConfig](m, serviceConfigKey)
 }
-func (m *ConfigurationResultModel) setServiceConfig(val ServiceConfig) error {
+func (m *ConfigurationResult) SetServiceConfig(val ServiceConfig) error {
 	return store.DefaultBackedModelMutatorFunc(m, serviceConfigKey, val)
 }
-func (m *ConfigurationResultModel) GetTaskTable() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *string](m, taskTableKey)
+func (m *ConfigurationResult) GetTaskTable() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *string](m, taskTableKey)
 }
-func (m *ConfigurationResultModel) setTaskTable(val *string) error {
+func (m *ConfigurationResult) SetTaskTable(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, taskTableKey, val)
 }
-func (m *ConfigurationResultModel) GetTranslations() (any, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, any](m, translationsKey)
+func (m *ConfigurationResult) GetTranslations() (any, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, any](m, translationsKey)
 }
-func (m *ConfigurationResultModel) setTranslations(val any) error {
+func (m *ConfigurationResult) SetTranslations(val any) error {
 	return store.DefaultBackedModelMutatorFunc(m, translationsKey, val)
 }
-func (m *ConfigurationResultModel) GetUserDateFormatOptions() (UserDateFormatOptions, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, UserDateFormatOptions](m, userDateFormatOptionsKey)
+func (m *ConfigurationResult) GetUserDateFormatOptions() (UserDateFormatOptions, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, UserDateFormatOptions](m, userDateFormatOptionsKey)
 }
-func (m *ConfigurationResultModel) setUserDateFormatOptions(val UserDateFormatOptions) error {
+func (m *ConfigurationResult) SetUserDateFormatOptions(val UserDateFormatOptions) error {
 	return store.DefaultBackedModelMutatorFunc(m, userDateFormatOptionsKey, val)
 }
-func (m *ConfigurationResultModel) GetUseRR() (*bool, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *bool](m, useRRKey)
+func (m *ConfigurationResult) GetUseRR() (*bool, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *bool](m, useRRKey)
 }
-func (m *ConfigurationResultModel) setUseRR(val *bool) error {
+func (m *ConfigurationResult) SetUseRR(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, useRRKey, val)
 }
-func (m *ConfigurationResultModel) GetUserTimeFormat() (UserTimeFormat, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, UserTimeFormat](m, userTimeFormatKey)
+func (m *ConfigurationResult) GetUserTimeFormat() (UserTimeFormat, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, UserTimeFormat](m, userTimeFormatKey)
 }
-func (m *ConfigurationResultModel) setUserTimeFormat(val UserTimeFormat) error {
+func (m *ConfigurationResult) SetUserTimeFormat(val UserTimeFormat) error {
 	return store.DefaultBackedModelMutatorFunc(m, userTimeFormatKey, val)
 }
-func (m *ConfigurationResultModel) GetUserTimeFormatOptions() (UserTimeFormatOptions, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, UserTimeFormatOptions](m, userTimeFormatOptionsKey)
+func (m *ConfigurationResult) GetUserTimeFormatOptions() (UserTimeFormatOptions, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, UserTimeFormatOptions](m, userTimeFormatOptionsKey)
 }
-func (m *ConfigurationResultModel) setUserTimeFormatOptions(val UserTimeFormatOptions) error {
+func (m *ConfigurationResult) SetUserTimeFormatOptions(val UserTimeFormatOptions) error {
 	return store.DefaultBackedModelMutatorFunc(m, userTimeFormatOptionsKey, val)
 }
-func (m *ConfigurationResultModel) GetViewScale() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*ConfigurationResultModel, *string](m, viewScaleKey)
+func (m *ConfigurationResult) GetViewScale() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*ConfigurationResult, *string](m, viewScaleKey)
 }
-func (m *ConfigurationResultModel) setViewScale(val *string) error {
+func (m *ConfigurationResult) SetViewScale(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, viewScaleKey, val)
 }
 
@@ -198,13 +165,13 @@ type UserDateFormatOptions interface {
 	kiotaStore.BackedModel
 
 	GetDay() (*string, error)
-	setDay(*string) error
+	SetDay(*string) error
 	GetMonth() (*string, error)
-	setMonth(*string) error
+	SetMonth(*string) error
 	GetWeek() (*string, error)
-	setWeek(*string) error
+	SetWeek(*string) error
 	GetWeekday() (*string, error)
-	setWeekday(*string) error
+	SetWeekday(*string) error
 }
 
 type UserDateFormatOptionsModel struct {
@@ -235,34 +202,34 @@ func (m *UserDateFormatOptionsModel) Serialize(writer serialization.Serializatio
 
 func (m *UserDateFormatOptionsModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		dayKey:     internalSerialization.DeserializeStringFunc(m.setDay),
-		monthKey:   internalSerialization.DeserializeStringFunc(m.setMonth),
-		weekKey:    internalSerialization.DeserializeStringFunc(m.setWeek),
-		weekdayKey: internalSerialization.DeserializeStringFunc(m.setWeekday),
+		dayKey:     internalSerialization.DeserializeStringFunc(m.SetDay),
+		monthKey:   internalSerialization.DeserializeStringFunc(m.SetMonth),
+		weekKey:    internalSerialization.DeserializeStringFunc(m.SetWeek),
+		weekdayKey: internalSerialization.DeserializeStringFunc(m.SetWeekday),
 	}
 }
 
 func (m *UserDateFormatOptionsModel) GetDay() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserDateFormatOptionsModel, *string](m, dayKey)
 }
-func (m *UserDateFormatOptionsModel) setDay(val *string) error {
+func (m *UserDateFormatOptionsModel) SetDay(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, dayKey, val)
 }
 func (m *UserDateFormatOptionsModel) GetMonth() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserDateFormatOptionsModel, *string](m, monthKey)
 }
-func (m *UserDateFormatOptionsModel) setMonth(val *string) error {
+func (m *UserDateFormatOptionsModel) SetMonth(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, monthKey, val)
 }
 func (m *UserDateFormatOptionsModel) GetWeek() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserDateFormatOptionsModel, *string](m, weekKey)
 }
-func (m *UserDateFormatOptionsModel) setWeek(val *string) error {
+func (m *UserDateFormatOptionsModel) SetWeek(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, weekKey, val)
 }
 func (m *UserDateFormatOptionsModel) GetWeekday() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserDateFormatOptionsModel, *string](m, weekdayKey)
 }
-func (m *UserDateFormatOptionsModel) setWeekday(val *string) error {
+func (m *UserDateFormatOptionsModel) SetWeekday(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, weekdayKey, val)
 }

--- a/appointmentbookingapi/execute_rule_conditions.go
+++ b/appointmentbookingapi/execute_rule_conditions.go
@@ -15,11 +15,11 @@ type ExecuteRuleConditionsRequest interface {
 	kiotaStore.BackedModel
 
 	GetCatalogId() (*string, error)
-	setCatalogId(*string) error
+	SetCatalogId(*string) error
 	GetOtherInputs() (any, error)
-	setOtherInputs(any) error
+	SetOtherInputs(any) error
 	GetTaskId() (*string, error)
-	setTaskId(*string) error
+	SetTaskId(*string) error
 }
 
 type ExecuteRuleConditionsRequestModel struct {
@@ -47,27 +47,27 @@ func (m *ExecuteRuleConditionsRequestModel) Serialize(writer serialization.Seria
 
 func (m *ExecuteRuleConditionsRequestModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		catalogIDKey:   internalSerialization.DeserializeStringFunc(m.setCatalogId),
-		otherInputsKey: internalSerialization.DeserializeAnyFunc(m.setOtherInputs),
-		taskIDKey:      internalSerialization.DeserializeStringFunc(m.setTaskId),
+		catalogIDKey:   internalSerialization.DeserializeStringFunc(m.SetCatalogId),
+		otherInputsKey: internalSerialization.DeserializeAnyFunc(m.SetOtherInputs),
+		taskIDKey:      internalSerialization.DeserializeStringFunc(m.SetTaskId),
 	}
 }
 
 func (m *ExecuteRuleConditionsRequestModel) GetCatalogId() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsRequestModel, *string](m, catalogIDKey)
 }
-func (m *ExecuteRuleConditionsRequestModel) setCatalogId(val *string) error {
+func (m *ExecuteRuleConditionsRequestModel) SetCatalogId(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, catalogIDKey, val)
 }
 func (m *ExecuteRuleConditionsRequestModel) GetOtherInputs() (any, error) {
 	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsRequestModel, any](m, otherInputsKey)
 }
-func (m *ExecuteRuleConditionsRequestModel) setOtherInputs(val any) error {
+func (m *ExecuteRuleConditionsRequestModel) SetOtherInputs(val any) error {
 	return store.DefaultBackedModelMutatorFunc(m, otherInputsKey, val)
 }
 func (m *ExecuteRuleConditionsRequestModel) GetTaskId() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsRequestModel, *string](m, taskIDKey)
 }
-func (m *ExecuteRuleConditionsRequestModel) setTaskId(val *string) error {
+func (m *ExecuteRuleConditionsRequestModel) SetTaskId(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, taskIDKey, val)
 }

--- a/appointmentbookingapi/execute_rule_conditions_response.go
+++ b/appointmentbookingapi/execute_rule_conditions_response.go
@@ -6,9 +6,9 @@ import (
 )
 
 // ExecuteRuleConditionsResponse represents the response from execute_rule_conditions.
-type ExecuteRuleConditionsResponse = core.ServiceNowItemResponse[*ExecuteRuleConditionsResultModel]
+type ExecuteRuleConditionsResponse = core.ServiceNowItemResponse[*ExecuteRuleConditionsResult]
 
 // CreateExecuteRuleConditionsResponseFromDiscriminatorValue is a factory.
 func CreateExecuteRuleConditionsResponseFromDiscriminatorValue(_ serialization.ParseNode) (serialization.Parsable, error) {
-	return core.NewBaseServiceNowItemResponse[*ExecuteRuleConditionsResultModel](CreateExecuteRuleConditionsResultFromDiscriminatorValue), nil
+	return core.NewBaseServiceNowItemResponse[*ExecuteRuleConditionsResult](CreateExecuteRuleConditionsResultFromDiscriminatorValue), nil
 }

--- a/appointmentbookingapi/execute_rule_conditions_result.go
+++ b/appointmentbookingapi/execute_rule_conditions_result.go
@@ -6,36 +6,21 @@ import (
 	internalSerialization "github.com/michaeldcanady/servicenow-sdk-go/internal/serialization"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/store"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
-	kiotaStore "github.com/microsoft/kiota-abstractions-go/store"
 )
 
-type ExecuteRuleConditionsResult interface {
-	serialization.Parsable
-	kiotaStore.BackedModel
-
-	GetDedicatedCapacity() (*bool, error)
-	setDedicatedCapacity(*bool) error
-	GetFutureMaxBookableDays() (*string, error)
-	setFutureMaxBookableDays(*string) error
-	GetRuleId() (*string, error)
-	setRuleId(*string) error
-	GetRuleName() (*string, error)
-	setRuleName(*string) error
-}
-
-type ExecuteRuleConditionsResultModel struct {
+type ExecuteRuleConditionsResult struct {
 	core.BaseModel
 }
 
-func NewExecuteRuleConditionsResult() *ExecuteRuleConditionsResultModel {
-	return &ExecuteRuleConditionsResultModel{BaseModel: *core.NewBaseModel()}
+func NewExecuteRuleConditionsResult() *ExecuteRuleConditionsResult {
+	return &ExecuteRuleConditionsResult{BaseModel: *core.NewBaseModel()}
 }
 
 func CreateExecuteRuleConditionsResultFromDiscriminatorValue(_ serialization.ParseNode) (serialization.Parsable, error) {
 	return NewExecuteRuleConditionsResult(), nil
 }
 
-func (m *ExecuteRuleConditionsResultModel) Serialize(writer serialization.SerializationWriter) error {
+func (m *ExecuteRuleConditionsResult) Serialize(writer serialization.SerializationWriter) error {
 	if conversion.IsNil(m) {
 		return nil
 	}
@@ -47,36 +32,36 @@ func (m *ExecuteRuleConditionsResultModel) Serialize(writer serialization.Serial
 	)
 }
 
-func (m *ExecuteRuleConditionsResultModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
+func (m *ExecuteRuleConditionsResult) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		dedicatedCapacityKey:     internalSerialization.DeserializeBoolFunc(m.setDedicatedCapacity),
-		futureMaxBookableDaysKey: internalSerialization.DeserializeStringFunc(m.setFutureMaxBookableDays),
-		ruleIdKey:                internalSerialization.DeserializeStringFunc(m.setRuleId),
-		ruleNameKey:              internalSerialization.DeserializeStringFunc(m.setRuleName),
+		dedicatedCapacityKey:     internalSerialization.DeserializeBoolFunc(m.SetDedicatedCapacity),
+		futureMaxBookableDaysKey: internalSerialization.DeserializeStringFunc(m.SetFutureMaxBookableDays),
+		ruleIdKey:                internalSerialization.DeserializeStringFunc(m.SetRuleId),
+		ruleNameKey:              internalSerialization.DeserializeStringFunc(m.SetRuleName),
 	}
 }
 
-func (m *ExecuteRuleConditionsResultModel) GetDedicatedCapacity() (*bool, error) {
-	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResultModel, *bool](m, dedicatedCapacityKey)
+func (m *ExecuteRuleConditionsResult) GetDedicatedCapacity() (*bool, error) {
+	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResult, *bool](m, dedicatedCapacityKey)
 }
-func (m *ExecuteRuleConditionsResultModel) setDedicatedCapacity(val *bool) error {
+func (m *ExecuteRuleConditionsResult) SetDedicatedCapacity(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, dedicatedCapacityKey, val)
 }
-func (m *ExecuteRuleConditionsResultModel) GetFutureMaxBookableDays() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResultModel, *string](m, futureMaxBookableDaysKey)
+func (m *ExecuteRuleConditionsResult) GetFutureMaxBookableDays() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResult, *string](m, futureMaxBookableDaysKey)
 }
-func (m *ExecuteRuleConditionsResultModel) setFutureMaxBookableDays(val *string) error {
+func (m *ExecuteRuleConditionsResult) SetFutureMaxBookableDays(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, futureMaxBookableDaysKey, val)
 }
-func (m *ExecuteRuleConditionsResultModel) GetRuleId() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResultModel, *string](m, ruleIdKey)
+func (m *ExecuteRuleConditionsResult) GetRuleId() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResult, *string](m, ruleIdKey)
 }
-func (m *ExecuteRuleConditionsResultModel) setRuleId(val *string) error {
+func (m *ExecuteRuleConditionsResult) SetRuleId(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, ruleIdKey, val)
 }
-func (m *ExecuteRuleConditionsResultModel) GetRuleName() (*string, error) {
-	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResultModel, *string](m, ruleNameKey)
+func (m *ExecuteRuleConditionsResult) GetRuleName() (*string, error) {
+	return store.DefaultBackedModelAccessorFunc[*ExecuteRuleConditionsResult, *string](m, ruleNameKey)
 }
-func (m *ExecuteRuleConditionsResultModel) setRuleName(val *string) error {
+func (m *ExecuteRuleConditionsResult) SetRuleName(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, ruleNameKey, val)
 }

--- a/appointmentbookingapi/field_mapping.go
+++ b/appointmentbookingapi/field_mapping.go
@@ -15,13 +15,13 @@ type FieldMapping interface {
 	kiotaStore.BackedModel
 
 	GetContact() (*string, error)
-	setContact(*string) error
+	SetContact(*string) error
 	GetContactRPVariable() (RPVariable, error)
-	setContactRPVariable(RPVariable) error
+	SetContactRPVariable(RPVariable) error
 	GetLocation() (*string, error)
-	setLocation(*string) error
+	SetLocation(*string) error
 	GetLocationRPVariable() (RPVariable, error)
-	setLocationRPVariable(RPVariable) error
+	SetLocationRPVariable(RPVariable) error
 }
 
 type FieldMappingModel struct {
@@ -52,34 +52,34 @@ func (m *FieldMappingModel) Serialize(writer serialization.SerializationWriter) 
 
 func (m *FieldMappingModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		contactKey:            internalSerialization.DeserializeStringFunc(m.setContact),
-		contactRPVariableKey:  internalSerialization.DeserializeObjectValueFunc[RPVariable](CreateRPVariableFromDiscriminatorValue, m.setContactRPVariable),
-		locationKey:           internalSerialization.DeserializeStringFunc(m.setLocation),
-		locationRPVariableKey: internalSerialization.DeserializeObjectValueFunc[RPVariable](CreateRPVariableFromDiscriminatorValue, m.setLocationRPVariable),
+		contactKey:            internalSerialization.DeserializeStringFunc(m.SetContact),
+		contactRPVariableKey:  internalSerialization.DeserializeObjectValueFunc[RPVariable](CreateRPVariableFromDiscriminatorValue, m.SetContactRPVariable),
+		locationKey:           internalSerialization.DeserializeStringFunc(m.SetLocation),
+		locationRPVariableKey: internalSerialization.DeserializeObjectValueFunc[RPVariable](CreateRPVariableFromDiscriminatorValue, m.SetLocationRPVariable),
 	}
 }
 
 func (m *FieldMappingModel) GetContact() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*FieldMappingModel, *string](m, contactKey)
 }
-func (m *FieldMappingModel) setContact(val *string) error {
+func (m *FieldMappingModel) SetContact(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, contactKey, val)
 }
 func (m *FieldMappingModel) GetContactRPVariable() (RPVariable, error) {
 	return store.DefaultBackedModelAccessorFunc[*FieldMappingModel, RPVariable](m, contactRPVariableKey)
 }
-func (m *FieldMappingModel) setContactRPVariable(val RPVariable) error {
+func (m *FieldMappingModel) SetContactRPVariable(val RPVariable) error {
 	return store.DefaultBackedModelMutatorFunc(m, contactRPVariableKey, val)
 }
 func (m *FieldMappingModel) GetLocation() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*FieldMappingModel, *string](m, locationKey)
 }
-func (m *FieldMappingModel) setLocation(val *string) error {
+func (m *FieldMappingModel) SetLocation(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, locationKey, val)
 }
 func (m *FieldMappingModel) GetLocationRPVariable() (RPVariable, error) {
 	return store.DefaultBackedModelAccessorFunc[*FieldMappingModel, RPVariable](m, locationRPVariableKey)
 }
-func (m *FieldMappingModel) setLocationRPVariable(val RPVariable) error {
+func (m *FieldMappingModel) SetLocationRPVariable(val RPVariable) error {
 	return store.DefaultBackedModelMutatorFunc(m, locationRPVariableKey, val)
 }

--- a/appointmentbookingapi/models_extra_test.go
+++ b/appointmentbookingapi/models_extra_test.go
@@ -16,10 +16,10 @@ func TestAppointmentResultModel_GettersSetters(t *testing.T) {
 		getter func() (interface{}, error)
 		value  interface{}
 	}{
-		{"Data", func(v interface{}) error { return model.setData(v.(*string)) }, func() (interface{}, error) { return model.GetData() }, internal.ToPointer("val")},
-		{"Message", func(v interface{}) error { return model.setMessage(v.(*string)) }, func() (interface{}, error) { return model.GetMessage() }, internal.ToPointer("val")},
-		{"Reason", func(v interface{}) error { return model.setReason(v.(*string)) }, func() (interface{}, error) { return model.GetReason() }, internal.ToPointer("val")},
-		{"Success", func(v interface{}) error { return model.setSuccess(v.(*bool)) }, func() (interface{}, error) { return model.GetSuccess() }, internal.ToPointer(true)},
+		{"Data", func(v interface{}) error { return model.SetData(v.(*string)) }, func() (interface{}, error) { return model.GetData() }, internal.ToPointer("val")},
+		{"Message", func(v interface{}) error { return model.SetMessage(v.(*string)) }, func() (interface{}, error) { return model.GetMessage() }, internal.ToPointer("val")},
+		{"Reason", func(v interface{}) error { return model.SetReason(v.(*string)) }, func() (interface{}, error) { return model.GetReason() }, internal.ToPointer("val")},
+		{"Success", func(v interface{}) error { return model.SetSuccess(v.(*bool)) }, func() (interface{}, error) { return model.GetSuccess() }, internal.ToPointer(true)},
 	}
 
 	for _, tt := range tests {
@@ -48,9 +48,9 @@ func TestExecuteRuleConditionsRequestModel_GettersSetters(t *testing.T) {
 		getter func() (interface{}, error)
 		value  interface{}
 	}{
-		{"CatalogId", func(v interface{}) error { return model.setCatalogId(v.(*string)) }, func() (interface{}, error) { return model.GetCatalogId() }, internal.ToPointer("val")},
-		{"OtherInputs", func(v interface{}) error { return model.setOtherInputs(v) }, func() (interface{}, error) { return model.GetOtherInputs() }, "val"},
-		{"TaskId", func(v interface{}) error { return model.setTaskId(v.(*string)) }, func() (interface{}, error) { return model.GetTaskId() }, internal.ToPointer("val")},
+		{"CatalogId", func(v interface{}) error { return model.SetCatalogId(v.(*string)) }, func() (interface{}, error) { return model.GetCatalogId() }, internal.ToPointer("val")},
+		{"OtherInputs", func(v interface{}) error { return model.SetOtherInputs(v) }, func() (interface{}, error) { return model.GetOtherInputs() }, "val"},
+		{"TaskId", func(v interface{}) error { return model.SetTaskId(v.(*string)) }, func() (interface{}, error) { return model.GetTaskId() }, internal.ToPointer("val")},
 	}
 
 	for _, tt := range tests {
@@ -73,10 +73,10 @@ func TestExecuteRuleConditionsResultModel_GettersSetters(t *testing.T) {
 		getter func() (interface{}, error)
 		value  interface{}
 	}{
-		{"DedicatedCapacity", func(v interface{}) error { return model.setDedicatedCapacity(v.(*bool)) }, func() (interface{}, error) { return model.GetDedicatedCapacity() }, internal.ToPointer(true)},
-		{"FutureMaxBookableDays", func(v interface{}) error { return model.setFutureMaxBookableDays(v.(*string)) }, func() (interface{}, error) { return model.GetFutureMaxBookableDays() }, internal.ToPointer("val")},
-		{"RuleId", func(v interface{}) error { return model.setRuleId(v.(*string)) }, func() (interface{}, error) { return model.GetRuleId() }, internal.ToPointer("val")},
-		{"RuleName", func(v interface{}) error { return model.setRuleName(v.(*string)) }, func() (interface{}, error) { return model.GetRuleName() }, internal.ToPointer("val")},
+		{"DedicatedCapacity", func(v interface{}) error { return model.SetDedicatedCapacity(v.(*bool)) }, func() (interface{}, error) { return model.GetDedicatedCapacity() }, internal.ToPointer(true)},
+		{"FutureMaxBookableDays", func(v interface{}) error { return model.SetFutureMaxBookableDays(v.(*string)) }, func() (interface{}, error) { return model.GetFutureMaxBookableDays() }, internal.ToPointer("val")},
+		{"RuleId", func(v interface{}) error { return model.SetRuleId(v.(*string)) }, func() (interface{}, error) { return model.GetRuleId() }, internal.ToPointer("val")},
+		{"RuleName", func(v interface{}) error { return model.SetRuleName(v.(*string)) }, func() (interface{}, error) { return model.GetRuleName() }, internal.ToPointer("val")},
 	}
 
 	for _, tt := range tests {
@@ -99,13 +99,13 @@ func TestAvailabilityResultModel_GettersSetters(t *testing.T) {
 		getter func() (interface{}, error)
 		value  interface{}
 	}{
-		{"Availability", func(v interface{}) error { return model.setAvailability(v.([]AvailabilitySlot)) }, func() (interface{}, error) { return model.GetAvailability() }, []AvailabilitySlot{NewAvailabilitySlot()}},
-		{"HasMore", func(v interface{}) error { return model.setHasMore(v.(*bool)) }, func() (interface{}, error) { return model.GetHasMore() }, internal.ToPointer(true)},
-		{"NextAvailableSlot", func(v interface{}) error { return model.setNextAvailableSlot(v) }, func() (interface{}, error) { return model.GetNextAvailableSlot() }, "val"},
-		{"NoApptAvailable", func(v interface{}) error { return model.setNoApptAvailable(v.(*bool)) }, func() (interface{}, error) { return model.GetNoApptAvailable() }, internal.ToPointer(true)},
-		{"Success", func(v interface{}) error { return model.setSuccess(v.(*bool)) }, func() (interface{}, error) { return model.GetSuccess() }, internal.ToPointer(true)},
-		{"TimeZone", func(v interface{}) error { return model.setTimeZone(v.(*string)) }, func() (interface{}, error) { return model.GetTimeZone() }, internal.ToPointer("val")},
-		{"TimeZoneDisplayValue", func(v interface{}) error { return model.setTimeZoneDisplayValue(v.(*string)) }, func() (interface{}, error) { return model.GetTimeZoneDisplayValue() }, internal.ToPointer("val")},
+		{"Availability", func(v interface{}) error { return model.SetAvailability(v.([]AvailabilitySlot)) }, func() (interface{}, error) { return model.GetAvailability() }, []AvailabilitySlot{NewAvailabilitySlot()}},
+		{"HasMore", func(v interface{}) error { return model.SetHasMore(v.(*bool)) }, func() (interface{}, error) { return model.GetHasMore() }, internal.ToPointer(true)},
+		{"NextAvailableSlot", func(v interface{}) error { return model.SetNextAvailableSlot(v) }, func() (interface{}, error) { return model.GetNextAvailableSlot() }, "val"},
+		{"NoApptAvailable", func(v interface{}) error { return model.SetNoApptAvailable(v.(*bool)) }, func() (interface{}, error) { return model.GetNoApptAvailable() }, internal.ToPointer(true)},
+		{"Success", func(v interface{}) error { return model.SetSuccess(v.(*bool)) }, func() (interface{}, error) { return model.GetSuccess() }, internal.ToPointer(true)},
+		{"TimeZone", func(v interface{}) error { return model.SetTimeZone(v.(*string)) }, func() (interface{}, error) { return model.GetTimeZone() }, internal.ToPointer("val")},
+		{"TimeZoneDisplayValue", func(v interface{}) error { return model.SetTimeZoneDisplayValue(v.(*string)) }, func() (interface{}, error) { return model.GetTimeZoneDisplayValue() }, internal.ToPointer("val")},
 	}
 
 	for _, tt := range tests {

--- a/appointmentbookingapi/query_parameters.go
+++ b/appointmentbookingapi/query_parameters.go
@@ -2,8 +2,8 @@ package appointmentbookingapi
 
 // CalendarRequestBuilderGetQueryParameters represents the query parameters for GET /calendar.
 type CalendarRequestBuilderGetQueryParameters struct {
-	// CatalogId Sys_id of the record producer.
-	CatalogId *string `url:"catalog_id,omitempty"`
+	// CatalogID Sys_id of the record producer.
+	CatalogID *string `url:"catalog_id,omitempty"`
 	// Location Sys_id of the location.
 	Location *string `url:"location,omitempty"`
 	// OpenedFor Sys_id of the user.
@@ -12,6 +12,6 @@ type CalendarRequestBuilderGetQueryParameters struct {
 
 // ConfigurationRequestBuilderGetQueryParameters represents the query parameters for GET /configuration.
 type ConfigurationRequestBuilderGetQueryParameters struct {
-	// CatalogId Sys_id of the record producer.
-	CatalogId *string `url:"catalog_id,omitempty"`
+	// CatalogID Sys_id of the record producer.
+	CatalogID *string `url:"catalog_id,omitempty"`
 }

--- a/appointmentbookingapi/rp_variable.go
+++ b/appointmentbookingapi/rp_variable.go
@@ -15,11 +15,11 @@ type RPVariable interface {
 	kiotaStore.BackedModel
 
 	GetDisplayName() (*string, error)
-	setDisplayName(*string) error
+	SetDisplayName(*string) error
 	GetLabel() (*string, error)
-	setLabel(*string) error
+	SetLabel(*string) error
 	GetName() (*string, error)
-	setName(*string) error
+	SetName(*string) error
 }
 
 type RPVariableModel struct {
@@ -49,27 +49,27 @@ func (m *RPVariableModel) Serialize(writer serialization.SerializationWriter) er
 
 func (m *RPVariableModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		displayNameKey: internalSerialization.DeserializeStringFunc(m.setDisplayName),
-		labelKey:       internalSerialization.DeserializeStringFunc(m.setLabel),
-		nameKey:        internalSerialization.DeserializeStringFunc(m.setName),
+		displayNameKey: internalSerialization.DeserializeStringFunc(m.SetDisplayName),
+		labelKey:       internalSerialization.DeserializeStringFunc(m.SetLabel),
+		nameKey:        internalSerialization.DeserializeStringFunc(m.SetName),
 	}
 }
 
 func (m *RPVariableModel) GetDisplayName() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*RPVariableModel, *string](m, displayNameKey)
 }
-func (m *RPVariableModel) setDisplayName(val *string) error {
+func (m *RPVariableModel) SetDisplayName(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, displayNameKey, val)
 }
 func (m *RPVariableModel) GetLabel() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*RPVariableModel, *string](m, labelKey)
 }
-func (m *RPVariableModel) setLabel(val *string) error {
+func (m *RPVariableModel) SetLabel(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, labelKey, val)
 }
 func (m *RPVariableModel) GetName() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*RPVariableModel, *string](m, nameKey)
 }
-func (m *RPVariableModel) setName(val *string) error {
+func (m *RPVariableModel) SetName(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, nameKey, val)
 }

--- a/appointmentbookingapi/service_config.go
+++ b/appointmentbookingapi/service_config.go
@@ -15,35 +15,35 @@ type ServiceConfig interface {
 	kiotaStore.BackedModel
 
 	GetActive() (*bool, error)
-	setActive(*bool) error
+	SetActive(*bool) error
 	GetActiveString() (*string, error)
-	setActiveString(*string) error
+	SetActiveString(*string) error
 	GetAppointmentBookingConfig() (*string, error)
-	setAppointmentBookingConfig(*string) error
+	SetAppointmentBookingConfig(*string) error
 	GetAppointmentDuration() (*string, error)
-	setAppointmentDuration(*string) error
+	SetAppointmentDuration(*string) error
 	GetAppointmentsPerBookableSlot() (*string, error)
-	setAppointmentsPerBookableSlot(*string) error
+	SetAppointmentsPerBookableSlot(*string) error
 	GetBookableDays() (*string, error)
-	setBookableDays(*string) error
+	SetBookableDays(*string) error
 	GetCancelByTime() (*string, error)
-	setCancelByTime(*string) error
+	SetCancelByTime(*string) error
 	GetDefaultTimezone() (*string, error)
-	setDefaultTimezone(*string) error
+	SetDefaultTimezone(*string) error
 	GetEnableAdvancedConfig() (*bool, error)
-	setEnableAdvancedConfig(*bool) error
+	SetEnableAdvancedConfig(*bool) error
 	GetFieldMapping() (FieldMapping, error)
-	setFieldMapping(FieldMapping) error
+	SetFieldMapping(FieldMapping) error
 	GetFutureBookableMaxDays() (*string, error)
-	setFutureBookableMaxDays(*string) error
+	SetFutureBookableMaxDays(*string) error
 	GetLeadTime() (*string, error)
-	setLeadTime(*string) error
+	SetLeadTime(*string) error
 	GetMandatory() (*string, error)
-	setMandatory(*string) error
+	SetMandatory(*string) error
 	GetUseSlotEndTimeAs() (*string, error)
-	setUseSlotEndTimeAs(*string) error
+	SetUseSlotEndTimeAs(*string) error
 	GetWorkDuration() (*string, error)
-	setWorkDuration(*string) error
+	SetWorkDuration(*string) error
 }
 
 type ServiceConfigModel struct {
@@ -85,111 +85,111 @@ func (m *ServiceConfigModel) Serialize(writer serialization.SerializationWriter)
 
 func (m *ServiceConfigModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		activeKey:                      internalSerialization.DeserializeBoolFunc(m.setActive),
-		activeStringKey:                internalSerialization.DeserializeStringFunc(m.setActiveString),
-		appointmentBookingConfigKey:    internalSerialization.DeserializeStringFunc(m.setAppointmentBookingConfig),
-		appointmentDurationKey:         internalSerialization.DeserializeStringFunc(m.setAppointmentDuration),
-		appointmentsPerBookableSlotKey: internalSerialization.DeserializeStringFunc(m.setAppointmentsPerBookableSlot),
-		bookableDaysKey:                internalSerialization.DeserializeStringFunc(m.setBookableDays),
-		cancelByTimeKey:                internalSerialization.DeserializeStringFunc(m.setCancelByTime),
-		defaultTimezoneKey:             internalSerialization.DeserializeStringFunc(m.setDefaultTimezone),
-		enableAdvancedConfigKey:        internalSerialization.DeserializeBoolFunc(m.setEnableAdvancedConfig),
-		fieldMappingKey:                internalSerialization.DeserializeObjectValueFunc[FieldMapping](CreateFieldMappingFromDiscriminatorValue, m.setFieldMapping),
-		futureBookableMaxDaysKey:       internalSerialization.DeserializeStringFunc(m.setFutureBookableMaxDays),
-		leadTimeKey:                    internalSerialization.DeserializeStringFunc(m.setLeadTime),
-		mandatoryKey:                   internalSerialization.DeserializeStringFunc(m.setMandatory),
-		useSlotEndTimeAsKey:            internalSerialization.DeserializeStringFunc(m.setUseSlotEndTimeAs),
-		workDurationKey:                internalSerialization.DeserializeStringFunc(m.setWorkDuration),
+		activeKey:                      internalSerialization.DeserializeBoolFunc(m.SetActive),
+		activeStringKey:                internalSerialization.DeserializeStringFunc(m.SetActiveString),
+		appointmentBookingConfigKey:    internalSerialization.DeserializeStringFunc(m.SetAppointmentBookingConfig),
+		appointmentDurationKey:         internalSerialization.DeserializeStringFunc(m.SetAppointmentDuration),
+		appointmentsPerBookableSlotKey: internalSerialization.DeserializeStringFunc(m.SetAppointmentsPerBookableSlot),
+		bookableDaysKey:                internalSerialization.DeserializeStringFunc(m.SetBookableDays),
+		cancelByTimeKey:                internalSerialization.DeserializeStringFunc(m.SetCancelByTime),
+		defaultTimezoneKey:             internalSerialization.DeserializeStringFunc(m.SetDefaultTimezone),
+		enableAdvancedConfigKey:        internalSerialization.DeserializeBoolFunc(m.SetEnableAdvancedConfig),
+		fieldMappingKey:                internalSerialization.DeserializeObjectValueFunc(CreateFieldMappingFromDiscriminatorValue, m.SetFieldMapping),
+		futureBookableMaxDaysKey:       internalSerialization.DeserializeStringFunc(m.SetFutureBookableMaxDays),
+		leadTimeKey:                    internalSerialization.DeserializeStringFunc(m.SetLeadTime),
+		mandatoryKey:                   internalSerialization.DeserializeStringFunc(m.SetMandatory),
+		useSlotEndTimeAsKey:            internalSerialization.DeserializeStringFunc(m.SetUseSlotEndTimeAs),
+		workDurationKey:                internalSerialization.DeserializeStringFunc(m.SetWorkDuration),
 	}
 }
 
 func (m *ServiceConfigModel) GetActive() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *bool](m, activeKey)
 }
-func (m *ServiceConfigModel) setActive(val *bool) error {
+func (m *ServiceConfigModel) SetActive(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, activeKey, val)
 }
 func (m *ServiceConfigModel) GetActiveString() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, activeStringKey)
 }
-func (m *ServiceConfigModel) setActiveString(val *string) error {
+func (m *ServiceConfigModel) SetActiveString(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, activeStringKey, val)
 }
 func (m *ServiceConfigModel) GetAppointmentBookingConfig() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, appointmentBookingConfigKey)
 }
-func (m *ServiceConfigModel) setAppointmentBookingConfig(val *string) error {
+func (m *ServiceConfigModel) SetAppointmentBookingConfig(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, appointmentBookingConfigKey, val)
 }
 func (m *ServiceConfigModel) GetAppointmentDuration() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, appointmentDurationKey)
 }
-func (m *ServiceConfigModel) setAppointmentDuration(val *string) error {
+func (m *ServiceConfigModel) SetAppointmentDuration(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, appointmentDurationKey, val)
 }
 func (m *ServiceConfigModel) GetAppointmentsPerBookableSlot() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, appointmentsPerBookableSlotKey)
 }
-func (m *ServiceConfigModel) setAppointmentsPerBookableSlot(val *string) error {
+func (m *ServiceConfigModel) SetAppointmentsPerBookableSlot(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, appointmentsPerBookableSlotKey, val)
 }
 func (m *ServiceConfigModel) GetBookableDays() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, bookableDaysKey)
 }
-func (m *ServiceConfigModel) setBookableDays(val *string) error {
+func (m *ServiceConfigModel) SetBookableDays(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, bookableDaysKey, val)
 }
 func (m *ServiceConfigModel) GetCancelByTime() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, cancelByTimeKey)
 }
-func (m *ServiceConfigModel) setCancelByTime(val *string) error {
+func (m *ServiceConfigModel) SetCancelByTime(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, cancelByTimeKey, val)
 }
 func (m *ServiceConfigModel) GetDefaultTimezone() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, defaultTimezoneKey)
 }
-func (m *ServiceConfigModel) setDefaultTimezone(val *string) error {
+func (m *ServiceConfigModel) SetDefaultTimezone(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, defaultTimezoneKey, val)
 }
 func (m *ServiceConfigModel) GetEnableAdvancedConfig() (*bool, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *bool](m, enableAdvancedConfigKey)
 }
-func (m *ServiceConfigModel) setEnableAdvancedConfig(val *bool) error {
+func (m *ServiceConfigModel) SetEnableAdvancedConfig(val *bool) error {
 	return store.DefaultBackedModelMutatorFunc(m, enableAdvancedConfigKey, val)
 }
 func (m *ServiceConfigModel) GetFieldMapping() (FieldMapping, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, FieldMapping](m, fieldMappingKey)
 }
-func (m *ServiceConfigModel) setFieldMapping(val FieldMapping) error {
+func (m *ServiceConfigModel) SetFieldMapping(val FieldMapping) error {
 	return store.DefaultBackedModelMutatorFunc(m, fieldMappingKey, val)
 }
 func (m *ServiceConfigModel) GetFutureBookableMaxDays() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, futureBookableMaxDaysKey)
 }
-func (m *ServiceConfigModel) setFutureBookableMaxDays(val *string) error {
+func (m *ServiceConfigModel) SetFutureBookableMaxDays(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, futureBookableMaxDaysKey, val)
 }
 func (m *ServiceConfigModel) GetLeadTime() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, leadTimeKey)
 }
-func (m *ServiceConfigModel) setLeadTime(val *string) error {
+func (m *ServiceConfigModel) SetLeadTime(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, leadTimeKey, val)
 }
 func (m *ServiceConfigModel) GetMandatory() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, mandatoryKey)
 }
-func (m *ServiceConfigModel) setMandatory(val *string) error {
+func (m *ServiceConfigModel) SetMandatory(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, mandatoryKey, val)
 }
 func (m *ServiceConfigModel) GetUseSlotEndTimeAs() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, useSlotEndTimeAsKey)
 }
-func (m *ServiceConfigModel) setUseSlotEndTimeAs(val *string) error {
+func (m *ServiceConfigModel) SetUseSlotEndTimeAs(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, useSlotEndTimeAsKey, val)
 }
 func (m *ServiceConfigModel) GetWorkDuration() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*ServiceConfigModel, *string](m, workDurationKey)
 }
-func (m *ServiceConfigModel) setWorkDuration(val *string) error {
+func (m *ServiceConfigModel) SetWorkDuration(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, workDurationKey, val)
 }

--- a/appointmentbookingapi/sub_request_builders.go
+++ b/appointmentbookingapi/sub_request_builders.go
@@ -2,6 +2,7 @@ package appointmentbookingapi
 
 import (
 	"context"
+
 	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -81,7 +82,7 @@ func NewCalendarRequestBuilder(pathParameters map[string]string, requestAdapter 
 }
 
 // Get sends a GET request to retrieve calendar.
-func (rB *CalendarRequestBuilder) Get(ctx context.Context, config *CalendarRequestBuilderGetRequestConfiguration) (CalendarResponse, error) {
+func (rB *CalendarRequestBuilder) Get(ctx context.Context, config *CalendarRequestBuilderGetRequestConfiguration) (*CalendarResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
@@ -100,7 +101,7 @@ func (rB *CalendarRequestBuilder) Get(ctx context.Context, config *CalendarReque
 		return nil, nil
 	}
 
-	return res.(CalendarResponse), nil
+	return res.(*CalendarResponse), nil
 }
 
 // ToGetRequestInformation creates a RequestInformation object for a GET request.

--- a/appointmentbookingapi/user_time_format.go
+++ b/appointmentbookingapi/user_time_format.go
@@ -15,9 +15,9 @@ type UserTimeFormat interface {
 	kiotaStore.BackedModel
 
 	GetType() (*string, error)
-	setType(*string) error
+	SetType(*string) error
 	GetValue() (*string, error)
-	setValue(*string) error
+	SetValue(*string) error
 }
 
 type UserTimeFormatModel struct {
@@ -46,20 +46,20 @@ func (m *UserTimeFormatModel) Serialize(writer serialization.SerializationWriter
 
 func (m *UserTimeFormatModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		typeKey:  internalSerialization.DeserializeStringFunc(m.setType),
-		valueKey: internalSerialization.DeserializeStringFunc(m.setValue),
+		typeKey:  internalSerialization.DeserializeStringFunc(m.SetType),
+		valueKey: internalSerialization.DeserializeStringFunc(m.SetValue),
 	}
 }
 
 func (m *UserTimeFormatModel) GetType() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserTimeFormatModel, *string](m, typeKey)
 }
-func (m *UserTimeFormatModel) setType(val *string) error {
+func (m *UserTimeFormatModel) SetType(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, typeKey, val)
 }
 func (m *UserTimeFormatModel) GetValue() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserTimeFormatModel, *string](m, valueKey)
 }
-func (m *UserTimeFormatModel) setValue(val *string) error {
+func (m *UserTimeFormatModel) SetValue(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, valueKey, val)
 }

--- a/appointmentbookingapi/user_time_format_options.go
+++ b/appointmentbookingapi/user_time_format_options.go
@@ -15,11 +15,11 @@ type UserTimeFormatOptions interface {
 	kiotaStore.BackedModel
 
 	GetHour() (*string, error)
-	setHour(*string) error
+	SetHour(*string) error
 	GetHourCycle() (*string, error)
-	setHourCycle(*string) error
+	SetHourCycle(*string) error
 	GetMinute() (*string, error)
-	setMinute(*string) error
+	SetMinute(*string) error
 }
 
 type UserTimeFormatOptionsModel struct {
@@ -49,27 +49,27 @@ func (m *UserTimeFormatOptionsModel) Serialize(writer serialization.Serializatio
 
 func (m *UserTimeFormatOptionsModel) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		hourKey:      internalSerialization.DeserializeStringFunc(m.setHour),
-		hourCycleKey: internalSerialization.DeserializeStringFunc(m.setHourCycle),
-		minuteKey:    internalSerialization.DeserializeStringFunc(m.setMinute),
+		hourKey:      internalSerialization.DeserializeStringFunc(m.SetHour),
+		hourCycleKey: internalSerialization.DeserializeStringFunc(m.SetHourCycle),
+		minuteKey:    internalSerialization.DeserializeStringFunc(m.SetMinute),
 	}
 }
 
 func (m *UserTimeFormatOptionsModel) GetHour() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserTimeFormatOptionsModel, *string](m, hourKey)
 }
-func (m *UserTimeFormatOptionsModel) setHour(val *string) error {
+func (m *UserTimeFormatOptionsModel) SetHour(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, hourKey, val)
 }
 func (m *UserTimeFormatOptionsModel) GetHourCycle() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserTimeFormatOptionsModel, *string](m, hourCycleKey)
 }
-func (m *UserTimeFormatOptionsModel) setHourCycle(val *string) error {
+func (m *UserTimeFormatOptionsModel) SetHourCycle(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, hourCycleKey, val)
 }
 func (m *UserTimeFormatOptionsModel) GetMinute() (*string, error) {
 	return store.DefaultBackedModelAccessorFunc[*UserTimeFormatOptionsModel, *string](m, minuteKey)
 }
-func (m *UserTimeFormatOptionsModel) setMinute(val *string) error {
+func (m *UserTimeFormatOptionsModel) SetMinute(val *string) error {
 	return store.DefaultBackedModelMutatorFunc(m, minuteKey, val)
 }

--- a/website/snippets/modules.go
+++ b/website/snippets/modules.go
@@ -82,19 +82,32 @@ func moduleActSub() {
 
 func moduleAppointmentBooking() {
 	var client *servicenowsdkgo.ServiceNowServiceClient
-	var availabilityRequest *appointmentbookingapi.AvailabilityRequestModel
-	var appointmentRequest *appointmentbookingapi.AppointmentRequestModel
+	var catalogID, startDate, endDate string
 
 	// [START module_appointment_booking]
 	booking := client.AppointmentBooking()
 
 	// Check availability
+	availabilityRequest := appointmentbookingapi.NewAvailabilityRequest()
+	if err := availabilityRequest.SetCatalogId(&catalogID); err != nil {
+		log.Fatal(err)
+	}
+	if err := availabilityRequest.SetStartDate(&startDate); err != nil {
+		log.Fatal(err)
+	}
+	if err := availabilityRequest.SetEndDate(&endDate); err != nil {
+		log.Fatal(err)
+	}
 	availability, err := booking.Availability().Post(context.Background(), availabilityRequest, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Book an appointment
+	appointmentRequest := appointmentbookingapi.NewAppointmentRequest()
+	if err := appointmentRequest.SetCatalogId(&catalogID); err != nil {
+		log.Fatal(err)
+	}
 	appointment, err := booking.Appointment().Post(context.Background(), appointmentRequest, nil)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Summary
- The three POST-body models (`AvailabilityRequestModel`, `AppointmentRequestModel`, `ExecuteRuleConditionsRequestModel`) only had unexported setters, making the module's write-side endpoints unusable (closes #488).
- Setters are exported across all the package's models — matching `policyapi`'s convention and completing the in-progress rename already present in the working tree (e.g. `service_config.go`).
- The docs snippet now constructs a real request via `NewAvailabilityRequest()` + setters instead of sidestepping construction with a nil `var`.

## Test plan
- `go build ./...`, `go test ./appointmentbookingapi/...`, full `go test ./...` — all green
- `golangci-lint run ./appointmentbookingapi/...` — 0 issues
- `go vet -tags snippets ./website/snippets/` passes (this was the original repro from #488)

🤖 Generated with [Claude Code](https://claude.com/claude-code)