### PR TITLE
fix: guard ServicenowError.Error against nil main error and detail

### DIFF
--- a/internal/new/service_now_error.go
+++ b/internal/new/service_now_error.go
@@ -68,10 +68,16 @@ func (exc *ServicenowError) setError(mainError MainErrorable) error {
 
 func (exc *ServicenowError) Error() string {
 	mainErr, _ := exc.GetError()
+	if IsNil(mainErr) {
+		return "unknown service-now error"
+	}
 	msg, _ := mainErr.GetMessage()
 	if msg != nil {
 		return *msg
 	}
 	details, _ := mainErr.GetDetail()
-	return *details
+	if details != nil {
+		return *details
+	}
+	return "unknown service-now error"
 }

--- a/internal/new/service_now_error_test.go
+++ b/internal/new/service_now_error_test.go
@@ -103,3 +103,40 @@ func TestServicenowError_ErrorBranches(t *testing.T) {
 		t.Errorf("Expected BS nil error, got %v", err)
 	}
 }
+
+func TestServicenowError_Error(t *testing.T) {
+	msg := "boom"
+	detail := "extra"
+
+	withMessage := NewMainError()
+	_ = withMessage.SetMessage(&msg)
+
+	withDetail := NewMainError()
+	_ = withDetail.SetDetail(&detail)
+
+	newErr := func(main MainErrorable) *ServicenowError {
+		e := NewServicenowError()
+		if main != nil {
+			_ = e.setError(main)
+		}
+		return e
+	}
+
+	tests := []struct {
+		name     string
+		model    *ServicenowError
+		expected string
+	}{
+		{"message set", newErr(withMessage), msg},
+		{"only detail set", newErr(withDetail), detail},
+		{"error key absent", newErr(nil), "unknown service-now error"},
+		{"message and detail absent", newErr(NewMainError()), "unknown service-now error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.model.Error(); got != tt.expected {
+				t.Errorf("got %q, expected %q", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `ServicenowError.Error()` panicked with a nil-pointer dereference when a ServiceNow error response omitted the `error` object (nil `mainErr`) or had neither `message` nor `detail` set (`*details` deref on a nil pointer).
- Guards `mainErr` with the package `IsNil` helper and checks `details` before dereferencing, falling back to a fixed string so `Error()` never panics.

Fixes #514

## Testing
- `go test ./internal/new/`