### PR TITLE
chore(ci): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+name: OpenSSF Scorecard
+
+on:
+  workflow_dispatch:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 1 * * 1"
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          sarif_file: results.sarif

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
 ![GitHub](https://img.shields.io/github/license/michaeldcanady/servicenow-sdk-go?style=plastic)
 [![Maintainability](https://qlty.sh/badges/e778f295-dfb1-4637-a15e-f179549fcae4/maintainability.svg)](https://qlty.sh/gh/michaeldcanady/projects/servicenow-sdk-go)
 [![codecov](https://codecov.io/gh/michaeldcanady/servicenow-sdk-go/graph/badge.svg?token=MJPM1UAI78)](https://codecov.io/gh/michaeldcanady/servicenow-sdk-go)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/michaeldcanady/servicenow-sdk-go/badge)](https://scorecard.dev/viewer/?uri=github.com/michaeldcanady/servicenow-sdk-go)
 
 A Service-Now API client enabling Go programs to interact with Service-Now in a simple and uniform way
 


### PR DESCRIPTION
## Summary

Closes #526

- Adds a new `.github/workflows/scorecard.yml` workflow that runs [OpenSSF Scorecard](https://github.com/ossf/scorecard-action) on a weekly schedule (Monday 01:30 UTC), on `branch_protection_rule` changes, on push to `main`, and via manual `workflow_dispatch`, matching OpenSSF's recommended setup.
- Results are published as SARIF, uploaded as a build artifact, and uploaded to GitHub code scanning (`github/codeql-action/upload-sarif`), and published to the public Scorecard API (`publish_results: true`), consistent with the repo's existing CodeQL/`govulncheck`/Dependabot supply-chain security investment.
- All third-party actions (`actions/checkout`, `ossf/scorecard-action`, `actions/upload-artifact`, `github/codeql-action/upload-sarif`) are pinned to a full-length commit SHA with a version comment, per Scorecard's own "Pinned-Dependencies" recommendation.
- Job permissions are scoped to the minimum needed (`security-events: write` for the SARIF upload, `id-token: write` for OIDC-based result publishing); the workflow-level `permissions: {}` default stays locked down otherwise.
- Adds the resulting OpenSSF Scorecard badge to `Readme.md` alongside the existing GoDoc/release/codecov badges (optional item from the issue).

This is CI/workflow-only plumbing and does not affect the published SDK, so it's a `chore` per this repo's commit conventions.

## Test plan

- [x] Validated `scorecard.yml` is well-formed YAML (parsed successfully with `js-yaml`).
- [x] Cross-checked `needs`/`permissions`/`uses` wiring by hand against `ossf/scorecard-action`'s documented usage and this repo's existing workflow style (no `act`/local GitHub Actions runner available in this repo).
- [ ] Confirm the workflow runs successfully once merged to `main` (first scheduled/push run) and that results show up in the Security > Code scanning tab and at https://scorecard.dev.