### PR TITLE
docs(release-2.0): correct nil-guard tracker doc, add sentinel evidence

### DIFF
--- a/release-2.0-issues/004-nil-receiver-guards-return-nil-nil.md
+++ b/release-2.0-issues/004-nil-receiver-guards-return-nil-nil.md
@@ -3,10 +3,13 @@
 - **Priority:** P1 — API design; 2.0 is the only window to fix it
 - **Raised by:** Senior Principal Engineer
 - **Area:** SDK design / public API contract
+- **Status (2026-07-24):** Original defect fixed (ADR-006 / PR #487). This doc's
+  citations were stale as of a follow-up audit and have been corrected below — the
+  remaining gap is now tracked as a separate GitHub issue, not in this doc.
 
 ## Problem
 
-The standard verb-method preamble across every `*api` package is:
+The standard verb-method preamble across every `*api` package used to be:
 
 ```go
 if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
@@ -14,20 +17,17 @@ if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 }
 ```
 
-(e.g. `tableapi/table_request_builder.go:76`, `:120`, `:164`; the pattern is
-codified in CLAUDE.md and repeated in dozens of builders.)
-
-A caller who accidentally holds a nil builder gets `(nil, nil)` — no result **and no
+A caller who accidentally holds a nil builder got `(nil, nil)` — no result **and no
 error**. The inevitable outcome is a confusing downstream nil-pointer dereference far
 from the actual mistake, or worse, code that treats "no error" as success. This
 violates the Go convention that a nil error means the operation succeeded and the
 result is usable.
 
-The adapter guard right next to it already does the right thing
-(`return nil, snerrors.ErrNilRequestAdapter`), so the codebase is internally
+The adapter guard right next to it already did the right thing
+(`return nil, snerrors.ErrNilRequestAdapter`), so the codebase was internally
 inconsistent about how nil-guards behave.
 
-## Recommendation
+## Recommendation (as originally written — now implemented)
 
 Since 2.0 is a breaking release, change the contract now:
 
@@ -39,5 +39,25 @@ Since 2.0 is a breaking release, change the contract now:
 4. Update CLAUDE.md and the `new-api-module` skill / `api-module-consistency-reviewer`
    agent so new modules follow the corrected pattern.
 
-This is mechanical but wide; a scripted sweep plus the consistency-reviewer agent can
-verify completeness.
+## Verification update (2026-07-24)
+
+This doc originally cited `tableapi/table_request_builder.go:76,120,164` as still
+returning bare `nil, nil`. **That citation is now stale/wrong** — those exact lines
+were fixed by ADR-006 / PR #487 and today correctly return
+`nil, snerrors.ErrNilRequestBuilder`. `tableapi`, `caseapi`, `appserviceapi`,
+`actsubapi`, `cmdbinstanceapi`, `policyapi`, and `appointmentbookingapi` were sampled
+and confirmed to have the guard consistently, matching ADR-006's stated contract.
+
+The underlying defect class (nil receiver → wrong/missing error) is **not** fully
+closed, though: `cdmapplicationsapi`, `cdmchangesetapi`, and `cdmeditorapi` have
+**zero** nil-receiver guards on any verb method — these three packages don't even
+have the old `nil, nil` fallback, they nil-pointer-panic instead. ADR-006's claim
+that the guard was "applied across every `*api` package" is therefore inaccurate for
+these three packages today; the ADR text itself doesn't need editing, just the code
+catching up to it.
+
+This remaining gap is a materially different (and worse — panic, not a wrong return
+value) bug than what this doc originally tracked, so it's filed separately as
+[#551](https://github.com/michaeldcanady/servicenow-sdk-go/issues/551) rather than
+reopening this doc's scope. Recommend treating this doc as closed/historical once
+#551 lands.

--- a/release-2.0-issues/005-consolidate-error-sentinels.md
+++ b/release-2.0-issues/005-consolidate-error-sentinels.md
@@ -3,6 +3,8 @@
 - **Priority:** P1 — breaking-change window closes at 2.0
 - **Raised by:** Senior Principal Engineer
 - **Area:** SDK design / error handling
+- **Status (2026-07-24):** Confirmed still open by a follow-up audit against
+  `release/2.0` @ `aca3942`, with new concrete duplicate-name examples added below.
 
 ## Problem
 
@@ -18,17 +20,41 @@ matching a sentinel instead of the sentinel itself, which breaks `errors.Is` for
 callers. Once v2.0.0 ships, removing or re-homing any exported sentinel is a new
 breaking change, so this cleanup is now-or-wait-for-v3.
 
+## Confirmed concrete examples (2026-07-24 audit)
+
+Same identifier name, two different sentinel *values* (different message text),
+exported from two different importable packages — this is the exact shape that
+breaks `errors.Is` for a consumer who imports both:
+
+- `ErrNilContext`:
+  - Root `errors.go:7` — `errors.New("ctx cannot be nil")`
+  - `errors/errors.go:10` (`snerrors.ErrNilContext`) — `errors.New("context cannot be
+    nil")`
+- `ErrNilResponse`:
+  - `tableapi/errors.go:9` — `errors.New("response can't be nil")`
+  - `errors/errors.go:9` (`snerrors.ErrNilResponse`) — `errors.New("response cannot
+    be nil")`
+
+Additionally, `attachmentapi/errors.go` is a **fourth** micro-location for sentinels
+(e.g. `ErrNilParams`) that was not in the original three-location inventory above and
+should fold into the same consolidation pass rather than being missed.
+
 ## Recommendation
 
 1. Inventory: `grep -rn 'errors.New(' --include='*.go' . | grep -v _test` and diff the
    messages against `errors/errors.go`.
 2. Make `errors/errors.go` the single home for cross-package sentinels; deprecate (or
-   delete, since v2 may break) duplicates in `tableapi/errors.go` and friends — keep
-   package-local sentinels only where the condition is genuinely package-specific.
+   delete, since v2 may break) duplicates in `tableapi/errors.go`, `attachmentapi/errors.go`,
+   and root `errors.go` — keep package-local sentinels only where the condition is
+   genuinely package-specific.
 3. Replace inline `errors.New` duplicates with the shared sentinel by identity.
 4. Add a unit test that asserts, for each public verb-method failure mode, that
    `errors.Is(err, snerrors.ErrX)` holds — locking the contract for consumers.
 
 ## Cross-references
 
-- Issue 004 adds `ErrNilRequestBuilder`; do these together to avoid two sweeps.
+- Issue 004 adds `ErrNilRequestBuilder`; do these together to avoid two sweeps. (That
+  addition has since shipped for most `*api` packages — see the doc-004 status note
+  and [#551](https://github.com/michaeldcanady/servicenow-sdk-go/issues/551) for the
+  remaining CDM-package gap, which should reuse the same `snerrors.ErrNilRequestBuilder`
+  sentinel this consolidation is meant to protect.)

--- a/release-2.0-issues/README.md
+++ b/release-2.0-issues/README.md
@@ -12,6 +12,32 @@ Fix PRs are open against `release/2.0`:
 Issue 012's go-directive item is blocked by kiota-http-go's own `go 1.25.0` floor (see the issue file).
 Still open: 002/003 (release-day runbooks), 005 (remaining sentinel consolidation), 008, 011 (decision), 012 (test-module split), 014.
 
+## Status (2026-07-24)
+
+Follow-up codebase-exploration audit against `release/2.0` @ `aca3942` (post
+ADR-006 / PR #550):
+
+- **006, 007, 013 confirmed done.** No action. (007 has one harmless cosmetic
+  straggler — the Table API issue-label badge URL in `Readme.md:40` — not worth its
+  own tracker item; note left here in case someone wants to sweep it opportunistically.)
+- **004's original citations were stale** (the `tableapi` lines it named are fixed).
+  Doc corrected in place to reflect that, and to redirect the still-open part of its
+  scope — three CDM packages (`cdmapplicationsapi`, `cdmchangesetapi`,
+  `cdmeditorapi`) that have **zero** nil-receiver guards at all, contradicting
+  ADR-006's "applied everywhere" claim — to new issue
+  [#551](https://github.com/michaeldcanady/servicenow-sdk-go/issues/551).
+  **#551 blocks the v2.0.0 tag**: it's a code bug (nil-pointer panic instead of a
+  documented sentinel error) in public API surface that freezes at GA, not a
+  cosmetic/doc issue.
+- **005 confirmed still open**, with two new concrete duplicate-sentinel examples
+  added as evidence (`ErrNilContext`, `ErrNilResponse`) plus a fourth sentinel
+  micro-location (`attachmentapi/errors.go`) folded into scope. Does not block the
+  tag by itself — see reasoning in doc 005 and the audit notes — but should ship in
+  the same window as #551 since both touch `snerrors.ErrNilRequestBuilder`/sentinel
+  identity.
+- 001, 002, 003, 014 re-confirmed still open as previously tracked; no new
+  information this pass.
+
 ## Release blockers (P0)
 
 | # | Issue | Owner role |
@@ -19,18 +45,19 @@ Still open: 002/003 (release-day runbooks), 005 (remaining sentinel consolidatio
 | [001](001-ci-test-failures-never-fail-the-build.md) | CI test failures never fail the build (`report-tests.sh` always exits 0) | DevOps |
 | [002](002-no-release-path-from-release-2.0-to-v2.0.0-tag.md) | No defined path from `release/2.0` to a v2.0.0 tag; non-conventional commits and missing `BREAKING CHANGE` footer would yield v1.13.0 | DevOps + PM |
 | [003](003-v2-module-path-runbook.md) | `/v2` module path bump — deferred by design, needs a release-day runbook so the tag isn't burned | Engineering |
+| [#551](https://github.com/michaeldcanady/servicenow-sdk-go/issues/551) | Three CDM `*api` packages have zero nil-receiver guards, panic instead of returning `snerrors.ErrNilRequestBuilder`, contradicting ADR-006 | Engineering |
 
 ## High priority (P1) — do before GA
 
 | # | Issue | Owner role |
 | --- | --- | --- |
-| [004](004-nil-receiver-guards-return-nil-nil.md) | `return nil, nil` nil-receiver guards silently swallow bugs; fix the contract while breaking changes are free | Engineering |
-| [005](005-consolidate-error-sentinels.md) | Three error-sentinel locations + inline `errors.New` duplicates break `errors.Is` | Engineering |
-| [006](006-repo-hygiene-stray-working-files.md) | Scratch files (`coverage.html`, `fix_error_mappings.py`, `files_to_fix.txt`, ...) committed at repo root | PM + Engineering |
-| [007](007-readme-links-all-broken.md) | Every Readme API-table link 404s (old hyphenated directory names) | PM |
+| [004](004-nil-receiver-guards-return-nil-nil.md) | `return nil, nil` nil-receiver guards silently swallow bugs; original defect fixed, doc now points remaining CDM gap at #551 | Engineering |
+| [005](005-consolidate-error-sentinels.md) | Three (now four) error-sentinel locations + inline `errors.New` duplicates break `errors.Is` | Engineering |
+| [006](006-repo-hygiene-stray-working-files.md) | Scratch files (`coverage.html`, `fix_error_mappings.py`, `files_to_fix.txt`, ...) committed at repo root — **done** | PM + Engineering |
+| [007](007-readme-links-all-broken.md) | Every Readme API-table link 404s (old hyphenated directory names) — **done**, one cosmetic badge-URL straggler remains | PM |
 | [008](008-v2-migration-guide-and-launch-comms.md) | No v1→v2 migration guide, v1 support policy, or launch checklist | PM |
 | [009](009-ci-coverage-gaps.md) | Integration tests never run in CI; no govulncheck; unpinned lint/tool versions; stale lint exclusions | DevOps |
-| [014](014-public-api-surface-audit.md) | Final exported-surface audit before the API freezes at v2.0.0 | Engineering |
+| [014](014-public-api-surface-audit.md) | Final exported-surface audit before the API freezes at v2.0.0; confirmed `New<X>RequestBuilderInternal` constructors are exported (not internal) across `*api` packages | Engineering |
 
 ## Medium priority (P2) — decide before GA, fix opportunistically
 
@@ -39,13 +66,13 @@ Still open: 002/003 (release-day runbooks), 005 (remaining sentinel consolidatio
 | [010](010-docs-pipeline-inefficiencies.md) | Docs workflow: stale `pages.yml` filter, deploy rebuilds instead of using its artifact | DevOps |
 | [011](011-dual-release-please-channels.md) | Weekly-preview and stable release-please channels share one changelog/tag namespace | DevOps |
 | [012](012-go-directive-and-test-deps.md) | `go 1.25.0` floor limits adoption; godog/httpmock/godotenv pollute consumer-visible go.mod | Engineering |
-| [013](013-missing-security-and-governance-files.md) | No SECURITY.md/CODEOWNERS; verify Dependabot auto-merge is gated by required checks | DevOps + PM |
+| [013](013-missing-security-and-governance-files.md) | No SECURITY.md/CODEOWNERS; verify Dependabot auto-merge is gated by required checks — **done** | DevOps + PM |
 
 ## Suggested sequencing
 
 1. **Now:** 001 (real test gate) → then everything else merges against honest CI.
-2. **In parallel:** 004+005 (one error-contract sweep), 006, 007, 009, 014.
-3. **Product track:** 008 (migration guide + support policy), 011 decision, 013.
+2. **In parallel:** [#551](https://github.com/michaeldcanady/servicenow-sdk-go/issues/551) + 005 (one error-contract sweep, now that 004's original scope is done), 009, 014.
+3. **Product track:** 008 (migration guide + support policy), 011 decision.
 4. **Release day:** 003 then 002, in that order, per their runbooks.
 
 ## What we deliberately did not flag
@@ -54,3 +81,9 @@ Still open: 002/003 (release-day runbooks), 005 (remaining sentinel consolidatio
   matches the msgraph-sdk-go idiom the project intentionally targets.
 - `VERSION`/`CHANGELOG.md` automation — release-please wiring is correct for the
   steady state; only the 2.0 transition (002/003) and channel overlap (011) need work.
+- TODO/FIXME/HACK markers, stub bodies, ADR-007 speculative-builder-chain
+  violations, skipped/empty tests — none found in a 2026-07-24 sweep.
+- The missing `/v2` go.mod suffix — known, intentionally deferred to release day
+  (issue 003), not a new finding.
+- The NerdIT-Tech org question — resolved via ADR-010 / PR #550 (issue #496,
+  closed).


### PR DESCRIPTION
## Summary
- `release-2.0-issues/004-nil-receiver-guards-return-nil-nil.md`: corrects stale `tableapi` line citations (already fixed by #487) and redirects the still-open remainder of scope to #551.
- `release-2.0-issues/005-consolidate-error-sentinels.md`: adds two concrete duplicate-sentinel examples (`ErrNilContext`, `ErrNilResponse`) plus the `attachmentapi/errors.go` fourth micro-location, as evidence for the still-open consolidation work.
- `release-2.0-issues/README.md`: status refresh — adds #551 to the P0 blocker table, marks 006/007/013 done.

Docs-only, no code changes. Produced during a product-manager triage pass over a codebase audit of `release/2.0`.

## Test plan
- [x] Docs-only change; no code affected.
