### PR TITLE
chore(ci): pin golangci-lint version instead of tracking latest

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,9 @@ concurrency:
 
 env:
   COVERAGE_FILE: coverage.out
+  # Pin golangci-lint instead of tracking `latest`, so a new golangci-lint
+  # release can't break CI unexpectedly; bump this deliberately.
+  GOLANGCI_LINT_VERSION: v2.12.2
 
 permissions: {}
 
@@ -135,7 +138,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           skip-cache: false
           args: --timeout=5m
 


### PR DESCRIPTION
## Summary
- `lint-go` pointed `golangci-lint-action` at `version: latest`, so a new golangci-lint release can start failing CI with no corresponding change in this repo.
- Pinned it via a `GOLANGCI_LINT_VERSION` env var (currently `v2.12.2`), bumped deliberately going forward.

(Supersedes #543, which was accidentally opened against an unmerged, diverged branch instead of `main`.)

## Test plan
- [ ] CI passes on this PR (lint-go job specifically)