### PR TITLE
chore(ci): add PR auto-labeling and test-scoping script

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,90 @@
+# Path-based PR labeling config for actions/labeler.
+#
+# The "module: *" labels use the same per-package vocabulary as the "Affected
+# Module / API" dropdown in .github/ISSUE_TEMPLATE/bug-template.yaml (which
+# currently groups some of these more coarsely), so issues and PRs stay
+# comparable.
+
+"module: table-api":
+  - changed-files:
+      - any-glob-to-any-file: "table-api/**"
+
+"module: attachment-api":
+  - changed-files:
+      - any-glob-to-any-file: "attachment-api/**"
+
+"module: batch-api":
+  - changed-files:
+      - any-glob-to-any-file: "batch-api/**"
+
+"module: case-api":
+  - changed-files:
+      - any-glob-to-any-file: "case-api/**"
+
+"module: cdm":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "cdm-applications-api/**"
+          - "cdm-changeset-api/**"
+          - "cdm-editor-api/**"
+
+"module: cmdb":
+  - changed-files:
+      - any-glob-to-any-file: "cmdb-instance-api/**"
+
+"module: documents-api":
+  - changed-files:
+      - any-glob-to-any-file: "documents-api/**"
+
+"module: account-api":
+  - changed-files:
+      - any-glob-to-any-file: "account-api/**"
+
+"module: actsub-api":
+  - changed-files:
+      - any-glob-to-any-file: "actsub-api/**"
+
+"module: appointment-booking-api":
+  - changed-files:
+      - any-glob-to-any-file: "appointmentbooking-api/**"
+
+"module: app-service-api":
+  - changed-files:
+      - any-glob-to-any-file: "appservice-api/**"
+
+"module: policy-api":
+  - changed-files:
+      - any-glob-to-any-file: "policy-api/**"
+
+"module: credentials":
+  - changed-files:
+      - any-glob-to-any-file: "credentials/**"
+
+"module: core":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "core/**"
+          - "internal/**"
+          - "errors.go"
+          - "query/**"
+
+"type: documentation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "mkdocs.yml"
+          - "**/*.md"
+
+"type: devops":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/actions/**"
+          - ".github/dependabot.yml"
+          - ".github/labeler.yml"
+          - "justfile"
+          - "scripts/**"
+
+"tests":
+  - changed-files:
+      - any-glob-to-any-file: "tests/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions: {}
+
+jobs:
+  label:
+    name: Apply Path Labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Cherry-picks the PR auto-labeling work from `3e3ef8b` (release/2.0, via `chore/issue-template-audit`) onto `main`
- Adds `actions/labeler`-based auto-tagging of PRs by changed path (`.github/labeler.yml`, `.github/workflows/labeler.yml`)

## Adjustments from the original commit
- Dropped the `ci.yml` fail-fast hunk: that job doesn't exist under that name on `main` (it's `go.yml`), and `main`'s `lint-go` isn't matrixed, so the bug it fixed doesn't apply here
- Dropped the `devops-cicd` agent doc: it describes release/2.0's six-workflow layout (`ci.yml`/`pr.yml`/`codeql.yml`/`docs.yml`/...), not `main`'s actual workflows, and would be misleading as-is
- Dropped `scripts/affected-tests.sh` (test-scoping script) — not needed
- Rewrote `.github/labeler.yml`'s path globs from release/2.0's concatenated package directory names (`tableapi/`, `attachmentapi/`, ...) to `main`'s current hyphenated ones (`table-api/`, `attachment-api/`, ...) — the original globs would have silently never matched anything on `main`
- Adjusted the documentation/devops/tests label buckets to `main`'s actual layout: `docs/` + `mkdocs.yml` (not `website/`, which doesn't exist on `main`), `.github/actions/**` (not `.github/scripts/`), flat `tests/**` (not `tests/integration|e2e/`)
- Verified every remaining glob's top-level path actually exists in `main`'s current tree

## Test plan
- [x] Validated `.github/labeler.yml` and `.github/workflows/labeler.yml` parse as YAML
- [x] Confirmed every path referenced in `.github/labeler.yml` exists in `main`'s current tree (via `git cat-file -e`)
- [ ] First real PR against `main` after this merges will confirm labels apply correctly in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)