### PR TITLE
docs(adr): record five more v2.0 architectural decisions

### DIFF
--- a/.claude/skills/design-decisions/SKILL.md
+++ b/.claude/skills/design-decisions/SKILL.md
@@ -7,17 +7,25 @@ description: >
   or writing it fully from scratch (ADR 003), storing model properties in a
   Kiota BackingStore instead of plain struct fields so "absent" and "zero"
   stay distinguishable (ADR 002), and standardizing error sentinels/messaging
-  across the three separate error-sentinel locations (ADR 001). Consult this
-  BEFORE proposing or making changes to the request-builder/model
-  architecture, error handling conventions, or anything that would make this
-  SDK diverge from Kiota-generated SDK conventions (e.g. msgraph-sdk-go) --
-  these are not accidents or defaults, they were chosen over real
-  alternatives for stated reasons, and changing them without knowing why
-  risks silently undoing a considered trade-off. Also consult it before
-  answering any "why does this repo do X" / "why not just do Y instead"
-  question. Use it proactively even when not asked explicitly -- e.g. before
-  suggesting plain-struct models, a generated-from-OpenAPI client, or a
-  bespoke error type instead of the shared sentinels.
+  across the three separate error-sentinel locations (ADR 001). Also covers
+  the v2.0-era conventions: pointer-typed query parameters wired through
+  vanilla Kiota request-configuration (ADR 004), one generic core.PageIterator
+  instead of per-module wrappers (ADR 005), nil-receiver guards returning a
+  shared sentinel error instead of (nil, nil) (ADR 006), never scaffolding a
+  builder chain ahead of an implemented operation (ADR 007), and package/
+  symbol/URL names as independent naming axes (ADR 008). Consult this BEFORE
+  proposing or making changes to the request-builder/model architecture,
+  error handling conventions, pagination, nil-guard behavior, module naming,
+  or anything that would make this SDK diverge from Kiota-generated SDK
+  conventions (e.g. msgraph-sdk-go) -- these are not accidents or defaults,
+  they were chosen over real alternatives for stated reasons, and changing
+  them without knowing why risks silently undoing a considered trade-off.
+  Also consult it before answering any "why does this repo do X" / "why not
+  just do Y instead" question. Use it proactively even when not asked
+  explicitly -- e.g. before suggesting plain-struct models, a
+  generated-from-OpenAPI client, a per-module page-iterator wrapper, a bare
+  (nil, nil) nil-guard return, or a bespoke error type instead of the shared
+  sentinels.
 ---
 
 # Design decisions
@@ -31,8 +39,8 @@ top-level docs turns them into a decision log nobody can navigate, and
 duplicating the same reasoning in two places means it drifts out of sync the
 first time only one copy gets updated.
 
-There is no index file or template in `docs/adr/` yet — it's three files,
-numbered `001-`, `002-`, `003-` (three digits, not four). Read them directly:
+There is no index file or template in `docs/adr/` yet — it's eight files,
+numbered `001-` through `008-` (three digits, not four). Read them directly:
 
 1. [`001-error-standardization.md`](../../../docs/adr/001-error-standardization.md)
    — centralizes sentinel errors and message phrasing in the `/errors`
@@ -60,6 +68,31 @@ numbered `001-`, `002-`, `003-` (three digits, not four). Read them directly:
    this SDK looks hand-rolled and slightly different from upstream Kiota
    conventions — the divergence is either a considered ADR-003 trade-off or
    drift worth fixing, not a free design choice.
