### PR TITLE
chore(ci): resolve gofmt and gocognit lint failures on main

### DIFF
--- a/actsub-api/activity.go
+++ b/actsub-api/activity.go
@@ -42,100 +42,52 @@ func (m *Activity) Serialize(writer serialization.SerializationWriter) error {
 	return nil
 }
 
+// activityStringFieldDeserializer builds a deserializer for a single string-typed
+// field, delegating the actual mutation to the provided setter.
+func activityStringFieldDeserializer(setter func(*string) error) func(serialization.ParseNode) error {
+	return func(parseNode serialization.ParseNode) error {
+		val, err := parseNode.GetStringValue()
+		if err != nil {
+			return err
+		}
+		if val != nil {
+			return setter(val)
+		}
+		return nil
+	}
+}
+
+// activityFieldCollectionDeserializer builds a deserializer for a `[]*Field`
+// collection-typed field, delegating the actual mutation to the provided setter.
+func activityFieldCollectionDeserializer(setter func([]*Field) error) func(serialization.ParseNode) error {
+	return func(parseNode serialization.ParseNode) error {
+		val, err := parseNode.GetCollectionOfObjectValues(CreateFieldFromDiscriminatorValue)
+		if err != nil {
+			return err
+		}
+		if val != nil {
+			res := make([]*Field, len(val))
+			for i, v := range val {
+				if v != nil {
+					res[i] = v.(*Field)
+				}
+			}
+			return setter(res)
+		}
+		return nil
+	}
+}
+
 func (m *Activity) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		activityTypeIDKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetStringValue()
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				return m.SetActivityTypeID(val)
-			}
-			return nil
-		},
-		sourceTableNameKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetStringValue()
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				return m.SetSourceTableName(val)
-			}
-			return nil
-		},
-		subObjectTableNameKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetStringValue()
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				return m.SetSubObjectTableName(val)
-			}
-			return nil
-		},
-		subObjectSysIDKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetStringValue()
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				return m.SetSubObjectSysID(val)
-			}
-			return nil
-		},
-		titleKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetStringValue()
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				return m.SetTitle(val)
-			}
-			return nil
-		},
-		sysIDKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetStringValue()
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				return m.SetSysIDKey(val)
-			}
-			return nil
-		},
-		contentFieldsKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetCollectionOfObjectValues(CreateFieldFromDiscriminatorValue)
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				res := make([]*Field, len(val))
-				for i, v := range val {
-					if v != nil {
-						res[i] = v.(*Field)
-					}
-				}
-				return m.SetContentFields(res)
-			}
-			return nil
-		},
-		subheaderFieldsKey: func(parseNode serialization.ParseNode) error {
-			val, err := parseNode.GetCollectionOfObjectValues(CreateFieldFromDiscriminatorValue)
-			if err != nil {
-				return err
-			}
-			if val != nil {
-				res := make([]*Field, len(val))
-				for i, v := range val {
-					if v != nil {
-						res[i] = v.(*Field)
-					}
-				}
-				return m.SetSubheaderFields(res)
-			}
-			return nil
-		},
+		activityTypeIDKey:     activityStringFieldDeserializer(m.SetActivityTypeID),
+		sourceTableNameKey:    activityStringFieldDeserializer(m.SetSourceTableName),
+		subObjectTableNameKey: activityStringFieldDeserializer(m.SetSubObjectTableName),
+		subObjectSysIDKey:     activityStringFieldDeserializer(m.SetSubObjectSysID),
+		titleKey:              activityStringFieldDeserializer(m.SetTitle),
+		sysIDKey:              activityStringFieldDeserializer(m.SetSysIDKey),
+		contentFieldsKey:      activityFieldCollectionDeserializer(m.SetContentFields),
+		subheaderFieldsKey:    activityFieldCollectionDeserializer(m.SetSubheaderFields),
 	}
 }
 

--- a/appservice-api/appservice_models.go
+++ b/appservice-api/appservice_models.go
@@ -77,8 +77,8 @@ func (m *CreateServiceResult) Serialize(writer serialization.SerializationWriter
 
 func (m *CreateServiceResult) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
 	return map[string]func(serialization.ParseNode) error{
-		sysIdKey:     internalSerialization.DeserializeStringFunc()(m.setSysId),
-		nameKey:      internalSerialization.DeserializeStringFunc()(m.setName),
+		sysIdKey:    internalSerialization.DeserializeStringFunc()(m.setSysId),
+		nameKey:     internalSerialization.DeserializeStringFunc()(m.setName),
 		commentsKey: internalSerialization.DeserializeStringFunc()(m.setComments),
 	}
 }
@@ -580,7 +580,6 @@ func (m *ServiceDetailsRequest) GetBasicDetails() (*BasicDetails, error) {
 func (m *ServiceDetailsRequest) setBasicDetails(val *BasicDetails) error {
 	return store.DefaultBackedModelMutatorFunc(m.GetBackingStore(), basicDetailsKey, val)
 }
-
 
 func CreateServiceDetailsRequestFromDiscriminatorValue(_ serialization.ParseNode) (serialization.Parsable, error) {
 	return NewServiceDetailsRequest(), nil

--- a/appservice-api/constants.go
+++ b/appservice-api/constants.go
@@ -23,4 +23,3 @@ const (
 	valueKey                    = "value"
 	numberKey                   = "number"
 )
-

--- a/cmdb-instance-api/cmdb_request_builder.go
+++ b/cmdb-instance-api/cmdb_request_builder.go
@@ -40,4 +40,3 @@ func (rB *CmdbRequestBuilder) Instance() *CmdbInstanceRequestBuilder {
 func (rB *CmdbRequestBuilder) AppService() *appserviceapi.AppServiceRequestBuilder {
 	return appserviceapi.NewAppServiceRequestBuilderInternal(maps.Clone(rB.GetPathParameters()), rB.GetRequestAdapter())
 }
-


### PR DESCRIPTION
## Summary

`main`'s **Go CI** workflow's `Lint Go Code (oldstable)` job has been failing on every push/PR since at least 2026-06-15 (confirmed via `gh run list --branch main --workflow "Go CI"` showing repeated `failure` conclusions across multiple unrelated merges — dependency bumps, release commits, etc.). This restores a green baseline by fixing the four underlying lint violations:

1. `actsub-api/activity.go:45` — `cognitive complexity 46 of func (*Activity).GetFieldDeserializers is high (> 30) (gocognit)`
2. `appservice-api/appservice_models.go:80` — `File is not properly formatted (gofmt)`
3. `appservice-api/constants.go:26` — `File is not properly formatted (gofmt)`
4. `cmdb-instance-api/cmdb_request_builder.go:43` — `File is not properly formatted (gofmt)`

### Changes

- Ran `gofmt -s -w .` to fix the three formatting violations (no other files were affected — `gofmt -l .` was clean everywhere else).
- Reduced `(*Activity).GetFieldDeserializers`'s cognitive complexity by extracting the two repeated closure shapes (string-field deserializer, `[]*Field`-collection deserializer) into small named helper functions (`activityStringFieldDeserializer`, `activityFieldCollectionDeserializer`) that the map literal now delegates to. Behavior is unchanged — this is a pure mechanical refactor, no `//nolint` needed.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `golangci-lint run ./...` (v2.8.0, matching `version: latest` pinned in `.github/workflows/go.yml`) — `0 issues`
- [x] `go build ./...` — passes
- [x] `go test ./...` — all packages pass