### PR TITLE
docs(adr): record decision to stay at michaeldcanady org (no v2 migration)

### DIFF
--- a/.claude/skills/design-decisions/SKILL.md
+++ b/.claude/skills/design-decisions/SKILL.md
@@ -15,7 +15,9 @@ description: >
   builder chain ahead of an implemented operation (ADR 007), package/
   symbol/URL names as independent naming axes (ADR 008), and keeping the
   RequestBuilder/RequestInformation names despite their imprecise roles, for
-  Kiota/msgraph parity (ADR 009). Consult this BEFORE
+  Kiota/msgraph parity (ADR 009), and staying at the michaeldcanady GitHub
+  org/module path for the v2 lifecycle instead of migrating to a NerdIT-Tech
+  org (ADR 010). Consult this BEFORE
   proposing or making changes to the request-builder/model architecture,
   error handling conventions, pagination, nil-guard behavior, module naming,
   or anything that would make this SDK diverge from Kiota-generated SDK
@@ -41,8 +43,8 @@ top-level docs turns them into a decision log nobody can navigate, and
 duplicating the same reasoning in two places means it drifts out of sync the
 first time only one copy gets updated.
 
-There is no index file or template in `docs/adr/` yet — it's nine files,
-numbered `001-` through `009-` (three digits, not four). Read them directly:
+There is no index file or template in `docs/adr/` yet — it's ten files,
+numbered `001-` through `010-` (three digits, not four). Read them directly:
 
 1. [`001-error-standardization.md`](../../../docs/adr/001-error-standardization.md)
    — centralizes sentinel errors and message phrasing in the `/errors`
@@ -102,6 +104,12 @@ numbered `001-` through `009-` (three digits, not four). Read them directly:
    `kiota-abstractions-go`/msgraph-sdk-go conventions. Settled through v3 —
    don't revisit without a new major-version boundary and a concrete
    consumer-facing reason.
+10. [`010-no-nerdit-tech-migration.md`](../../../docs/adr/010-no-nerdit-tech-migration.md)
+    — declines a proposed GitHub org migration to NerdIT-Tech at v2; the
+    module path stays `github.com/michaeldcanady/servicenow-sdk-go` (only
+    the `/v2` semver suffix changes). Settled through v3 — don't revisit
+    without a new major-version boundary and a concrete, non-speculative
+    reason to move.
 
 Before touching an area covered by an ADR, or answering a "why"/"should we
 change this" question:

--- a/docs/adr/010-no-nerdit-tech-migration.md
+++ b/docs/adr/010-no-nerdit-tech-migration.md
@@ -1,0 +1,48 @@
+# ADR 010: Stay at `github.com/michaeldcanady/servicenow-sdk-go` — no org migration at v2
+
+## Status
+
+Accepted
+
+## Context
+
+Backlog grooming for v2.0 (#493) flagged that a GitHub org migration — moving
+the repo from `michaeldcanady/servicenow-sdk-go` to a `NerdIT-Tech` org path —
+is inherently breaking, since it changes the module import path. v2 already
+forces every consumer to update their import paths for the `/v2` semantic-import-versioning
+suffix (see the release-day runbook, `release-2.0-issues/003-v2-module-path-runbook.md`),
+so folding an org migration into that same bump would have been free from a
+consumer-churn standpoint. Migrating the org *after* v2 ships would mean
+either a v3 major bump just for the path change, or a permanent
+redirect/fork story — "TBD" was not viable, since v2.0.0 is the only point
+where this decision is free.
+
+Alternatives considered:
+
+1. **Migrate to `NerdIT-Tech` at v2** — transfer the GitHub repo before
+   release day, fold the new org path into the same commit as the `/v2`
+   module bump. Rejected: no concrete driver for the org move materialized
+   during grooming beyond a speculative future-org-structure benefit: the
+   maintainer decided against it (2026-07-24).
+2. **Stay at `michaeldcanady`** — commit to the current path for the entire
+   v2 lifecycle, revisit only at a future major version if a real reason
+   emerges.
+
+## Decision
+
+Keep the module path at `github.com/michaeldcanady/servicenow-sdk-go`. The
+`/v2` module-path bump (release-day runbook item, `release-2.0-issues/003`)
+changes only the semantic-import-versioning suffix — it does **not** change
+the org/owner segment. No GitHub repo transfer is planned for v2.0.0 or v3.
+
+## Consequences
+
+- **Pros:** no repo transfer to coordinate before release day (Actions,
+  apps, branch protection rules, CODEOWNERS handles all stay as-is); no risk
+  to the `go get` redirect story; one less moving part in the release
+  runbook.
+- **Cons:** none identified — this was a speculative option, not a
+  committed direction, so declining it costs nothing.
+- **Rule for future naming/org questions:** this is settled through v3 —
+  do not revisit without a new major version boundary and a concrete,
+  non-speculative reason to move.

--- a/release-2.0-issues/003-v2-module-path-runbook.md
+++ b/release-2.0-issues/003-v2-module-path-runbook.md
@@ -35,3 +35,4 @@ Execute immediately before the release merge (issue 002), as one commit:
 ## Cross-references
 
 - Depends on / sequenced with: issue 002 (release path).
+- Org/owner segment (`michaeldcanady`) stays fixed for v2 — see [[010-no-nerdit-tech-migration]] (#493, decided 2026-07-24). This runbook only changes the `/v2` semver suffix, never the owner.


### PR DESCRIPTION
## Summary
- Adds ADR-010 recording the decision (2026-07-24): no GitHub org migration to NerdIT-Tech at v2 — module path stays `github.com/michaeldcanady/servicenow-sdk-go`, only the `/v2` semver suffix changes.
- Cross-references the decision from the release-day module-path runbook (`release-2.0-issues/003-v2-module-path-runbook.md`).
- Indexes ADR-010 in the `design-decisions` skill, matching how ADR-009 was indexed.

Resolves #493.

## Test plan
- [x] Docs-only change; no code affected.
