### PR TITLE
fix: add missing request-adapter nil-guards across ~40 API packages

### DIFF
--- a/accountapi/account_item_request_builder.go
+++ b/accountapi/account_item_request_builder.go
@@ -31,6 +31,10 @@ func (rB *AccountItemRequestBuilder) Get(ctx context.Context, config *AccountIte
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err

--- a/accountapi/account_item_request_builder_test.go
+++ b/accountapi/account_item_request_builder_test.go
@@ -19,6 +19,15 @@ func TestAccountItemRequestBuilder_Get_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestAccountItemRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewAccountItemRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "account_id": "test-id"}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestAccountItemRequestBuilder_ToGetRequestInformation_NilBuilder(t *testing.T) {
 	var builder *AccountItemRequestBuilder
 

--- a/accountapi/account_request_builder.go
+++ b/accountapi/account_request_builder.go
@@ -12,7 +12,10 @@ import (
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
-const accountURLTemplate = "{+baseurl}/api/now/v1/account"
+const (
+	accountURLTemplate = "{+baseurl}/api/now/v1/account"
+	accountIDKey       = "account_id"
+)
 
 // AccountRequestBuilder provides operations to manage accounts.
 type AccountRequestBuilder struct {
@@ -29,7 +32,7 @@ func NewAccountRequestBuilderInternal(pathParameters map[string]string, requestA
 // ByID returns an AccountItemRequestBuilder for the specified account ID.
 func (rB *AccountRequestBuilder) ByID(accountID string) *AccountItemRequestBuilder {
 	pathParameters := maps.Clone(rB.GetPathParameters())
-	pathParameters["account_id"] = accountID
+	pathParameters[accountIDKey] = accountID
 	return NewAccountItemRequestBuilderInternal(pathParameters, rB.GetRequestAdapter())
 }
 
@@ -37,6 +40,10 @@ func (rB *AccountRequestBuilder) ByID(accountID string) *AccountItemRequestBuild
 func (rB *AccountRequestBuilder) Get(ctx context.Context, config *AccountRequestBuilderGetRequestConfiguration) (AccountCollectionResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)

--- a/accountapi/account_request_builder_test.go
+++ b/accountapi/account_request_builder_test.go
@@ -22,6 +22,15 @@ func TestAccountRequestBuilder_Get_NilBuilder(t *testing.T) {
 	assert.Nil(t, res)
 }
 
+func TestAccountRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewAccountRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	res, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, res)
+}
+
 func TestAccountRequestBuilder_ToGetRequestInformation_NilBuilder(t *testing.T) {
 	var builder *AccountRequestBuilder
 

--- a/actsubapi/collection_get_request_builder.go
+++ b/actsubapi/collection_get_request_builder.go
@@ -34,6 +34,10 @@ func (rB *collectionGetRequestBuilder) Get(ctx context.Context, config *abstract
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err

--- a/actsubapi/collection_get_request_builder_test.go
+++ b/actsubapi/collection_get_request_builder_test.go
@@ -19,6 +19,7 @@ func TestCollectionGetRequestBuilder_Get(t *testing.T) {
 		name       string
 		nilBuilder bool
 		nilInner   bool
+		nilAdapter bool
 		config     *abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]
 		mockRes    interface{}
 		mockErr    error
@@ -47,6 +48,10 @@ func TestCollectionGetRequestBuilder_Get(t *testing.T) {
 			name:     "Nil inner request builder",
 			nilInner: true,
 		},
+		{
+			name:       "Nil request adapter",
+			nilAdapter: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -58,6 +63,8 @@ func TestCollectionGetRequestBuilder_Get(t *testing.T) {
 				builder = nil
 			case tc.nilInner:
 				builder = &collectionGetRequestBuilder{nil}
+			case tc.nilAdapter:
+				builder = newCollectionGetRequestBuilder(map[string]string{"baseurl": "https://example.com"}, nil, activitiesURLTemplate)
 			default:
 				adapter := &mocking.MockRequestAdapter{}
 				adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tc.mockRes, tc.mockErr)
@@ -69,6 +76,9 @@ func TestCollectionGetRequestBuilder_Get(t *testing.T) {
 			switch {
 			case tc.nilBuilder, tc.nilInner:
 				require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+				assert.Nil(t, resp)
+			case tc.nilAdapter:
+				require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
 				assert.Nil(t, resp)
 			case tc.expectErr:
 				require.Error(t, err)

--- a/actsubapi/facets_request_builder.go
+++ b/actsubapi/facets_request_builder.go
@@ -84,6 +84,10 @@ func (rB *FacetsInstanceRequestBuilder) Get(ctx context.Context, config *FacetsR
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err

--- a/actsubapi/nil_guard_extra2_test.go
+++ b/actsubapi/nil_guard_extra2_test.go
@@ -155,3 +155,74 @@ func TestUnsubscribeRequestBuilder_ToDeleteRequestInformation_NilBuilder(t *test
 	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 	assert.Nil(t, requestInfo)
 }
+
+func TestUserStreamItemRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewUserStreamItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUserStreamItemRequestBuilder_Put_NilRequestAdapter(t *testing.T) {
+	builder := NewUserStreamItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Put(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestPreferencesRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewPreferencesRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestPreferenceItemRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewPreferenceItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestSubscriptionItemRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewSubscriptionItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestIsSubscribedRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewIsSubscribedRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestSubscribeRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewSubscribeRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUnsubscribeRequestBuilder_Delete_NilRequestAdapter(t *testing.T) {
+	builder := NewUnsubscribeRequestBuilderInternal(map[string]string{}, nil)
+
+	err := builder.Delete(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}

--- a/actsubapi/nil_guard_extra_test.go
+++ b/actsubapi/nil_guard_extra_test.go
@@ -93,6 +93,15 @@ func TestFacetsInstanceRequestBuilder_Get_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestFacetsInstanceRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewFacetsInstanceRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestFacetsInstanceRequestBuilder_ToGetRequestInformation_NilBuilder(t *testing.T) {
 	var builder *FacetsInstanceRequestBuilder
 

--- a/actsubapi/preferences_request_builder.go
+++ b/actsubapi/preferences_request_builder.go
@@ -36,6 +36,10 @@ func (rB *PreferencesRequestBuilder) Post(ctx context.Context, body *ActivitySub
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
 	if err != nil {
 		return nil, err
@@ -103,6 +107,10 @@ func NewPreferenceItemRequestBuilderInternal(pathParameters map[string]string, r
 func (rB *PreferenceItemRequestBuilder) Get(ctx context.Context, config *PreferencesRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)

--- a/actsubapi/subscriptions_request_builder.go
+++ b/actsubapi/subscriptions_request_builder.go
@@ -70,6 +70,10 @@ func (rB *SubscriptionItemRequestBuilder) Get(ctx context.Context, config *Subsc
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -162,6 +166,10 @@ func (rB *IsSubscribedRequestBuilder) Get(ctx context.Context, config *IsSubscri
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -213,6 +221,10 @@ func NewSubscribeRequestBuilderInternal(pathParameters map[string]string, reques
 func (rB *SubscribeRequestBuilder) Post(ctx context.Context, body *ActivitySubscriptionModel, config *SubscribeRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -273,6 +285,10 @@ func NewUnsubscribeRequestBuilderInternal(pathParameters map[string]string, requ
 func (rB *UnsubscribeRequestBuilder) Delete(ctx context.Context, config *UnsubscribeRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, config)

--- a/actsubapi/user_stream_request_builder.go
+++ b/actsubapi/user_stream_request_builder.go
@@ -59,6 +59,10 @@ func (rB *UserStreamItemRequestBuilder) Get(ctx context.Context, config *UserStr
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -95,6 +99,10 @@ func (rB *UserStreamItemRequestBuilder) ToGetRequestInformation(_ context.Contex
 func (rB *UserStreamItemRequestBuilder) Put(ctx context.Context, body *ActivitySubscriptionModel, config *UserStreamRequestBuilderPutRequestConfiguration) (*core.BaseServiceNowItemResponse[*ActivitySubscriptionModel], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)

--- a/appointmentbookingapi/appointment_request_builder.go
+++ b/appointmentbookingapi/appointment_request_builder.go
@@ -27,6 +27,10 @@ func (rB *AppointmentRequestBuilder) Post(ctx context.Context, body AppointmentR
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
 	if err != nil {
 		return nil, err

--- a/appointmentbookingapi/nil_guard_extra_test.go
+++ b/appointmentbookingapi/nil_guard_extra_test.go
@@ -119,3 +119,57 @@ func TestUserWindowRequestBuilder_ToPostRequestInformation_NilBuilder(t *testing
 	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 	assert.Nil(t, requestInfo)
 }
+
+func TestAppointmentRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewAppointmentRequestBuilder(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestAvailabilityRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewAvailabilityRequestBuilder(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestCalendarRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewCalendarRequestBuilder(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestConfigurationRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewConfigurationRequestBuilder(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestExecuteRuleConditionsRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewExecuteRuleConditionsRequestBuilder(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUserWindowRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewUserWindowRequestBuilder(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}

--- a/appointmentbookingapi/sub_request_builders.go
+++ b/appointmentbookingapi/sub_request_builders.go
@@ -30,6 +30,10 @@ func (rB *AvailabilityRequestBuilder) Post(ctx context.Context, body Availabilit
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
 	if err != nil {
 		return nil, err
@@ -84,6 +88,10 @@ func (rB *CalendarRequestBuilder) Get(ctx context.Context, config *CalendarReque
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -133,6 +141,10 @@ func (rB *ConfigurationRequestBuilder) Get(ctx context.Context, config *Configur
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -180,6 +192,10 @@ func NewExecuteRuleConditionsRequestBuilder(pathParameters map[string]string, re
 func (rB *ExecuteRuleConditionsRequestBuilder) Post(ctx context.Context, body ExecuteRuleConditionsRequest, config *ExecuteRuleConditionsRequestBuilderPostRequestConfiguration) (ExecuteRuleConditionsResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
@@ -234,6 +250,10 @@ func NewUserWindowRequestBuilder(pathParameters map[string]string, requestAdapte
 func (rB *UserWindowRequestBuilder) Post(ctx context.Context, body any, config *UserWindowRequestBuilderPostRequestConfiguration) (AvailabilityResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)

--- a/appserviceapi/appservice_request_builders.go
+++ b/appserviceapi/appservice_request_builders.go
@@ -109,6 +109,10 @@ func (rB *PopulateServiceRequestBuilder) Put(ctx context.Context, body *Populate
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
 	if err != nil {
 		return nil, err
@@ -157,6 +161,10 @@ func NewServiceDetailsRequestBuilderInternal(pathParameters map[string]string, r
 func (rB *ServiceDetailsRequestBuilder) Put(ctx context.Context, body *ServiceDetailsRequest, config *ServiceDetailsRequestConfiguration) (ServiceDetailsResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)

--- a/appserviceapi/find_service_request_builder.go
+++ b/appserviceapi/find_service_request_builder.go
@@ -29,6 +29,10 @@ func (rB *FindServiceRequestBuilder) Get(ctx context.Context, config *FindServic
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err

--- a/appserviceapi/nil_guard_extra_test.go
+++ b/appserviceapi/nil_guard_extra_test.go
@@ -102,6 +102,51 @@ func TestServiceDetailsRequestBuilder_ToPutRequestInformation_NilBuilder(t *test
 	assert.Nil(t, requestInfo)
 }
 
+func TestRegisterServiceRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewRegisterServiceRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestCreateRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewCreateRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestFindServiceRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewFindServiceRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestPopulateServiceRequestBuilder_Put_NilRequestAdapter(t *testing.T) {
+	builder := NewPopulateServiceRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Put(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestServiceDetailsRequestBuilder_Put_NilRequestAdapter(t *testing.T) {
+	builder := NewServiceDetailsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Put(context.Background(), nil, nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 // ---------------------------------------------------------------------------
 // Child-builder nil-receiver guards (AppServiceRequestBuilder, CsdmRequestBuilder,
 // CsdmAppServiceItemRequestBuilder)

--- a/appserviceapi/service_post_request_builder.go
+++ b/appserviceapi/service_post_request_builder.go
@@ -37,6 +37,10 @@ func (rB *servicePostRequestBuilder[TBody, TResponse]) post(ctx context.Context,
 		return zero, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return zero, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.toPostRequestInformation(ctx, body, config)
 	if err != nil {
 		return zero, err

--- a/attachmentapi/attachment_item_request_builder.go
+++ b/attachmentapi/attachment_item_request_builder.go
@@ -66,6 +66,10 @@ func (rB *AttachmentItemRequestBuilder) Get(ctx context.Context, requestConfigur
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)
 	if err != nil {
 		return nil, err
@@ -93,6 +97,10 @@ func (rB *AttachmentItemRequestBuilder) Get(ctx context.Context, requestConfigur
 func (rB *AttachmentItemRequestBuilder) Delete(ctx context.Context, requestConfiguration *AttachmentItemRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, requestConfiguration)

--- a/attachmentapi/attachment_item_request_builder_test.go
+++ b/attachmentapi/attachment_item_request_builder_test.go
@@ -472,3 +472,20 @@ func TestAttachmentItemRequestBuilder_ToDeleteRequestInformation(t *testing.T) {
 		})
 	}
 }
+
+func TestAttachmentItemRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewAttachmentItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
+
+func TestAttachmentItemRequestBuilder_Delete_NilRequestAdapter(t *testing.T) {
+	builder := NewAttachmentItemRequestBuilderInternal(map[string]string{}, nil)
+
+	err := builder.Delete(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}

--- a/attachmentapi/attachment_request_builder.go
+++ b/attachmentapi/attachment_request_builder.go
@@ -89,8 +89,12 @@ func (rB *AttachmentRequestBuilder) Upload() *AttachmentUploadRequestBuilder {
 
 // Get returns AttachmentCollectionResponse using provided arguments
 func (rB *AttachmentRequestBuilder) Get(ctx context.Context, requestConfiguration *AttachmentRequestBuilderGetRequestConfiguration) (*AttachmentCollectionResponse, error) {
-	if conversion.IsNil(rB) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	if conversion.IsNil(requestConfiguration) {

--- a/attachmentapi/attachment_request_builder_test.go
+++ b/attachmentapi/attachment_request_builder_test.go
@@ -76,6 +76,15 @@ func TestAttachmentRequestBuilder_Get_NilBuilder(t *testing.T) {
 	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 }
 
+func TestAttachmentRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewAttachmentRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
+
 func TestAttachmentRequestBuilder_Head_NilBuilder(t *testing.T) {
 	builder := (*AttachmentRequestBuilder)(nil)
 

--- a/attachmentapi/attachment_upload_request_builder.go
+++ b/attachmentapi/attachment_upload_request_builder.go
@@ -52,8 +52,12 @@ func NewAttachmentUploadRequestBuilder(
 
 // Post Uploads the provided attachment using the provided arguments
 func (rB *AttachmentUploadRequestBuilder) Post(ctx context.Context, body abstractions.MultipartBody, requestConfiguration *AttachmentUploadRequestBuilderPostRequestConfiguration) (*File, error) {
-	if conversion.IsNil(rB) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	if conversion.IsNil(body) {

--- a/attachmentapi/attachment_upload_request_builder_test.go
+++ b/attachmentapi/attachment_upload_request_builder_test.go
@@ -232,6 +232,15 @@ func TestAttachmentUploadRequestBuilder_Post_NilBuilder(t *testing.T) {
 	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 }
 
+func TestAttachmentUploadRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	rb := NewAttachmentUploadRequestBuilderInternal(map[string]string{}, nil)
+
+	res, err := rb.Post(context.Background(), abstractions.NewMultipartBody(), nil)
+
+	assert.Nil(t, res)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
+
 func TestAttachmentUploadRequestBuilder_ToPostRequestInformation(t *testing.T) {
 	setupMockSerialization := func(mockContent abstractions.MultipartBody) *mocking.MockSerializationWriterFactory {
 		mockSerializationWriter := mocking.NewMockSerializationWriter()

--- a/batchapi/batch_request_builder.go
+++ b/batchapi/batch_request_builder.go
@@ -92,6 +92,10 @@ func (rB *BatchRequestBuilder) Post(ctx context.Context, body BatchRequest, requ
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	if conversion.IsNil(body) {
 		return nil, snerrors.NewValidationError("body")
 	}

--- a/batchapi/batch_request_builder_test.go
+++ b/batchapi/batch_request_builder_test.go
@@ -363,6 +363,7 @@ func TestBatchRequestBuilder_Post(t *testing.T) {
 				expected.AddRequestOptions([]abstractions.RequestOption{})
 
 				mockInternalRequestBuilder := mocking.NewMockRequestBuilder()
+				mockInternalRequestBuilder.On("GetRequestAdapter").Return(mocking.NewMockRequestAdapter())
 
 				builder := &BatchRequestBuilder{mockInternalRequestBuilder}
 
@@ -396,6 +397,19 @@ func TestBatchRequestBuilder_Post(t *testing.T) {
 
 				require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 				assert.Nil(t, requestInformation)
+			},
+		},
+		{
+			name: "Nil request adapter",
+			test: func(t *testing.T) {
+				request := newMockBatchRequest()
+
+				builder := NewBatchRequestBuilderInternal(map[string]string{}, nil)
+
+				result, err := builder.Post(context.Background(), request, nil)
+
+				require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+				assert.Nil(t, result)
 			},
 		},
 	}

--- a/caseapi/case_request_builder.go
+++ b/caseapi/case_request_builder.go
@@ -51,6 +51,9 @@ func (rB *CaseRequestBuilder) Get(ctx context.Context, config *CaseRequestBuilde
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -84,6 +87,9 @@ func (rB *CaseRequestBuilder) ToGetRequestInformation(_ context.Context, config 
 func (rB *CaseRequestBuilder) Post(ctx context.Context, body CaseResult, config *CaseRequestBuilderPostRequestConfiguration) (CaseItemResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
 	if err != nil {

--- a/caseapi/case_request_builder_test.go
+++ b/caseapi/case_request_builder_test.go
@@ -97,11 +97,12 @@ func TestCaseRequestBuilder_ToGetRequestInformation(t *testing.T) {
 
 func TestCaseRequestBuilder_Get(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupMock func(m *mocking.MockRequestAdapter)
-		nilRecv   bool
-		wantErr   error
-		wantNil   bool
+		name       string
+		setupMock  func(m *mocking.MockRequestAdapter)
+		nilRecv    bool
+		nilAdapter bool
+		wantErr    error
+		wantNil    bool
 	}{
 		{
 			name: "happy path - returns collection response",
@@ -131,12 +132,25 @@ func TestCaseRequestBuilder_Get(t *testing.T) {
 			nilRecv: true,
 			wantErr: snerrors.ErrNilRequestBuilder,
 		},
+		{
+			name:       "nil request adapter returns ErrNilRequestAdapter",
+			nilAdapter: true,
+			wantErr:    snerrors.ErrNilRequestAdapter,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.nilRecv {
 				var builder *CaseRequestBuilder
+				resp, err := builder.Get(context.Background(), nil)
+				assert.Nil(t, resp)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			if tt.nilAdapter {
+				builder := NewCaseRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
 				resp, err := builder.Get(context.Background(), nil)
 				assert.Nil(t, resp)
 				require.ErrorIs(t, err, tt.wantErr)
@@ -210,11 +224,12 @@ func TestCaseRequestBuilder_ToPostRequestInformation(t *testing.T) {
 
 func TestCaseRequestBuilder_Post(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupMock func(m *mocking.MockRequestAdapter)
-		nilRecv   bool
-		wantErr   error
-		wantNil   bool
+		name       string
+		setupMock  func(m *mocking.MockRequestAdapter)
+		nilRecv    bool
+		nilAdapter bool
+		wantErr    error
+		wantNil    bool
 	}{
 		{
 			name: "happy path - returns item response",
@@ -247,12 +262,25 @@ func TestCaseRequestBuilder_Post(t *testing.T) {
 			nilRecv: true,
 			wantErr: snerrors.ErrNilRequestBuilder,
 		},
+		{
+			name:       "nil request adapter returns ErrNilRequestAdapter",
+			nilAdapter: true,
+			wantErr:    snerrors.ErrNilRequestAdapter,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.nilRecv {
 				var builder *CaseRequestBuilder
+				resp, err := builder.Post(context.Background(), NewCaseResult(), nil)
+				assert.Nil(t, resp)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			if tt.nilAdapter {
+				builder := NewCaseRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
 				resp, err := builder.Post(context.Background(), NewCaseResult(), nil)
 				assert.Nil(t, resp)
 				require.ErrorIs(t, err, tt.wantErr)
@@ -350,11 +378,12 @@ func TestCaseItemRequestBuilder_ToGetRequestInformation(t *testing.T) {
 
 func TestCaseItemRequestBuilder_Get(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupMock func(m *mocking.MockRequestAdapter)
-		nilRecv   bool
-		wantErr   error
-		wantNil   bool
+		name       string
+		setupMock  func(m *mocking.MockRequestAdapter)
+		nilRecv    bool
+		nilAdapter bool
+		wantErr    error
+		wantNil    bool
 	}{
 		{
 			name: "happy path - returns item response",
@@ -384,12 +413,25 @@ func TestCaseItemRequestBuilder_Get(t *testing.T) {
 			nilRecv: true,
 			wantErr: snerrors.ErrNilRequestBuilder,
 		},
+		{
+			name:       "nil request adapter returns ErrNilRequestAdapter",
+			nilAdapter: true,
+			wantErr:    snerrors.ErrNilRequestAdapter,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.nilRecv {
 				var builder *CaseItemRequestBuilder
+				resp, err := builder.Get(context.Background(), nil)
+				assert.Nil(t, resp)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			if tt.nilAdapter {
+				builder := NewCaseItemRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "id": "test-id"}, nil)
 				resp, err := builder.Get(context.Background(), nil)
 				assert.Nil(t, resp)
 				require.ErrorIs(t, err, tt.wantErr)
@@ -463,11 +505,12 @@ func TestCaseItemRequestBuilder_ToPutRequestInformation(t *testing.T) {
 
 func TestCaseItemRequestBuilder_Put(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupMock func(m *mocking.MockRequestAdapter)
-		nilRecv   bool
-		wantErr   error
-		wantNil   bool
+		name       string
+		setupMock  func(m *mocking.MockRequestAdapter)
+		nilRecv    bool
+		nilAdapter bool
+		wantErr    error
+		wantNil    bool
 	}{
 		{
 			name: "happy path - returns item response",
@@ -500,12 +543,25 @@ func TestCaseItemRequestBuilder_Put(t *testing.T) {
 			nilRecv: true,
 			wantErr: snerrors.ErrNilRequestBuilder,
 		},
+		{
+			name:       "nil request adapter returns ErrNilRequestAdapter",
+			nilAdapter: true,
+			wantErr:    snerrors.ErrNilRequestAdapter,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.nilRecv {
 				var builder *CaseItemRequestBuilder
+				resp, err := builder.Put(context.Background(), NewCaseResult(), nil)
+				assert.Nil(t, resp)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			if tt.nilAdapter {
+				builder := NewCaseItemRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "id": "test-id"}, nil)
 				resp, err := builder.Put(context.Background(), NewCaseResult(), nil)
 				assert.Nil(t, resp)
 				require.ErrorIs(t, err, tt.wantErr)
@@ -573,11 +629,12 @@ func TestCaseActivitiesRequestBuilder_ToGetRequestInformation(t *testing.T) {
 
 func TestCaseActivitiesRequestBuilder_Get(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupMock func(m *mocking.MockRequestAdapter)
-		nilRecv   bool
-		wantErr   error
-		wantNil   bool
+		name       string
+		setupMock  func(m *mocking.MockRequestAdapter)
+		nilRecv    bool
+		nilAdapter bool
+		wantErr    error
+		wantNil    bool
 	}{
 		{
 			name: "happy path - returns item response",
@@ -607,12 +664,25 @@ func TestCaseActivitiesRequestBuilder_Get(t *testing.T) {
 			nilRecv: true,
 			wantErr: snerrors.ErrNilRequestBuilder,
 		},
+		{
+			name:       "nil request adapter returns ErrNilRequestAdapter",
+			nilAdapter: true,
+			wantErr:    snerrors.ErrNilRequestAdapter,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.nilRecv {
 				var builder *CaseActivitiesRequestBuilder
+				resp, err := builder.Get(context.Background(), nil)
+				assert.Nil(t, resp)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			if tt.nilAdapter {
+				builder := NewCaseActivitiesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "id": "test-id"}, nil)
 				resp, err := builder.Get(context.Background(), nil)
 				assert.Nil(t, resp)
 				require.ErrorIs(t, err, tt.wantErr)
@@ -686,11 +756,12 @@ func TestCaseFieldValuesRequestBuilder_ToGetRequestInformation(t *testing.T) {
 
 func TestCaseFieldValuesRequestBuilder_Get(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupMock func(m *mocking.MockRequestAdapter)
-		nilRecv   bool
-		wantErr   error
-		wantNil   bool
+		name       string
+		setupMock  func(m *mocking.MockRequestAdapter)
+		nilRecv    bool
+		nilAdapter bool
+		wantErr    error
+		wantNil    bool
 	}{
 		{
 			name: "happy path - returns item response",
@@ -720,12 +791,25 @@ func TestCaseFieldValuesRequestBuilder_Get(t *testing.T) {
 			nilRecv: true,
 			wantErr: snerrors.ErrNilRequestBuilder,
 		},
+		{
+			name:       "nil request adapter returns ErrNilRequestAdapter",
+			nilAdapter: true,
+			wantErr:    snerrors.ErrNilRequestAdapter,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.nilRecv {
 				var builder *CaseFieldValuesRequestBuilder
+				resp, err := builder.Get(context.Background(), nil)
+				assert.Nil(t, resp)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			if tt.nilAdapter {
+				builder := NewCaseFieldValuesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "field_name": "state"}, nil)
 				resp, err := builder.Get(context.Background(), nil)
 				assert.Nil(t, resp)
 				require.ErrorIs(t, err, tt.wantErr)

--- a/caseapi/sub_request_builders.go
+++ b/caseapi/sub_request_builders.go
@@ -53,6 +53,9 @@ func (rB *CaseItemRequestBuilder) Get(ctx context.Context, config *CaseItemReque
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -86,6 +89,9 @@ func (rB *CaseItemRequestBuilder) ToGetRequestInformation(_ context.Context, con
 func (rB *CaseItemRequestBuilder) Put(ctx context.Context, body CaseResult, config *CaseItemRequestBuilderPutRequestConfiguration) (CaseItemResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
 	if err != nil {
@@ -137,6 +143,9 @@ func (rB *CaseActivitiesRequestBuilder) Get(ctx context.Context, config *CaseAct
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -187,6 +196,9 @@ func NewItemFieldValuesRequestBuilderInternal(pathParameters map[string]string, 
 func (rB *CaseFieldValuesRequestBuilder) Get(ctx context.Context, config *CaseFieldValuesRequestBuilderGetRequestConfiguration) (FieldValuesResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {

--- a/cdmapplicationsapi/applications_request_builders.go
+++ b/cdmapplicationsapi/applications_request_builders.go
@@ -83,6 +83,9 @@ func (rB *DeployablesRequestBuilder) Delete(ctx context.Context, config *Deploya
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -102,6 +105,9 @@ func (rB *DeployablesRequestBuilder) Delete(ctx context.Context, config *Deploya
 func (rB *DeployablesRequestBuilder) Put(ctx context.Context, body *DeployableUpdateRequest, config *DeployablesRequestBuilderPutRequestConfiguration) (DeployableUpdateResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -146,6 +152,9 @@ func (rB *SharedComponentsRequestBuilder) Delete(ctx context.Context, config *Sh
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -165,6 +174,9 @@ func (rB *SharedComponentsRequestBuilder) Delete(ctx context.Context, config *Sh
 func (rB *SharedComponentsRequestBuilder) Put(ctx context.Context, body *SharedComponentUpdateRequest, config *SharedComponentsRequestBuilderPutRequestConfiguration) (SharedComponentUpdateResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -223,6 +235,9 @@ func (rB *UploadStatusItemRequestBuilder) Get(ctx context.Context, config *Uploa
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -256,6 +271,9 @@ func NewExportsRequestBuilderInternal(pathParameters map[string]string, requestA
 func (rB *ExportsRequestBuilder) Get(ctx context.Context, config *ExportsRequestBuilderGetRequestConfiguration) (ExportsResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -323,6 +341,9 @@ func (rB *ExportItemStatusRequestBuilder) Get(ctx context.Context, config *Expor
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -356,6 +377,9 @@ func NewExportItemContentRequestBuilderInternal(pathParameters map[string]string
 func (rB *ExportItemContentRequestBuilder) Get(ctx context.Context, config *ExportItemContentRequestBuilderGetRequestConfiguration) ([]byte, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -428,6 +452,9 @@ func (rB *SharedLibrariesComponentsApplicationsRequestBuilder) Get(ctx context.C
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -492,6 +519,9 @@ func (rB *UploadsComponentsRequestBuilder) Post(ctx context.Context, body *Compo
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -535,6 +565,9 @@ func (rB *UploadsComponentsVarsRequestBuilder) Post(ctx context.Context, body *C
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -572,6 +605,9 @@ func NewUploadsCollectionsRequestBuilderInternal(pathParameters map[string]strin
 func (rB *UploadsCollectionsRequestBuilder) Post(ctx context.Context, body *CollectionUploadRequest, config *UploadsCollectionsRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -615,6 +651,9 @@ func NewUploadsCollectionsFileRequestBuilderInternal(pathParameters map[string]s
 func (rB *UploadsCollectionsFileRequestBuilder) Post(ctx context.Context, media *Media, config *UploadsCollectionsFileRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -670,6 +709,9 @@ func NewUploadsDeployablesFileRequestBuilderInternal(pathParameters map[string]s
 func (rB *UploadsDeployablesFileRequestBuilder) Post(ctx context.Context, media *Media, config *UploadsDeployablesFileRequestBuilderPostRequestConfiguration) (UploadStatusResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {

--- a/cdmapplicationsapi/applications_request_builders_test.go
+++ b/cdmapplicationsapi/applications_request_builders_test.go
@@ -456,6 +456,108 @@ func TestUploadsDeployablesFileRequestBuilder_NilReceiverGuards(t *testing.T) {
 	}
 }
 
+func TestDeployablesRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewDeployablesRequestBuilderInternal(map[string]string{}, nil)
+
+	err := builder.Delete(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+
+	resp, err := builder.Put(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestSharedComponentsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewSharedComponentsRequestBuilderInternal(map[string]string{}, nil)
+
+	err := builder.Delete(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+
+	resp, err := builder.Put(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUploadStatusItemRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewUploadStatusItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestExportsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewExportsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestExportItemStatusRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewExportItemStatusRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestExportItemContentRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewExportItemContentRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestSharedLibrariesComponentsApplicationsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewSharedLibrariesComponentsApplicationsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsComponentsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewUploadsComponentsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsComponentsVarsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewUploadsComponentsVarsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsCollectionsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewUploadsCollectionsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsCollectionsFileRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewUploadsCollectionsFileRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsDeployablesFileRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewUploadsDeployablesFileRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 // ---------------------------------------------------------------------------
 // Happy-path / adapter-error coverage for verb methods.
 //

--- a/cdmchangesetapi/changeset_request_builders.go
+++ b/cdmchangesetapi/changeset_request_builders.go
@@ -62,6 +62,9 @@ func (rB *ChangesetsRequestBuilder) Get(ctx context.Context, config *ChangesetsR
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -85,6 +88,9 @@ func (rB *ChangesetsRequestBuilder) Get(ctx context.Context, config *ChangesetsR
 func (rB *ChangesetsRequestBuilder) Delete(ctx context.Context, config *ChangesetsRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -115,6 +121,9 @@ func NewChangesetActivityRequestBuilderInternal(pathParameters map[string]string
 func (rB *ChangesetActivityRequestBuilder) Get(ctx context.Context, config *ChangesetActivityRequestBuilderGetRequestConfiguration) (ChangesetActivityResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -168,6 +177,9 @@ func (rB *CommitStatusItemRequestBuilder) Get(ctx context.Context, config *Commi
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -199,6 +211,9 @@ func NewImpactedSharedComponentsRequestBuilderInternal(pathParameters map[string
 func (rB *ImpactedSharedComponentsRequestBuilder) Get(ctx context.Context, config *ImpactedSharedComponentsRequestBuilderGetRequestConfiguration) (ImpactedSharedComponentsResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -234,6 +249,9 @@ func NewImpactedDeployablesRequestBuilderInternal(pathParameters map[string]stri
 func (rB *ImpactedDeployablesRequestBuilder) Get(ctx context.Context, config *ImpactedDeployablesRequestBuilderGetRequestConfiguration) (ImpactedDeployablesResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -285,6 +303,9 @@ func NewImpactedDeployablesBySysIDRequestBuilderInternal(pathParameters map[stri
 func (rB *ImpactedDeployablesBySysIDRequestBuilder) Get(ctx context.Context, config *ImpactedDeployablesBySysIDRequestBuilderGetRequestConfiguration) (ImpactedDeployablesBySysIDResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {

--- a/cdmchangesetapi/changeset_request_builders_test.go
+++ b/cdmchangesetapi/changeset_request_builders_test.go
@@ -211,6 +211,57 @@ func TestImpactedDeployablesBySysIdRequestBuilder_NilReceiverGuards(t *testing.T
 	}
 }
 
+func TestChangesetsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewChangesetsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+
+	err = builder.Delete(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
+
+func TestChangesetActivityRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewChangesetActivityRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestCommitStatusItemRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewCommitStatusItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestImpactedSharedComponentsRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewImpactedSharedComponentsRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestImpactedDeployablesRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewImpactedDeployablesRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
+func TestImpactedDeployablesBySysIdRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewImpactedDeployablesBySysIDRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestCommitStatusRequestBuilder_ByID(t *testing.T) {
 	adapter := mocking.NewMockRequestAdapter()
 	builder := NewCommitStatusRequestBuilderInternal(map[string]string{"baseurl": "https://example.service-now.com"}, adapter)

--- a/cdmeditorapi/editor_request_builders.go
+++ b/cdmeditorapi/editor_request_builders.go
@@ -61,6 +61,9 @@ func (rB *NodesRequestBuilder) Get(ctx context.Context, config *NodesRequestBuil
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -84,6 +87,9 @@ func (rB *NodesRequestBuilder) Get(ctx context.Context, config *NodesRequestBuil
 func (rB *NodesRequestBuilder) Post(ctx context.Context, body NodeCreateRequest, config *NodesRequestBuilderPostRequestConfiguration) (NodeResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.POST, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -121,6 +127,9 @@ func (rB *NodeItemRequestBuilder) Put(ctx context.Context, body NodeUpdateReques
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
 	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.PUT, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
 		if config.Headers != nil {
@@ -147,6 +156,9 @@ func (rB *NodeItemRequestBuilder) Put(ctx context.Context, body NodeUpdateReques
 func (rB *NodeItemRequestBuilder) Delete(ctx context.Context, config *NodeItemRequestBuilderDeleteRequestConfiguration) error {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.DELETE, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {
@@ -176,6 +188,9 @@ func NewValidationRequestBuilderInternal(pathParameters map[string]string, reque
 func (rB *ValidationRequestBuilder) Get(ctx context.Context, config *ValidationRequestBuilderGetRequestConfiguration) (ValidationResponse, error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(abstractions.GET, rB.GetURLTemplate(), rB.GetPathParameters())
 	if !conversion.IsNil(config) {

--- a/cdmeditorapi/editor_request_builders_test.go
+++ b/cdmeditorapi/editor_request_builders_test.go
@@ -182,3 +182,33 @@ func TestValidationRequestBuilder_NilReceiverGuards(t *testing.T) {
 		})
 	}
 }
+
+func TestNodesRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewNodesRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+
+	postResp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, postResp)
+}
+
+func TestNodeItemRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewNodeItemRequestBuilderInternal(map[string]string{}, nil)
+
+	putResp, err := builder.Put(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, putResp)
+
+	require.ErrorIs(t, builder.Delete(context.Background(), nil), snerrors.ErrNilRequestAdapter)
+}
+
+func TestValidationRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewValidationRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}

--- a/cmdbinstanceapi/cmdb_class_request_builder.go
+++ b/cmdbinstanceapi/cmdb_class_request_builder.go
@@ -36,6 +36,10 @@ func (rB *CmdbClassRequestBuilder) Get(ctx context.Context, config *CmdbClassReq
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -58,6 +62,10 @@ func (rB *CmdbClassRequestBuilder) Get(ctx context.Context, config *CmdbClassReq
 func (rB *CmdbClassRequestBuilder) Post(ctx context.Context, body CmdbInstance, config *CmdbClassRequestBuilderPostRequestConfiguration) (*core.BaseServiceNowItemResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)

--- a/cmdbinstanceapi/cmdb_class_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_class_request_builder_test.go
@@ -118,6 +118,18 @@ func TestCmdbClassRequestBuilder_NilReceiverGuards(t *testing.T) {
 	}
 }
 
+func TestCmdbClassRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewCmdbClassRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+
+	itemResp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, itemResp)
+}
+
 func TestCmdbClassRequestBuilder_ByID(t *testing.T) {
 	adapter := &mocking.MockRequestAdapter{}
 	builder := NewCmdbClassRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "className": "test"}, adapter)

--- a/cmdbinstanceapi/cmdb_item_request_builder.go
+++ b/cmdbinstanceapi/cmdb_item_request_builder.go
@@ -37,6 +37,10 @@ func (rB *CmdbItemRequestBuilder) Get(ctx context.Context, config *CmdbItemReque
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToGetRequestInformation(ctx, config)
 	if err != nil {
 		return nil, err
@@ -61,6 +65,10 @@ func (rB *CmdbItemRequestBuilder) Put(ctx context.Context, body CmdbInstance, co
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToPutRequestInformation(ctx, body, config)
 	if err != nil {
 		return nil, err
@@ -83,6 +91,10 @@ func (rB *CmdbItemRequestBuilder) Put(ctx context.Context, body CmdbInstance, co
 func (rB *CmdbItemRequestBuilder) Patch(ctx context.Context, body CmdbInstance, config *CmdbItemRequestBuilderPatchRequestConfiguration) (*core.BaseServiceNowItemResponse[CmdbInstance], error) {
 	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPatchRequestInformation(ctx, body, config)

--- a/cmdbinstanceapi/cmdb_item_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_item_request_builder_test.go
@@ -163,6 +163,22 @@ func TestCmdbItemRequestBuilder_NilReceiverGuards(t *testing.T) {
 	}
 }
 
+func TestCmdbItemRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewCmdbItemRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+
+	resp, err = builder.Put(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+
+	resp, err = builder.Patch(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestCmdbItemRequestBuilder_Relation(t *testing.T) {
 	adapter := &mocking.MockRequestAdapter{}
 	builder := NewCmdbItemRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "className": "test", "sys_id": "123"}, adapter)

--- a/cmdbinstanceapi/cmdb_relation_item_request_builder.go
+++ b/cmdbinstanceapi/cmdb_relation_item_request_builder.go
@@ -32,6 +32,10 @@ func (rB *CmdbRelationItemRequestBuilder) Delete(ctx context.Context, config *Cm
 		return snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, config)
 	if err != nil {
 		return err

--- a/cmdbinstanceapi/cmdb_relation_item_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_relation_item_request_builder_test.go
@@ -70,6 +70,13 @@ func TestCmdbRelationItemRequestBuilder_NilReceiverGuards(t *testing.T) {
 	}
 }
 
+func TestCmdbRelationItemRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewCmdbRelationItemRequestBuilderInternal(map[string]string{}, nil)
+
+	err := builder.Delete(context.Background(), nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
+
 func TestCmdbRelationItemRequestBuilder_ToDeleteRequestInformation(t *testing.T) {
 	builder := NewCmdbRelationItemRequestBuilderInternal(map[string]string{
 		"baseurl":    "https://example.com",

--- a/cmdbinstanceapi/cmdb_relation_request_builder.go
+++ b/cmdbinstanceapi/cmdb_relation_request_builder.go
@@ -37,6 +37,10 @@ func (rB *CmdbRelationRequestBuilder) Post(ctx context.Context, body CmdbInstanc
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.ToPostRequestInformation(ctx, body, config)
 	if err != nil {
 		return nil, err

--- a/cmdbinstanceapi/cmdb_relation_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_relation_request_builder_test.go
@@ -69,6 +69,14 @@ func TestCmdbRelationRequestBuilder_NilReceiverGuards(t *testing.T) {
 	}
 }
 
+func TestCmdbRelationRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
+	builder := NewCmdbRelationRequestBuilderInternal(map[string]string{}, nil)
+
+	resp, err := builder.Post(context.Background(), nil, nil)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestCmdbRelationRequestBuilder_ByID(t *testing.T) {
 	adapter := &mocking.MockRequestAdapter{}
 	builder := NewCmdbRelationRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "className": "test", "sys_id": "123"}, adapter)

--- a/documentsapi/action_request_builder.go
+++ b/documentsapi/action_request_builder.go
@@ -68,8 +68,12 @@ func NewVersionActionRequestBuilderInternal(pathParameters map[string]string, re
 
 // Patch executes the specified action on the document version.
 func (rB *VersionActionRequestBuilder) Patch(ctx context.Context, requestConfiguration *VersionActionRequestBuilderPatchRequestConfiguration) error {
-	if conversion.IsNil(rB) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToPatchRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/action_request_builder_test.go
+++ b/documentsapi/action_request_builder_test.go
@@ -41,6 +41,14 @@ func TestVersionActionRequestBuilder_Patch_NilBuilder(t *testing.T) {
 	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 }
 
+func TestVersionActionRequestBuilder_Patch_NilRequestAdapter(t *testing.T) {
+	builder := NewVersionActionRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	err := builder.Patch(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
+
 func TestVersionActionRequestBuilder_Patch(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/documentsapi/attach_request_builder_test.go
+++ b/documentsapi/attach_request_builder_test.go
@@ -63,6 +63,15 @@ func TestAttachRequestBuilder_Post_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestAttachRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewAttachRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	resp, err := builder.Post(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestAttachRequestBuilder_ToPostRequestInformation(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		adapter := &mocking.MockRequestAdapter{}

--- a/documentsapi/content_request_builder.go
+++ b/documentsapi/content_request_builder.go
@@ -30,8 +30,12 @@ func NewContentRequestBuilderInternal(pathParameters map[string]string, requestA
 
 // Get fetches and streams the default version attachment for the document.
 func (rB *ContentRequestBuilder) Get(ctx context.Context, requestConfiguration *ContentRequestBuilderGetRequestConfiguration) ([]byte, error) {
-	if conversion.IsNil(rB) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/content_request_builder_test.go
+++ b/documentsapi/content_request_builder_test.go
@@ -5,11 +5,30 @@ import (
 	"errors"
 	"testing"
 
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestContentRequestBuilder_Get_NilBuilder(t *testing.T) {
+	var builder *ContentRequestBuilder
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+	assert.Nil(t, resp)
+}
+
+func TestContentRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewContentRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
 
 func TestContentRequestBuilder_Get(t *testing.T) {
 	tests := []struct {

--- a/documentsapi/create_document_request_builder_test.go
+++ b/documentsapi/create_document_request_builder_test.go
@@ -63,6 +63,15 @@ func TestCreateDocumentRequestBuilder_Post_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestCreateDocumentRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewCreateDocumentRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	resp, err := builder.Post(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestCreateDocumentRequestBuilder_ToPostRequestInformation(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		adapter := &mocking.MockRequestAdapter{}

--- a/documentsapi/create_request_builder_test.go
+++ b/documentsapi/create_request_builder_test.go
@@ -22,6 +22,15 @@ func TestCreateRequestBuilder_Post_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestCreateRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewCreateRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	resp, err := builder.Post(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestCreateRequestBuilder_ToPostRequestInformation(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		adapter := &mocking.MockRequestAdapter{}

--- a/documentsapi/delete_request_builder.go
+++ b/documentsapi/delete_request_builder.go
@@ -29,8 +29,12 @@ func NewDeleteRequestBuilderInternal(pathParameters map[string]string, requestAd
 
 // Delete removes a document.
 func (rB *DeleteRequestBuilder) Delete(ctx context.Context, requestConfiguration *DeleteRequestBuilderDeleteRequestConfiguration) error {
-	if conversion.IsNil(rB) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToDeleteRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/delete_request_builder_test.go
+++ b/documentsapi/delete_request_builder_test.go
@@ -5,10 +5,28 @@ import (
 	"errors"
 	"testing"
 
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDeleteRequestBuilder_Delete_NilBuilder(t *testing.T) {
+	var builder *DeleteRequestBuilder
+
+	err := builder.Delete(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+}
+
+func TestDeleteRequestBuilder_Delete_NilRequestAdapter(t *testing.T) {
+	builder := NewDeleteRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	err := builder.Delete(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
 
 func TestDeleteRequestBuilder_Delete(t *testing.T) {
 	tests := []struct {

--- a/documentsapi/document_get_request_builder.go
+++ b/documentsapi/document_get_request_builder.go
@@ -40,6 +40,10 @@ func (rB *documentGetRequestBuilder) get(ctx context.Context, requestConfigurati
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.toGetRequestInformation(ctx, requestConfiguration)
 	if err != nil {
 		return nil, err

--- a/documentsapi/document_post_request_builder.go
+++ b/documentsapi/document_post_request_builder.go
@@ -40,6 +40,10 @@ func (rB *documentPostRequestBuilder) post(ctx context.Context, requestConfigura
 		return nil, snerrors.ErrNilRequestBuilder
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	requestInfo, err := rB.toPostRequestInformation(ctx, requestConfiguration)
 	if err != nil {
 		return nil, err

--- a/documentsapi/explore_request_builder.go
+++ b/documentsapi/explore_request_builder.go
@@ -29,8 +29,12 @@ func NewExploreRequestBuilderInternal(pathParameters map[string]string, requestA
 
 // Get retrieves folder and document metadata with filters, sorting, and pagination.
 func (rB *ExploreRequestBuilder) Get(ctx context.Context, requestConfiguration *ExploreRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[Document], error) {
-	if conversion.IsNil(rB) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/explore_request_builder_test.go
+++ b/documentsapi/explore_request_builder_test.go
@@ -6,11 +6,30 @@ import (
 	"testing"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
+	snerrors "github.com/michaeldcanady/servicenow-sdk-go/errors"
 	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExploreRequestBuilder_Get_NilBuilder(t *testing.T) {
+	var builder *ExploreRequestBuilder
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
+	assert.Nil(t, resp)
+}
+
+func TestExploreRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewExploreRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
 
 func TestExploreRequestBuilder_Get(t *testing.T) {
 	tests := []struct {

--- a/documentsapi/sync_down_request_builder_test.go
+++ b/documentsapi/sync_down_request_builder_test.go
@@ -63,6 +63,15 @@ func TestSyncDownRequestBuilder_Post_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestSyncDownRequestBuilder_Post_NilRequestAdapter(t *testing.T) {
+	builder := NewSyncDownRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "documentSysId": "doc-id"}, nil)
+
+	resp, err := builder.Post(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestSyncDownRequestBuilder_ToPostRequestInformation(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		adapter := &mocking.MockRequestAdapter{}

--- a/documentsapi/version_state_request_builder_test.go
+++ b/documentsapi/version_state_request_builder_test.go
@@ -63,6 +63,15 @@ func TestVersionStateRequestBuilder_Get_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestVersionStateRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewVersionStateRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "version_sys_id": "version-id"}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestVersionStateRequestBuilder_ToGetRequestInformation(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		adapter := &mocking.MockRequestAdapter{}

--- a/documentsapi/versions_request_builder.go
+++ b/documentsapi/versions_request_builder.go
@@ -29,8 +29,12 @@ func NewVersionsRequestBuilderInternal(pathParameters map[string]string, request
 
 // Get retrieves the versions of the specified document.
 func (rB *VersionsRequestBuilder) Get(ctx context.Context, requestConfiguration *VersionsRequestBuilderGetRequestConfiguration) (*core.BaseServiceNowCollectionResponse[Document], error) {
-	if conversion.IsNil(rB) {
+	if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
 		return nil, snerrors.ErrNilRequestBuilder
+	}
+
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
 	}
 
 	requestInfo, err := rB.ToGetRequestInformation(ctx, requestConfiguration)

--- a/documentsapi/versions_request_builder_test.go
+++ b/documentsapi/versions_request_builder_test.go
@@ -75,6 +75,15 @@ func TestVersionsRequestBuilder_Get_NilBuilder(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestVersionsRequestBuilder_Get_NilRequestAdapter(t *testing.T) {
+	builder := NewVersionsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "document_sys_id": "doc-id"}, nil)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+	assert.Nil(t, resp)
+}
+
 func TestVersionsRequestBuilder_ToGetRequestInformation(t *testing.T) {
 	adapter := &mocking.MockRequestAdapter{}
 	builder := NewVersionsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "document_sys_id": "doc-id"}, adapter)


### PR DESCRIPTION
## Summary
- ~40 verb methods across 12 packages (`accountapi`, `actsubapi`, `appointmentbookingapi`, `appserviceapi`, `attachmentapi`, `batchapi`, `caseapi`, `cdmapplicationsapi`, `cdmchangesetapi`, `cdmeditorapi`, `cmdbinstanceapi`, `documentsapi`) checked for a nil request builder but not a nil `RequestAdapter`, so a builder constructed with a nil adapter would panic instead of returning `snerrors.ErrNilRequestAdapter`.
- Adds the missing `conversion.IsNil(rB.GetRequestAdapter())` guard at each verb method; where several thin wrapper builders delegated to a shared internal helper (`documentsapi`'s `documentGetRequestBuilder`/`documentPostRequestBuilder`, `appserviceapi`'s `servicePostRequestBuilder`), the guard was added once at the shared call site instead of duplicated.
- Widens a handful of builders' nil-checks from `conversion.IsNil(rB)` to the canonical `conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder)` — adding the adapter guard exposed a latent panic when the embedded `RequestBuilder` was nil but the outer receiver was not.
- Every touched method gets a matching unit test asserting `errors.Is(err, snerrors.ErrNilRequestAdapter)`, per the acceptance criteria on #566.

Fixes #566

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run` on all touched packages (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)