+4. [`004-vanilla-kiota-request-configuration.md`](../../../docs/adr/004-vanilla-kiota-request-configuration.md)
+   — every `*QueryParameters` struct uses pointer fields with
+   `uriparametername` tags through `abstractions.ConfigureRequestInformation`,
+   replacing a bespoke go-querystring wrapper, to match msgraph-sdk-go and let
+   "unset" and "zero" stay distinguishable. Sharp edge: new integer query
+   params must be `*int32`, not `*int` — the native encoder silently drops a
+   bare `*int`.
+5. [`005-generic-page-iterator-only.md`](../../../docs/adr/005-generic-page-iterator-only.md)
+   — `core.NewPageIterator[T]` is the one documented pagination pattern;
+   per-module wrapper constructors (the old `tableapi`/`attachmentapi` ones)
+   were removed and shouldn't be re-added for new modules, even for symmetry.
+6. [`006-nil-receiver-sentinel-error.md`](../../../docs/adr/006-nil-receiver-sentinel-error.md)
+   — nil-receiver guards on verb methods return `snerrors.ErrNilRequestBuilder`,
+   never a bare `(nil, nil)`/`nil`, so a nil builder fails loud at the call
+   site instead of silently succeeding. Enforced by the
+   `api-module-consistency-reviewer` agent and `new-api-module` skill.
+7. [`007-no-speculative-builder-chains.md`](../../../docs/adr/007-no-speculative-builder-chains.md)
+   — don't add a request-builder accessor for a URL segment until the
+   operation(s) behind it are actually implemented; a navigable chain with no
+   working verb method is worse than not having the chain at all.
+8. [`008-package-symbol-url-naming-independence.md`](../../../docs/adr/008-package-symbol-url-naming-independence.md)
+   — package names, exported symbol names, and accessor/URL-segment names are
+   independent naming axes (see `aggregationapi` package vs. `Stats*` types vs.
+   `Now().Stats()`); an inconsistency in one doesn't mean the other two need to
+   change too.
 
 Before touching an area covered by an ADR, or answering a "why"/"should we
 change this" question:

