### PR TITLE
chore(ci): add concurrency guards to release workflows

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 3 * * 1" # Weekly preview release (every Monday at 3 AM UTC)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   issues: write
@@ -17,7 +20,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      should_release: ${{ steps.diff.outputs.any_changed }}
+      should_release: ${{ steps.determine.outputs.should_release }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -25,13 +28,27 @@ jobs:
 
       - name: Get latest tag
         id: latest_tag
-        run: echo "tag=$(git describe --tags --abbrev=0 || echo "")" >> $GITHUB_OUTPUT
+        run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")" >> $GITHUB_OUTPUT
 
+      # Only runs when a prior tag exists. On a first run (no tags yet) there's
+      # nothing to diff against, so this step is skipped rather than relying on
+      # tj-actions/changed-files' undocumented behavior for an empty base_sha.
       - name: Check for changes since latest tag
         id: diff
+        if: ${{ steps.latest_tag.outputs.tag != '' }}
         uses: tj-actions/changed-files@v47.0.6
         with:
           base_sha: ${{ steps.latest_tag.outputs.tag }}
+
+      - name: Determine whether to release
+        id: determine
+        run: |
+          if [ -z "${{ steps.latest_tag.outputs.tag }}" ]; then
+            echo "No prior tag found; defaulting should_release=true for first run."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=${{ steps.diff.outputs.any_changed }}" >> "$GITHUB_OUTPUT"
+          fi
 
   release-please:
     needs: detect-changes


### PR DESCRIPTION
## Summary
- Add a `concurrency` group (`${{ github.workflow }}-${{ github.ref }}`, no `cancel-in-progress`) to both `stable-release.yml` and `weekly-release.yml` so a rapid double-push to `main`, or a manual `workflow_dispatch` racing the Monday cron, queues rather than races two concurrent `release-please` runs against the same config. Cancellation is intentionally left off since aborting a `release-please` run mid-flight could leave partial PR/tag state.
- Harden `weekly-release.yml`'s `detect-changes` job for the "no tags yet" first-run case: the `tj-actions/changed-files` diff step is now skipped entirely (via `if: steps.latest_tag.outputs.tag != ''`) instead of being fed an empty `base_sha`, and a new `Determine whether to release` step explicitly defaults `should_release=true` when no prior tag exists.

Closes #522

## Test plan
- [x] Read both workflow files in full before editing.
- [x] Parsed both YAML files with `js-yaml` to confirm they're well-formed after the edit.
- [x] Manually traced `needs`/`if`/`outputs` wiring: `detect-changes.outputs.should_release` now flows from the new `determine` step instead of directly from `diff`, and `release-please`'s `if` condition is unchanged and still resolves correctly.
- [ ] No local GitHub Actions runner available in this repo; a real dry run will need to happen via a `workflow_dispatch` (or the next scheduled Monday run / next push to `main`) after merge.