### PR TITLE
chore(ci): enforce branch naming and PR-linked-issue conventions

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -1,0 +1,63 @@
+name: Branch Policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  branch-name:
+    name: Check Branch Name
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Automated branches (release-please, dependabot) don't follow the
+    # human-authored <type>/<kebab-description> convention, so they're exempt.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.head_ref, 'dependabot/') }}
+    steps:
+      - name: Validate branch name matches <type>/<kebab-description>
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          # Same type vocabulary as pull-request-title-lint.yml, so branch
+          # names and PR titles stay in sync.
+          PATTERN='^(fix|feat|chore|docs|style|refactor|perf|test)/[a-z0-9]+(-[a-z0-9]+)*$'
+
+          if [[ ! "$HEAD_REF" =~ $PATTERN ]]; then
+            echo "::error::Branch name '$HEAD_REF' does not match the required '<type>/<kebab-description>' pattern (e.g. 'fix/nil-pointer-in-tableapi')."
+            echo "Allowed types: fix, feat, chore, docs, style, refactor, perf, test"
+            exit 1
+          fi
+
+          echo "Branch name '$HEAD_REF' is valid."
+
+  linked-issue:
+    name: Check Linked Issue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Automated PRs (release-please, dependabot) and PRs explicitly labeled
+    # as trivial don't require a linked issue.
+    if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'no-issue-required') }}
+    steps:
+      - name: Validate PR body references an issue
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Accepts any "#123" reference (e.g. "Closes #123", "Part of #123",
+          # "Fixes #123") so partial/complementary work against an issue is
+          # still recognized, not just PRs that auto-close the issue.
+          if ! grep -qE '#[0-9]+' <<< "$PR_BODY"; then
+            echo "::error::PR description must reference a linked issue (e.g. 'Closes #123' or 'Part of #123')."
+            echo "If this PR is a trivial chore with no associated issue, apply the 'no-issue-required' label instead."
+            exit 1
+          fi
+
+          echo "PR body references a linked issue."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,38 @@ To get started, you'll need to have the following tools installed:
 
 1. Fork the repository
 2. Clone it to your local machine: `git clone {url}`
-3. Create a new branch for your changes: `git checkout -b my-new-feature`
+3. Create a new branch for your changes, named `<type>/<kebab-description>` (see
+   [Branching convention](#branching-convention) below): `git checkout -b fix/nil-pointer-in-tableapi`
 4. Make your changes and commit them: `git commit -am 'Add some feature'`
    1. Include tests that cover your changes.
    2. Update the documentation to reflect your changes, where appropriate.
    3. Add and entry to the `changelog.md` file describing your changes if appropriate.
-5. Push your changes to your fork: `git push origin my-new-feature`
-6. Create a pull request from your fork to the main repository: `gh pr create` (With the GitHub CLI)
+5. Push your changes to your fork: `git push origin fix/nil-pointer-in-tableapi`
+6. Create a pull request from your fork to the main repository: `gh pr create` (With the GitHub CLI).
+   The PR description must reference the issue it addresses (e.g. `Closes #123` or `Part of #123`) —
+   see [Linking issues](#linking-issues) below.
+
+## Branching convention
+
+This repo practices trunk-based development with typed feature branches. Branch names must match:
+
+```
+<type>/<kebab-description>
+```
+
+where `<type>` is one of `fix`, `feat`, `chore`, `docs`, `style`, `refactor`, `perf`, `test` — the
+same vocabulary enforced on PR titles — and `<kebab-description>` is a short, lowercase,
+hyphen-separated summary (e.g. `feat/add-cdm-changeset-api`, `docs/publish-support-policy`).
+`.github/workflows/branch-policy.yml` enforces this on every PR targeting `main` (automated
+`release-please--*` and `dependabot/*` branches are exempt).
+
+## Linking issues
+
+Every PR must reference an issue in its description (e.g. `Closes #123`, `Fixes #123`, or
+`Part of #123` for PRs that only address part of a larger issue).
+`.github/workflows/branch-policy.yml` enforces this on every PR targeting `main`. If a PR is a
+genuinely trivial chore with no associated issue, apply the `no-issue-required` label instead of
+opening a throwaway issue.
 
 ## Reporting Bugs
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/branch-policy.yml`, a new CI check on PRs targeting `main` with two jobs:
  - `branch-name` — validates the PR's head branch matches `<type>/<kebab-description>`, using the same type vocabulary already enforced on PR titles (`fix`, `feat`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`). Exempts automated `release-please--*` and `dependabot/*` branches.
  - `linked-issue` — validates the PR description references an issue (`#123`, e.g. `Closes #123` / `Part of #123`). Exempts dependabot PRs and any PR labeled `no-issue-required` (added as a label in this PR's setup) as an escape hatch for trivial chores.
- Documents both conventions in `CONTRIBUTING.md` (new "Branching convention" and "Linking issues" sections), and updates the existing "Contributing Code" steps to reflect the branch-naming convention.

This is the CI-enforcement portion of #503 — the repo already practices trunk-based development with typed branches, this just writes the rule down and backs it with a status check instead of leaving it as tribal knowledge. The broader CONTRIBUTING consolidation task is out of scope here per the issue's own note that it can be split out separately.

Part of #503

## Test plan

- [x] Validated `branch-policy.yml` parses as well-formed YAML (`yq '.jobs | keys'`)
- [x] Manually verified the branch-name regex against sample branch names (`chore/enforce-branching-strategy`, `fix/nil-pointer`, `release-please--branches--main`, `dependabot/go_modules/foo`, `feature/foo` (should fail), `chore/enforce_branching` (should fail))
- [ ] Confirm this PR itself passes both new checks once opened (branch name `chore/enforce-branching-strategy`, body references `#503`)
- [ ] After merge, confirm branch protection on `main` is updated to require the new `branch-name` / `linked-issue` status checks (tracked separately under #527, which audits required status checks)
Fixes #503
