### PR TITLE
chore(ci): scan website npm deps and reduce gomod update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,28 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
-  
+      interval: weekly
+    groups:
+      go-dependencies:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: weekly
+    groups:
+      website-dependencies:
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: daily
-  
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What & why

Closes #521.

Dependabot's `.github/dependabot.yml` covered `gomod`, `devcontainers`, and `github-actions`, but not the `npm` deps under `website/` that `docs.yml` builds (Docusaurus, `website/package-lock.json`) — a supply-chain blind spot. Also, `gomod` ran on a `daily` cadence with no grouping; since `pr.yml`'s `dependabot-merge` job already auto-merges non-major dependabot PRs, `daily` mostly added auto-merge churn rather than added safety.

Changes:
- Add an `npm` ecosystem entry scoped to `directory: /website`, `weekly` cadence, grouping minor/patch bumps into a single `website-dependencies` PR.
- Move `gomod` from `daily` to `weekly`, grouping minor/patch bumps into a single `go-dependencies` PR (majors are excluded from the group so they still surface individually for manual review).
- `devcontainers` and `github-actions` entries left as-is (out of scope for this issue).

## Checklist

- [x] `.github/dependabot.yml` YAML validated (parsed successfully with `js-yaml`)
- [x] `npm` ecosystem added for `website/`, matching the `package-lock.json` location `docs.yml` depends on
- [x] `gomod` cadence reduced to `weekly` with minor/patch grouping
- [x] No other CI issue's scope touched (single-file change, no workflow edits)
- [ ] N/A — no exported Go surface changed; docs site untouched by this change
- [x] `VERSION` and `CHANGELOG.md` untouched

## Test plan

- [x] Manually parsed the updated YAML to confirm it's well-formed and produces the expected structure (four `updates` entries: `gomod`, `npm`, `devcontainers`, `github-actions`)
- [ ] Dependabot will pick up the new `npm` ecosystem entry and start opening grouped PRs for `website/` on its next scheduled run (not verifiable locally — no live Dependabot runner in this repo)