### PR TITLE
fix(cdm): add nil-receiver guards to cdmapplicationsapi/cdmchangesetapi/cdmeditorapi

### DIFF
--- a/cdmapplicationsapi/applications_request_builders.go
+++ b/cdmapplicationsapi/applications_request_builders.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
@@ -79,6 +80,9 @@ func NewDeployablesRequestBuilderInternal(pathParameters map[string]string, requ
 
 // Delete deletes a deployable.
 func (rB *DeployablesRequestBuilder) Delete(ctx context.Context, config *DeployablesRequestBuilderDeleteRequestConfiguration) error {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -96,6 +100,9 @@ func (rB *DeployablesRequestBuilder) Delete(ctx context.Context, config *Deploya
 
 // Put updates deployables.
 func (rB *DeployablesRequestBuilder) Put(ctx context.Context, body *DeployableUpdateRequest, config *DeployablesRequestBuilderPutRequestConfiguration) (DeployableUpdateResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -136,6 +143,9 @@ func NewSharedComponentsRequestBuilderInternal(pathParameters map[string]string,
 
 // Delete deletes shared component references.
 func (rB *SharedComponentsRequestBuilder) Delete(ctx context.Context, config *SharedComponentsRequestBuilderDeleteRequestConfiguration) error {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -153,6 +163,9 @@ func (rB *SharedComponentsRequestBuilder) Delete(ctx context.Context, config *Sh
 
 // Put updates shared components.
 func (rB *SharedComponentsRequestBuilder) Put(ctx context.Context, body *SharedComponentUpdateRequest, config *SharedComponentsRequestBuilderPutRequestConfiguration) (SharedComponentUpdateResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -207,6 +220,9 @@ func NewUploadStatusItemRequestBuilderInternal(pathParameters map[string]string,
 
 // Get gets the status of a specific upload.
 func (rB *UploadStatusItemRequestBuilder) Get(ctx context.Context, config *UploadStatusItemRequestBuilderGetRequestConfiguration) (UploadStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -238,6 +254,9 @@ func NewExportsRequestBuilderInternal(pathParameters map[string]string, requestA
 
 // Get gets the collection of deployable exports.
 func (rB *ExportsRequestBuilder) Get(ctx context.Context, config *ExportsRequestBuilderGetRequestConfiguration) (ExportsResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -301,6 +320,9 @@ func NewExportItemStatusRequestBuilderInternal(pathParameters map[string]string,
 
 // Get gets the status of a specific export.
 func (rB *ExportItemStatusRequestBuilder) Get(ctx context.Context, config *ExportItemStatusRequestBuilderGetRequestConfiguration) (ExportStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -332,6 +354,9 @@ func NewExportItemContentRequestBuilderInternal(pathParameters map[string]string
 
 // Get fetches the export content.
 func (rB *ExportItemContentRequestBuilder) Get(ctx context.Context, config *ExportItemContentRequestBuilderGetRequestConfiguration) ([]byte, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -400,6 +425,9 @@ func NewSharedLibrariesComponentsApplicationsRequestBuilderInternal(pathParamete
 
 // Get gets the collection of shared library component applications.
 func (rB *SharedLibrariesComponentsApplicationsRequestBuilder) Get(ctx context.Context, config *SharedLibrariesComponentsApplicationsRequestBuilderGetRequestConfiguration) (SharedLibrariesComponentsApplicationsResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -461,6 +489,9 @@ func NewUploadsComponentsRequestBuilderInternal(pathParameters map[string]string
 
 // Post uploads components.
 func (rB *UploadsComponentsRequestBuilder) Post(ctx context.Context, body *ComponentUploadRequest, config *UploadsComponentsRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -501,6 +532,9 @@ func NewUploadsComponentsVarsRequestBuilderInternal(pathParameters map[string]st
 
 // Post uploads component variables.
 func (rB *UploadsComponentsVarsRequestBuilder) Post(ctx context.Context, body *ComponentVarsUploadRequest, config *UploadsComponentsVarsRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -536,6 +570,9 @@ func NewUploadsCollectionsRequestBuilderInternal(pathParameters map[string]strin
 
 // Post uploads collections.
 func (rB *UploadsCollectionsRequestBuilder) Post(ctx context.Context, body *CollectionUploadRequest, config *UploadsCollectionsRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -576,6 +613,9 @@ func NewUploadsCollectionsFileRequestBuilderInternal(pathParameters map[string]s
 
 // Post uploads collection files using a stream payload (like attachment-api)
 func (rB *UploadsCollectionsFileRequestBuilder) Post(ctx context.Context, media *Media, config *UploadsCollectionsFileRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -628,6 +668,9 @@ func NewUploadsDeployablesFileRequestBuilderInternal(pathParameters map[string]s
 
 // Post uploads deployable files.
 func (rB *UploadsDeployablesFileRequestBuilder) Post(ctx context.Context, media *Media, config *UploadsDeployablesFileRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {

--- a/cdmapplicationsapi/applications_request_builders_test.go
+++ b/cdmapplicationsapi/applications_request_builders_test.go
@@ -1,8 +1,10 @@
 package cdmapplicationsapi
 
 import (
+	"context"
 	"testing"
 
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/stretchr/testify/assert"
@@ -270,4 +272,178 @@ func TestUploadsDeployablesFileRequestBuilder_Post(t *testing.T) {
 	uri, err := requestInfo.GetUri()
 	assert.Nil(t, err)
 	assert.Equal(t, "https://example.service-now.com/api/sn_cdm/applications/uploads/deployables/file?appName=test_app&deployableName=test_dep", uri.String())
+}
+
+func TestDeployablesRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*DeployablesRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			err := builder.Delete(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+
+			resp, err := builder.Put(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestSharedComponentsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*SharedComponentsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			err := builder.Delete(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+
+			resp, err := builder.Put(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestUploadStatusItemRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*UploadStatusItemRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestExportsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ExportsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestExportItemStatusRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ExportItemStatusRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestExportItemContentRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ExportItemContentRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestSharedLibrariesComponentsApplicationsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*SharedLibrariesComponentsApplicationsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestUploadsComponentsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*UploadsComponentsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Post(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestUploadsComponentsVarsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*UploadsComponentsVarsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Post(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestUploadsCollectionsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*UploadsCollectionsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Post(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestUploadsCollectionsFileRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*UploadsCollectionsFileRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Post(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestUploadsDeployablesFileRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*UploadsDeployablesFileRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Post(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
 }

--- a/cdmchangesetapi/changeset_request_builders.go
+++ b/cdmchangesetapi/changeset_request_builders.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
@@ -58,6 +59,9 @@ func (rB *ChangesetsRequestBuilder) ByID(id string) *ChangesetItemRequestBuilder
 }
 
 func (rB *ChangesetsRequestBuilder) Get(ctx context.Context, config *ChangesetsRequestBuilderGetRequestConfiguration) (ChangesetsResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -79,6 +83,9 @@ func (rB *ChangesetsRequestBuilder) Get(ctx context.Context, config *ChangesetsR
 }
 
 func (rB *ChangesetsRequestBuilder) Delete(ctx context.Context, config *ChangesetsRequestBuilderDeleteRequestConfiguration) error {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -106,6 +113,9 @@ func NewChangesetActivityRequestBuilderInternal(pathParameters map[string]string
 }
 
 func (rB *ChangesetActivityRequestBuilder) Get(ctx context.Context, config *ChangesetActivityRequestBuilderGetRequestConfiguration) (ChangesetActivityResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -155,6 +165,9 @@ func NewCommitStatusItemRequestBuilderInternal(pathParameters map[string]string,
 }
 
 func (rB *CommitStatusItemRequestBuilder) Get(ctx context.Context, config *CommitStatusRequestBuilderGetRequestConfiguration) (CommitStatusResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -184,6 +197,9 @@ func NewImpactedSharedComponentsRequestBuilderInternal(pathParameters map[string
 }
 
 func (rB *ImpactedSharedComponentsRequestBuilder) Get(ctx context.Context, config *ImpactedSharedComponentsRequestBuilderGetRequestConfiguration) (ImpactedSharedComponentsResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -216,6 +232,9 @@ func NewImpactedDeployablesRequestBuilderInternal(pathParameters map[string]stri
 }
 
 func (rB *ImpactedDeployablesRequestBuilder) Get(ctx context.Context, config *ImpactedDeployablesRequestBuilderGetRequestConfiguration) (ImpactedDeployablesResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -264,6 +283,9 @@ func NewImpactedDeployablesBySysIdRequestBuilderInternal(pathParameters map[stri
 }
 
 func (rB *ImpactedDeployablesBySysIdRequestBuilder) Get(ctx context.Context, config *ImpactedDeployablesBySysIdRequestBuilderGetRequestConfiguration) (ImpactedDeployablesBySysIdResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {

--- a/cdmchangesetapi/changeset_request_builders_test.go
+++ b/cdmchangesetapi/changeset_request_builders_test.go
@@ -1,8 +1,10 @@
 package cdmchangesetapi
 
 import (
+	"context"
 	"testing"
 
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/stretchr/testify/assert"
@@ -104,4 +106,91 @@ func TestChangesetItemRequestBuilder_ImpactedDeployables(t *testing.T) {
 
 	uri, _ := requestInfo.GetUri()
 	assert.Equal(t, "https://example.service-now.com/api/sn_cdm/changesets/sys123/impacted-deployables", uri.String())
+}
+
+func TestChangesetsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ChangesetsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+
+			err = builder.Delete(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+		})
+	}
+}
+
+func TestChangesetActivityRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ChangesetActivityRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestCommitStatusItemRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*CommitStatusItemRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestImpactedSharedComponentsRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ImpactedSharedComponentsRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestImpactedDeployablesRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ImpactedDeployablesRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestImpactedDeployablesBySysIdRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ImpactedDeployablesBySysIdRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
 }

--- a/cdmeditorapi/editor_request_builders.go
+++ b/cdmeditorapi/editor_request_builders.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/conversion"
 	internalhttp "github.com/michaeldcanady/servicenow-sdk-go/internal/http"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
@@ -57,6 +58,9 @@ func (rB *NodesRequestBuilder) ByID(id string) *NodeItemRequestBuilder {
 }
 
 func (rB *NodesRequestBuilder) Get(ctx context.Context, config *NodesRequestBuilderGetRequestConfiguration) (NodesResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -78,6 +82,9 @@ func (rB *NodesRequestBuilder) Get(ctx context.Context, config *NodesRequestBuil
 }
 
 func (rB *NodesRequestBuilder) Post(ctx context.Context, body NodeCreateRequest, config *NodesRequestBuilderPostRequestConfiguration) (NodeResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -111,6 +118,9 @@ func NewNodeItemRequestBuilderInternal(pathParameters map[string]string, request
 }
 
 func (rB *NodeItemRequestBuilder) Put(ctx context.Context, body NodeUpdateRequest, config *NodeItemRequestBuilderPutRequestConfiguration) (NodeResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -133,6 +143,9 @@ func (rB *NodeItemRequestBuilder) Put(ctx context.Context, body NodeUpdateReques
 }
 
 func (rB *NodeItemRequestBuilder) Delete(ctx context.Context, config *NodeItemRequestBuilderDeleteRequestConfiguration) (NodeDeleteResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -162,6 +175,9 @@ func NewValidationRequestBuilderInternal(pathParameters map[string]string, reque
 }
 
 func (rB *ValidationRequestBuilder) Get(ctx context.Context, config *ValidationRequestBuilderGetRequestConfiguration) (ValidationResponse, error) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+		return nil, snerrors.ErrNilRequestBuilder
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {

--- a/cdmeditorapi/editor_request_builders_test.go
+++ b/cdmeditorapi/editor_request_builders_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	jsonserialization "github.com/microsoft/kiota-serialization-json-go"
@@ -131,4 +132,54 @@ func TestValidationRequestBuilder_Get(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, mockRes, resp)
 	})
+}
+
+func TestNodesRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*NodesRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+
+			postResp, err := builder.Post(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, postResp)
+		})
+	}
+}
+
+func TestNodeItemRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*NodeItemRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			putResp, err := builder.Put(context.Background(), nil, nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, putResp)
+
+			delResp, err := builder.Delete(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, delResp)
+		})
+	}
+}
+
+func TestValidationRequestBuilder_NilReceiverGuards(t *testing.T) {
+	builders := map[string]*ValidationRequestBuilder{
+		"nil builder":              nil,
+		"nil inner RequestBuilder": {},
+	}
+	for name, builder := range builders {
+		t.Run(name, func(t *testing.T) {
+			resp, err := builder.Get(context.Background(), nil)
+			assert.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+			assert.Nil(t, resp)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Adds the standard ADR-006 nil-receiver guard (`conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder)` → `snerrors.ErrNilRequestBuilder`) to all 26 `Get`/`Post`/`Put`/`Delete` verb methods across `cdmapplicationsapi`, `cdmchangesetapi`, and `cdmeditorapi` — matching the pattern already used in `caseapi`, `tableapi`, `policyapi`, and others.
- Previously a nil builder receiver in these three packages would nil-pointer-panic instead of returning the sentinel error, contradicting ADR-006's claim that the guard was "applied across every `*api` package."
- Adds minimal nil-guard tests per builder type (26 subtests) asserting `errors.Is(err, snerrors.ErrNilRequestBuilder)` for both nil-outer-builder and nil-inner-`RequestBuilder` cases.

Filed #553 as a follow-up to rewrite these packages' full test suites to the fuller table-driven mocked-`Send` pattern used elsewhere (out of scope here — this PR only adds what's needed to cover the guard).

Resolves #551.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./cdmapplicationsapi/... ./cdmchangesetapi/... ./cdmeditorapi/...` — clean
- [x] `golangci-lint run` on the three packages — 0 issues
- [x] `go test ./cdmapplicationsapi/... ./cdmchangesetapi/... ./cdmeditorapi/... -v` — all pass, including new nil-guard subtests