--- a/docs/adr/004-vanilla-kiota-request-configuration.md
+++ b/docs/adr/004-vanilla-kiota-request-configuration.md
@@ -1,0 +1,65 @@
+# ADR 004: Vanilla Kiota request-configuration pattern for query parameters
+
+## Status
+
+Accepted
+
+## Context
+
+Every API module exposes a `*QueryParameters` struct per verb (e.g.
+`TableRequestBuilderGetQueryParameters`) that gets applied to the outgoing
+request. Historically these used plain value fields (`Limit int`,
+`Query string`, `DisplayValue DisplayValue`) and were encoded onto the
+request via a repo-specific `internal.ConfigureRequestInformation` /
+`internal.KiotaRequestInformation` wrapper built on the `go-querystring`
+library.
+
+This diverged from how Kiota-generated SDKs (e.g. msgraph-sdk-go) shape query
+parameters, and the divergence had a real cost: value fields can't represent
+"the caller didn't set this" separately from "the caller explicitly set the
+zero value," so `go-querystring` either always emitted a field or needed
+extra `omitempty`-style conventions layered on top to approximate what
+`abstractions.RequestInformation.AddQueryParameters` gives you for free with
+nil-checkable pointers.
+
+Alternatives considered:
+
+1. **Keep the value-typed structs and the go-querystring wrapper** — rejected
+   because it's the thing ADR-003 already argues against: reinventing a
+   Kiota runtime capability (`AddQueryParameters`) that ships for free, and
+   it keeps the SDK's query-parameter shape looking different from every
+   Kiota-generated SDK a caller might already know.
+2. **Pointer fields wired through `abstractions.ConfigureRequestInformation`
+   directly** — matches msgraph-sdk-go's convention exactly and removes a
+   dependency.
+
+A timeboxed spike (#494) was run specifically to classify this as breaking
+vs. additive before the v2.0 cut, since it could not land after the tag
+without becoming a v3 change.
+
+## Decision
+
+Every exported `*QueryParameters` struct across every API module uses pointer
+fields with `uriparametername` tags (`Limit *int32`, `Query *string`,
+`DisplayValue *DisplayValue`, etc.), and request builders call
+`abstractions.ConfigureRequestInformation` directly instead of a bespoke
+wrapper. The `internal.ConfigureRequestInformation` / `internal.KiotaRequestInformation`
+wrapper and the `go-querystring` dependency are removed entirely (#511).
+
+A non-obvious constraint this decision carries: the native encoder only
+recognizes `*int32` explicitly — a bare `*int` (even as a pointer) is
+silently dropped from the request. Any new integer query parameter must be
+declared as `*int32`, not `*int`, or it will vanish without error.
+
+## Consequences
+
+- **Pros:** query-parameter structs now look and behave like every other
+  Kiota-generated SDK's `*QueryParameters`; "unset" and "zero" are
+  distinguishable the same way ADR-002 already made models' properties
+  distinguishable; one fewer third-party dependency.
+- **Cons:** breaking for every caller constructing these structs with value
+  literals — they must switch to pointers (see `internal.ToPointer`).
+  Landed as a breaking v2.0 change specifically because it could not wait
+  for v3.
+- **Sharp edge to guard in review:** a new `*int` query-parameter field is a
+  silent bug, not a compile error — it must be `*int32`.

--- a/docs/adr/005-generic-page-iterator-only.md
+++ b/docs/adr/005-generic-page-iterator-only.md
@@ -1,0 +1,51 @@
+# ADR 005: One generic `core.PageIterator`, no per-module wrappers
+
+## Status
+
+Accepted
+
+## Context
+
+`tableapi` and `attachmentapi` each shipped their own one-line pagination
+entry point (`tableapi.NewTablePageIterator`, `tableapi.NewDefaultTablePageIterator`,
+`attachmentapi.NewAttachmentPageIterator`) that did nothing but pre-bind the
+module's `Create...FromDiscriminatorValue` factory to the generic
+`core.NewPageIterator[T]`. No other collection-bearing module had one, so the
+SDK had three ways to spell the same operation depending on which module you
+were in (#490).
+
+Alternatives considered:
+
+1. **Give every collection-bearing module its own wrapper** — rejected.
+   `core.PageIterator` follows response `Link` headers, and not every
+   ServiceNow collection endpoint emits them; a `NewDefault<X>PageIterator`
+   for every module would advertise pagination an endpoint may not actually
+   support. It also means auditing and maintaining N near-identical
+   constructors forever, and the wrappers only help the default record type
+   anyway — a caller using a custom type already passes a factory, at which
+   point the wrapper saves nothing.
+2. **Generic-only** — msgraph-sdk-go-core exposes exactly one generic
+   `PageIterator`; no generated per-module wrappers. Callers arriving from
+   other Kiota SDKs already know this shape (ADR-003's tie-breaker rule).
+
+## Decision
+
+Remove the three module-specific wrappers. `core.NewPageIterator[T]` is the
+single, only documented pagination pattern:
+
+```go
+iterator, err := core.NewPageIterator(response, client.GetRequestAdapter(),
+    tableapi.CreateTableRecordFromDiscriminatorValue)
+```
+
+## Consequences
+
+- **Pros:** one pattern to teach, document, and review, regardless of
+  module; no risk of a wrapper implying pagination support an endpoint
+  doesn't have.
+- **Cons:** breaking removal of the three wrapper constructors — callers
+  must migrate to the generic call. Landed pre-v2.0 for that reason.
+- **Rule for new modules:** do not add a `New<X>PageIterator` wrapper for a
+  new API module, even for symmetry with `tableapi`'s old shape — that
+  shape was removed deliberately, not left behind by omission. Document
+  per-endpoint whether it actually emits `Link` headers instead.

--- a/docs/adr/006-nil-receiver-sentinel-error.md
+++ b/docs/adr/006-nil-receiver-sentinel-error.md
@@ -1,0 +1,57 @@
+# ADR 006: Nil-receiver guards return a sentinel error, never `(nil, nil)`
+
+## Status
+
+Accepted
+
+## Context
+
+Every request-builder verb method (`Get`/`Post`/`Patch`/`Put`/`Delete`)
+starts with a nil-receiver guard (see `CLAUDE.md`'s constructor-triad
+section). Historically these guards returned `return nil, nil` — no result
+and no error — when the receiver or its embedded `RequestBuilder` was nil.
+`Delete`/`Patch` variants that only return an error swallowed the problem
+entirely with a bare `return nil`.
+
+This meant a caller holding a nil builder (e.g. from a failed prior chain
+step) saw silent success and only failed later, at a point in the code far
+from the actual mistake, with no error to grep for or wrap.
+
+Alternatives considered:
+
+1. **Leave `(nil, nil)` / bare `nil`** — rejected; it's a silent-failure
+   trap that pushes the debugging cost onto whoever hits the downstream
+   symptom.
+2. **A new, verb-specific error per package** — rejected; it would multiply
+   the "three separate error-sentinel locations" problem CLAUDE.md already
+   warns about, and give every module its own wording for the same failure.
+3. **One shared sentinel in `errors/errors.go`**, returned by every guard
+   across every module — matches ADR-001's centralization principle and
+   lets callers use `errors.Is` uniformly regardless of which module or verb
+   they called.
+
+## Decision
+
+Added `snerrors.ErrNilRequestBuilder` to `errors/errors.go`. Every
+nil-receiver guard across every `*api` package, `core.BaseRequestBuilder`
+setters, and the generic `appserviceapi` post builder now returns this
+sentinel (or the package's zero value + sentinel for single-error-return
+verbs) instead of `(nil, nil)` / bare `nil`.
+
+Navigation methods that return a bare `*Builder` (no error), and
+nil-response/null-element semantics elsewhere (`res == nil`,
+`ElementValue.IsNil`), are unchanged — this decision is scoped to
+verb-method nil-*receiver* guards specifically, not every nil check in the
+codebase.
+
+## Consequences
+
+- **Pros:** a nil builder now fails loudly and immediately, at the call
+  site, with an error identity (`errors.Is(err, snerrors.ErrNilRequestBuilder)`)
+  every caller can check the same way regardless of module.
+- **Cons:** breaking — any caller relying on `(nil, nil)` as a success-shaped
+  no-op must be updated to handle the returned error.
+- **Enforced by:** the `api-module-consistency-reviewer` agent and the
+  `new-api-module` skill both check for this pattern; a new module's guard
+  that returns bare `nil`/`(nil, nil)` instead of the sentinel is a
+  consistency-review finding, not a style nit.

--- a/docs/adr/007-no-speculative-builder-chains.md
+++ b/docs/adr/007-no-speculative-builder-chains.md
@@ -1,0 +1,50 @@
+# ADR 007: Don't scaffold a builder chain ahead of an implemented operation
+
+## Status
+
+Accepted
+
+## Context
+
+`Cdm().Policies().Mappings().Inputs().Resolved()` could be constructed —
+both `Inputs()` and `Resolved()` existed as request-builder accessors — but
+neither had a verb method (`Get`/`Post`/etc.) or a `To*RequestInformation`
+method. The resolved-inputs endpoint was advertised in the fluent chain and
+in docs/snippets, but was actually unreachable: calling it did nothing,
+because there was nothing to call. `Inputs()` itself existed only as a
+stepping stone to reach `Resolved()` (#489).
+
+Alternatives considered:
+
+1. **Implement the missing verb method(s) to make the chain functional** —
+   rejected for this PR specifically because the endpoint's actual behavior
+   wasn't yet scoped; forcing an implementation just to match the existing
+   (accidental) shape risked guessing at the wrong contract.
+2. **Leave the dead-end chain in place as a documented "coming soon"** —
+   rejected; an SDK builder chain that compiles and can be navigated but
+   silently does nothing on every verb is worse than a compile error, and
+   contradicts the nil-receiver-guard principle in ADR-006 of failing loud
+   and early rather than silently.
+3. **Remove the dead-end chain entirely** (`Inputs()`/`Resolved()` and their
+   builder types, 177 lines) until the endpoint is implemented additively.
+
+## Decision
+
+Remove builder-chain segments that have no reachable verb operation, rather
+than leaving them in place as a stub. A request-builder accessor should only
+exist once the operation(s) it leads to are actually implemented — not
+speculatively, to reserve a URL segment or match an API's documented shape
+in advance.
+
+## Consequences
+
+- **Pros:** every reachable point in a fluent chain does something; a
+  builder existing is a reliable signal that its operations work, matching
+  the "fail loud" spirit of ADR-006 rather than silently advertising
+  unreachable surface area.
+- **Cons:** breaking removal for anyone who had already started depending on
+  the chain shape (even though no verb ever worked). Re-adding the
+  Inputs/Resolved endpoint later is an additive change, not a revert.
+- **Rule for new modules and reviews:** don't scaffold a full URL-segment
+  chain "for completeness" ahead of the operation being implemented. Add the
+  builder when the verb method(s) it exposes are ready to ship together.

--- a/docs/adr/008-package-symbol-url-naming-independence.md
+++ b/docs/adr/008-package-symbol-url-naming-independence.md
@@ -1,0 +1,55 @@
+# ADR 008: Package names, exported symbol names, and URL segments are independent naming axes
+
+## Status
+
+Accepted
+
+## Context
+
+The module behind ServiceNow's `/api/now/stats` endpoint was implemented as
+package `statsapi`. ServiceNow's own documentation calls this the
+**Aggregate API**, and the SDK's docs site already labeled the module
+"Aggregation" — the package name (`statsapi`) was the one remaining place
+still using the old name, creating a naming inconsistency between the code,
+the docs, and ServiceNow's own terminology (#491, #505).
+
+The naive fix — rename everything, package and symbols and accessor alike,
+to `aggregation*` — would have been a larger and less-justified break: the
+exported `Stats*` type names mirror the actual wire format (ServiceNow's
+JSON response shape uses `stats`), and the `Now().Stats()` accessor mirrors
+the literal URL segment (`/api/now/stats`). Neither of those has anything to
+do with what the *package* should be called for discoverability.
+
+Alternatives considered:
+
+1. **Rename nothing, live with the inconsistency** — rejected; a
+   contributor searching ServiceNow's docs for "Aggregate API" would not
+   find `statsapi` by name.
+2. **Rename everything (package, types, accessor) to `aggregation*`** —
+   rejected; it would break the correspondence between `Stats*` types and
+   the actual `stats` wire field, and between `.Stats()` and the actual URL
+   segment — changes with no real justification, made only for superficial
+   uniformity.
+3. **Rename only the package** (`statsapi` → `aggregationapi`), keep
+   `Stats*` symbol names and the `Now().Stats()` accessor as-is.
+
+## Decision
+
+Package names follow ServiceNow's official name for the API surface.
+Exported symbol names follow the actual wire format. Accessor method names
+follow the literal URL segment. These three do not have to agree with each
+other, and a naming inconsistency in one axis doesn't imply the other two
+are wrong.
+
+## Consequences
+
+- **Pros:** the package is discoverable under ServiceNow's official
+  terminology; `Stats*` types and `.Stats()` still read correctly against
+  the actual JSON payload and URL a reader sees on the wire.
+- **Cons:** breaking for import paths
+  (`github.com/.../statsapi` → `github.com/.../aggregationapi`); mildly
+  surprising on first read that `aggregationapi.StatsResponse` isn't a typo.
+- **Rule for future renames:** when a module's name diverges from
+  ServiceNow's official naming, check independently whether the package
+  name, the symbol names, and the accessor/URL segment each need to change
+  — don't assume a rename must be all-or-nothing across all three.


### PR DESCRIPTION
## Summary
- Adds ADRs 004-008 to `docs/adr/`, capturing decisions already made in the release/2.0 history (PRs #511, #508, #506/#507, #505, #487) that weren't yet recorded: vanilla Kiota request-configuration for query parameters, generic-only `core.PageIterator`, nil-receiver guards returning a shared sentinel error, no speculative builder chains, and package/symbol/URL naming independence.
- Updates the `design-decisions` skill's frontmatter and body to index all eight ADRs.

## Test plan
- Docs-only change; no build/test impact.