### PR TITLE
chore(ci): quick-win workflow hygiene fixes

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   dependabot-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,7 @@ permissions: {}
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--'))
@@ -51,6 +52,7 @@ jobs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     strategy:
@@ -78,6 +80,7 @@ jobs:
         os: &os-platforms [ubuntu-latest, macos-latest, windows-latest]
         go-version: *go-versions
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: read
     defaults:
@@ -101,16 +104,14 @@ jobs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
-    strategy:
-      matrix:
-        go-version: *go-versions
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: stable
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -129,6 +130,7 @@ jobs:
         os: *os-platforms
         go-version: *go-versions
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   changes-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--'))
@@ -42,6 +43,7 @@ jobs:
   build:
     name: build-md
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     if: ${{ needs.changes-docs.outputs.docs == 'true' }}
@@ -95,6 +97,7 @@ jobs:
   lint:
     name: lint-md
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     if: ${{ needs.changes-docs.outputs.docs == 'true' }}
@@ -113,6 +116,7 @@ jobs:
   deploy:
     name: deploy-docs
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -14,6 +14,7 @@ jobs:
   main:
     name: Validate PR Title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -14,12 +14,13 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     outputs:
       should_release: ${{ steps.diff.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Needed to fetch all tags
 
@@ -37,6 +38,7 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.should_release == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Create preview release
         uses: googleapis/release-please-action@v5


### PR DESCRIPTION
## Summary

Closes #520.

Applies the low-risk workflow hygiene cleanups from the devops-cicd review:

- Add `timeout-minutes` to every job in every workflow (`go.yml`, `pages.yml`, `stable-release.yml`, `weekly-release.yml`, `pull-request-title-lint.yml`, `auto-merge-dependabot.yml`) to cap runaway runs — 5m for fast metadata/gating jobs, 10m for release-please/lint/check jobs, 15m for build/test matrices, 20m for the docs build/deploy.
- Bump `weekly-release.yml`'s `actions/checkout` from `@v6` to `@v7` so pinning is consistent with the rest of the repo.
- Restrict `lint-go` in `go.yml` to the `stable` Go version only (dropped the `oldstable` matrix leg) since golangci-lint results don't vary by Go version — this was previously running redundantly across both.

Two items from the issue were checked and found already satisfied in the current workflow state, so no change was needed:
- `build-go` (and `test-go`) in `go.yml` already declare only `permissions: contents: read`, no `pull-requests: write`.
- `dependabot-merge` in `auto-merge-dependabot.yml` already has an explicit job-level `permissions:` block (`pull-requests: write`, `contents: write`).

No change in CI behavior other than the intended fixes — same triggers, same gating logic, same job outputs/wiring.

## Test plan

- [x] Read every touched workflow file in full before and after editing.
- [x] `git diff` reviewed line-by-line for each of the 6 changed files.
- [x] Manually verified YAML structure/indentation by eye (no local `act` runner or yaml linter available in this environment).
- [x] Confirmed `needs`/`if`/`strategy` wiring in `go.yml` still resolves correctly after removing `lint-go`'s matrix (job no longer references `matrix.go-version`, `go-version: stable` set directly).
- [x] `go build ./...` passes (no Go source touched, workflow-only change).
- [ ] Verify the pushed branch's own `go.yml`/`pages.yml` runs pick up the new `timeout-minutes` values without errors on GitHub Actions.