### PR TITLE
chore(ci): stop skipping CI on release-please PRs by branch name

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--'))
+    # NOTE: release-please PRs are intentionally NOT excluded here by branch
+    # name. They go through the same tj-actions/changed-files filter as any
+    # other PR, so today's release-please PRs (CHANGELOG.md/VERSION only)
+    # naturally skip downstream jobs via `code == 'false'`, but a future
+    # release-please PR that also carries a go.mod change (e.g. the /v2
+    # module-path bump) still gets full CI. Do not reintroduce a
+    # branch-name-based skip here — see #523.
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     outputs:
       code: ${{ steps.filter.outputs.any_changed }}
     steps:


### PR DESCRIPTION
## Summary

- Removes the `!startsWith(github.head_ref, 'release-please--')` branch-name exclusion from the `changes` job in `.github/workflows/go.yml`. That exclusion made `needs.changes.outputs.code` falsy for *any* release-please PR, silently skipping every downstream job (build/test/lint/vulncheck) regardless of what files the PR actually touched.
- Release-please PRs now flow through the same `tj-actions/changed-files` path filter as every other PR. CHANGELOG.md/VERSION-only PRs still skip downstream jobs today (unchanged behavior), but a future release-please PR that also carries a `go.mod` change (e.g. the planned `/v2` module-path bump) will get full CI instead of merging unvalidated.
- Adds an inline comment on the `changes` job's `if` explaining why a branch-name-based skip must not be reintroduced there.

Closes #523

## Test plan

- [x] Read `.github/workflows/go.yml` in full before editing, confirmed the `changes` job was the only place gating on `release-please--` branch names.
- [x] Validated the edited YAML parses (`npx js-yaml .github/workflows/go.yml`).
- [x] Manually traced `needs`/`if`/`outputs` wiring: `changes.outputs.code` now depends solely on the `tj-actions/changed-files` filter result for both `push` and `pull_request` events; `check-go`/`build-go`/`lint-go`/`test-go` still gate on `needs.changes.outputs.code == 'true'` unchanged.
- [ ] Confirm on a real release-please PR (CHANGELOG/VERSION-only) that downstream jobs still report skipped, and that a release-please PR touching `go.mod` runs full CI — not verifiable from this worktree; there's no local Actions runner, so this needs to be observed on the next actual release-please run.