### PR TITLE
chore(docs): record decision to keep RequestBuilder/RequestInformation naming

### DIFF
--- a/.claude/skills/design-decisions/SKILL.md
+++ b/.claude/skills/design-decisions/SKILL.md
@@ -12,8 +12,10 @@ description: >
   vanilla Kiota request-configuration (ADR 004), one generic core.PageIterator
   instead of per-module wrappers (ADR 005), nil-receiver guards returning a
   shared sentinel error instead of (nil, nil) (ADR 006), never scaffolding a
-  builder chain ahead of an implemented operation (ADR 007), and package/
-  symbol/URL names as independent naming axes (ADR 008). Consult this BEFORE
+  builder chain ahead of an implemented operation (ADR 007), package/
+  symbol/URL names as independent naming axes (ADR 008), and keeping the
+  RequestBuilder/RequestInformation names despite their imprecise roles, for
+  Kiota/msgraph parity (ADR 009). Consult this BEFORE
   proposing or making changes to the request-builder/model architecture,
   error handling conventions, pagination, nil-guard behavior, module naming,
   or anything that would make this SDK diverge from Kiota-generated SDK
@@ -39,8 +41,8 @@ top-level docs turns them into a decision log nobody can navigate, and
 duplicating the same reasoning in two places means it drifts out of sync the
 first time only one copy gets updated.
 
-There is no index file or template in `docs/adr/` yet — it's eight files,
-numbered `001-` through `008-` (three digits, not four). Read them directly:
+There is no index file or template in `docs/adr/` yet — it's nine files,
+numbered `001-` through `009-` (three digits, not four). Read them directly:
 
 1. [`001-error-standardization.md`](../../../docs/adr/001-error-standardization.md)
    — centralizes sentinel errors and message phrasing in the `/errors`
@@ -93,6 +95,13 @@ numbered `001-` through `008-` (three digits, not four). Read them directly:
    independent naming axes (see `aggregationapi` package vs. `Stats*` types vs.
    `Now().Stats()`); an inconsistency in one doesn't mean the other two need to
    change too.
+9. [`009-requestbuilder-requestinformation-naming.md`](../../../docs/adr/009-requestbuilder-requestinformation-naming.md)
+   — keeps `RequestBuilder`/`RequestInformation` named as-is despite the
+   names being technically imprecise (`RequestBuilder` is really a facade,
+   `RequestInformation` is the actual builder), because they mirror
+   `kiota-abstractions-go`/msgraph-sdk-go conventions. Settled through v3 —
+   don't revisit without a new major-version boundary and a concrete
+   consumer-facing reason.
 
 Before touching an area covered by an ADR, or answering a "why"/"should we
 change this" question:

--- a/docs/adr/009-requestbuilder-requestinformation-naming.md
+++ b/docs/adr/009-requestbuilder-requestinformation-naming.md
@@ -1,0 +1,59 @@
+# ADR 009: Keep `RequestBuilder`/`RequestInformation` naming (Kiota parity)
+
+## Status
+
+Accepted
+
+## Context
+
+Backlog grooming for v2.0 (#496) flagged that `RequestBuilder` and
+`RequestInformation` are, strictly speaking, misnamed: the type most callers
+chain against (`core.RequestBuilder` / `core.BaseRequestBuilder` and the
+per-module `*RequestBuilder` types) is really a fluent **facade** over the
+API surface, while `RequestInformation` — built up inside each `ToXRequestInformation`
+method and passed to `RequestAdapter.Send*` — is the object that actually
+accumulates URL, headers, query parameters, and body, i.e. the real
+**builder** in the classic sense.
+
+This naming is inherited directly from Kiota's runtime abstractions
+(`kiota-abstractions-go`) and from Kiota-*generated* SDKs like
+`msgraph-sdk-go`, per [[003-hand-written-on-kiota]] and [[008-package-symbol-url-naming-independence]]'s underlying premise that
+matching Kiota/msgraph conventions is a stated design goal so developers
+arriving from other Kiota SDKs find familiar idioms.
+
+Renaming these types is only possible as a breaking change, and v2.0 is the
+last point before v3 where a rename would be low-friction. The decision
+therefore has to be made deliberately now, not left implicit.
+
+Alternatives considered:
+
+1. **Rename to reflect actual roles** (e.g. `RequestBuilder` → something
+   like `Client`/`Facade`, `RequestInformation` → `RequestBuilder`) —
+   rejected. This breaks the naming correspondence with
+   `kiota-abstractions-go` and every Kiota-generated SDK (msgraph-sdk-go and
+   friends), which is exactly the familiarity ADR-003 says this SDK is
+   trying to preserve. It would also touch nearly every exported type across
+   every `*api` package, for a purely internal-precision gain with zero
+   consumer-facing benefit.
+2. **Keep the existing names** — matches the ecosystem convention this SDK
+   deliberately mirrors; the imprecision is real but well-precedented (Kiota
+   itself uses these names the same way) and costs nothing beyond an
+   occasional need to explain it.
+
+## Decision
+
+Keep `RequestBuilder`/`BaseRequestBuilder` and `RequestInformation` named as
+they are. No rename is scoped for v2.0 or planned for v3.
+
+## Consequences
+
+- **Pros:** naming stays consistent with `kiota-abstractions-go` and
+  Kiota-generated SDKs (msgraph-sdk-go and peers); no churn across every
+  `*api` package's exported surface; nothing to migrate for consumers.
+- **Cons:** the names remain technically imprecise — `RequestBuilder` is a
+  facade, `RequestInformation` is the actual builder — which can be mildly
+  confusing on first read until a contributor connects it to the Kiota
+  convention it mirrors.
+- **Rule for future naming questions on these types:** this is now settled
+  through v3 — do not revisit without a new major version boundary and a
+  concrete consumer-facing reason, not just internal-precision cleanup.


### PR DESCRIPTION
## Summary
- Adds ADR-009, recording the v2.0 decision to keep `RequestBuilder`/`RequestInformation` named as-is for Kiota/msgraph-sdk-go parity, despite `RequestBuilder` really being a facade and `RequestInformation` the actual builder
- Updates the `design-decisions` skill's index to reference ADR-009

Closes #496

## Test plan
- [x] Docs-only change, no code/tests affected