### PR TITLE
fix(cdm): use comma-ok type assertions in CDM request builders

### DIFF
--- a/cdmapplicationsapi/applications_request_builders.go
+++ b/cdmapplicationsapi/applications_request_builders.go
@@ -3,6 +3,7 @@ package cdmapplicationsapi
 
 import (
 	"context"
+	"fmt"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -131,7 +132,11 @@ func (rB *DeployablesRequestBuilder) Put(ctx context.Context, body *DeployableUp
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(DeployableUpdateResponse), nil
+	typedRes, ok := res.(DeployableUpdateResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*DeployableUpdateResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // Exports returns an ExportsRequestBuilder.
@@ -203,7 +208,11 @@ func (rB *SharedComponentsRequestBuilder) Put(ctx context.Context, body *SharedC
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(SharedComponentUpdateResponse), nil
+	typedRes, ok := res.(SharedComponentUpdateResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*SharedComponentUpdateResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // UploadStatusRequestBuilder provides operations to access upload status.
@@ -262,7 +271,11 @@ func (rB *UploadStatusItemRequestBuilder) Get(ctx context.Context, config *Uploa
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(UploadStatusResponse), nil
+	typedRes, ok := res.(UploadStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*UploadStatusResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // ExportsRequestBuilder provides operations to manage deployable exports.
@@ -305,7 +318,11 @@ func (rB *ExportsRequestBuilder) Get(ctx context.Context, config *ExportsRequest
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ExportsResponse), nil
+	typedRes, ok := res.(ExportsResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ExportsResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // ByID returns a ExportItemRequestBuilder.
@@ -374,7 +391,11 @@ func (rB *ExportItemStatusRequestBuilder) Get(ctx context.Context, config *Expor
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ExportStatusResponse), nil
+	typedRes, ok := res.(ExportStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ExportStatusResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // ExportItemContentRequestBuilder provides operations to download export content.
@@ -414,7 +435,11 @@ func (rB *ExportItemContentRequestBuilder) Get(ctx context.Context, config *Expo
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.([]byte), nil
+	typedRes, ok := res.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", []byte(nil))
+	}
+	return typedRes, nil
 }
 
 // SharedLibrariesRequestBuilder provides operations to manage shared libraries.
@@ -491,7 +516,11 @@ func (rB *SharedLibrariesComponentsApplicationsRequestBuilder) Get(ctx context.C
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(SharedLibrariesComponentsApplicationsResponse), nil
+	typedRes, ok := res.(SharedLibrariesComponentsApplicationsResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*SharedLibrariesComponentsApplicationsResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // UploadsRequestBuilder provides operations to manage uploads.
@@ -562,7 +591,11 @@ func (rB *UploadsComponentsRequestBuilder) Post(ctx context.Context, body *Compo
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(UploadStatusResponse), nil
+	typedRes, ok := res.(UploadStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*UploadStatusResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // Vars returns a UploadsComponentsVarsRequestBuilder.
@@ -611,7 +644,11 @@ func (rB *UploadsComponentsVarsRequestBuilder) Post(ctx context.Context, body *C
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(UploadStatusResponse), nil
+	typedRes, ok := res.(UploadStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*UploadStatusResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // UploadsCollectionsRequestBuilder provides operations to upload collections.
@@ -655,7 +692,11 @@ func (rB *UploadsCollectionsRequestBuilder) Post(ctx context.Context, body *Coll
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(UploadStatusResponse), nil
+	typedRes, ok := res.(UploadStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*UploadStatusResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // File returns a UploadsCollectionsFileRequestBuilder.
@@ -704,7 +745,11 @@ func (rB *UploadsCollectionsFileRequestBuilder) Post(ctx context.Context, media 
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(UploadStatusResponse), nil
+	typedRes, ok := res.(UploadStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*UploadStatusResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // UploadsDeployablesRequestBuilder provides operations to manage deployables uploads.
@@ -765,5 +810,9 @@ func (rB *UploadsDeployablesFileRequestBuilder) Post(ctx context.Context, media 
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(UploadStatusResponse), nil
+	typedRes, ok := res.(UploadStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*UploadStatusResponse)(nil))
+	}
+	return typedRes, nil
 }

--- a/cdmapplicationsapi/applications_request_builders_wrong_type_test.go
+++ b/cdmapplicationsapi/applications_request_builders_wrong_type_test.go
@@ -1,0 +1,165 @@
+package cdmapplicationsapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
+	jsonserialization "github.com/microsoft/kiota-serialization-json-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the comma-ok type-assertion guard: when the adapter
+// returns a non-nil value whose concrete type doesn't match the expected
+// response type, the verb method must return an error instead of panicking.
+
+func TestDeployablesRequestBuilder_Put_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewDeployablesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Put(context.Background(), NewDeployableUpdateRequest(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestSharedComponentsRequestBuilder_Put_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewSharedComponentsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Put(context.Background(), NewSharedComponentUpdateRequest(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestUploadStatusItemRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewUploadStatusItemRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestExportsRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewExportsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestExportItemStatusRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewExportItemStatusRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestSharedLibrariesComponentsApplicationsRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewSharedLibrariesComponentsApplicationsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsComponentsRequestBuilder_Post_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewUploadsComponentsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Post(context.Background(), NewComponentUploadRequest(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsComponentsVarsRequestBuilder_Post_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewUploadsComponentsVarsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Post(context.Background(), NewComponentVarsUploadRequest(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsCollectionsRequestBuilder_Post_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewUploadsCollectionsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Post(context.Background(), NewCollectionUploadRequest(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsCollectionsFileRequestBuilder_Post_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewUploadsCollectionsFileRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Post(context.Background(), NewMedia("application/octet-stream", []byte("data")), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestUploadsDeployablesFileRequestBuilder_Post_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewUploadsDeployablesFileRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Post(context.Background(), NewMedia("application/octet-stream", []byte("data")), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestExportItemContentRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("SendPrimitive", mock.Anything, mock.Anything, "[]byte", mock.Anything).
+		Return("not-bytes", nil)
+	builder := NewExportItemContentRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/cdmchangesetapi/changeset_request_builders.go
+++ b/cdmchangesetapi/changeset_request_builders.go
@@ -1,7 +1,9 @@
+//nolint:dupl // per-verb request-builder methods share the mandatory nil-guard/send boilerplate by convention; each depends on its own outer type, response type, and discriminator factory, so it can't be extracted into a shared helper
 package cdmchangesetapi
 
 import (
 	"context"
+	"fmt"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -85,7 +87,11 @@ func (rB *ChangesetsRequestBuilder) Get(ctx context.Context, config *ChangesetsR
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ChangesetsResponse), nil
+	typedRes, ok := res.(ChangesetsResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ChangesetsResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 func (rB *ChangesetsRequestBuilder) Delete(ctx context.Context, config *ChangesetsRequestBuilderDeleteRequestConfiguration) error {
@@ -148,7 +154,11 @@ func (rB *ChangesetActivityRequestBuilder) Get(ctx context.Context, config *Chan
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ChangesetActivityResponse), nil
+	typedRes, ok := res.(ChangesetActivityResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ChangesetActivityResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // CommitStatusRequestBuilder handles /changesets/commit-status endpoint.
@@ -203,7 +213,11 @@ func (rB *CommitStatusItemRequestBuilder) Get(ctx context.Context, config *Commi
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(CommitStatusResponse), nil
+	typedRes, ok := res.(CommitStatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*CommitStatusResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // ImpactedSharedComponentsRequestBuilder handles /changesets/impacted-shared-components endpoint.
@@ -244,7 +258,11 @@ func (rB *ImpactedSharedComponentsRequestBuilder) Get(ctx context.Context, confi
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ImpactedSharedComponentsResponse), nil
+	typedRes, ok := res.(ImpactedSharedComponentsResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ImpactedSharedComponentsResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // ImpactedDeployablesRequestBuilder handles /changesets/impacted-deployables endpoint.
@@ -285,7 +303,11 @@ func (rB *ImpactedDeployablesRequestBuilder) Get(ctx context.Context, config *Im
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ImpactedDeployablesResponse), nil
+	typedRes, ok := res.(ImpactedDeployablesResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ImpactedDeployablesResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // ChangesetItemRequestBuilder handles /changesets/{changeset_id} endpoint.
@@ -339,5 +361,9 @@ func (rB *ImpactedDeployablesBySysIDRequestBuilder) Get(ctx context.Context, con
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ImpactedDeployablesBySysIDResponse), nil
+	typedRes, ok := res.(ImpactedDeployablesBySysIDResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ImpactedDeployablesBySysIDResponse)(nil))
+	}
+	return typedRes, nil
 }

--- a/cdmchangesetapi/changeset_request_builders_wrong_type_test.go
+++ b/cdmchangesetapi/changeset_request_builders_wrong_type_test.go
@@ -1,0 +1,87 @@
+package cdmchangesetapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the comma-ok type-assertion guard: when the adapter
+// returns a non-nil value whose concrete type doesn't match the expected
+// response type, the verb method must return an error instead of panicking.
+
+func TestChangesetsRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewChangesetsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestChangesetActivityRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewChangesetActivityRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestCommitStatusItemRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewCommitStatusItemRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "commit_id": "commit123"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestImpactedSharedComponentsRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewImpactedSharedComponentsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestImpactedDeployablesRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewImpactedDeployablesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestImpactedDeployablesBySysIDRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewImpactedDeployablesBySysIDRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "changeset_id": "changeset123"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/cdmeditorapi/editor_request_builders.go
+++ b/cdmeditorapi/editor_request_builders.go
@@ -3,6 +3,7 @@ package cdmeditorapi
 
 import (
 	"context"
+	"fmt"
 	"maps"
 
 	"github.com/michaeldcanady/servicenow-sdk-go/core"
@@ -85,7 +86,11 @@ func (rB *NodesRequestBuilder) Get(ctx context.Context, config *NodesRequestBuil
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(NodesResponse), nil
+	typedRes, ok := res.(NodesResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*NodesResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 func (rB *NodesRequestBuilder) Post(ctx context.Context, body NodeCreateRequest, config *NodesRequestBuilderPostRequestConfiguration) (NodeResponse, error) {
@@ -116,7 +121,11 @@ func (rB *NodesRequestBuilder) Post(ctx context.Context, body NodeCreateRequest,
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(NodeResponse), nil
+	typedRes, ok := res.(NodeResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*NodeResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // NodeItemRequestBuilder handles /v1/nodes/{id} endpoint.
@@ -158,7 +167,11 @@ func (rB *NodeItemRequestBuilder) Put(ctx context.Context, body NodeUpdateReques
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(NodeResponse), nil
+	typedRes, ok := res.(NodeResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*NodeResponse)(nil))
+	}
+	return typedRes, nil
 }
 
 // Delete removes a node. It returns only an error: the endpoint answers with no content, so
@@ -222,5 +235,9 @@ func (rB *ValidationRequestBuilder) Get(ctx context.Context, config *ValidationR
 	if conversion.IsNil(res) {
 		return nil, nil
 	}
-	return res.(ValidationResponse), nil
+	typedRes, ok := res.(ValidationResponse)
+	if !ok {
+		return nil, fmt.Errorf("res is not %T", (*ValidationResponse)(nil))
+	}
+	return typedRes, nil
 }

--- a/cdmeditorapi/editor_request_builders_wrong_type_test.go
+++ b/cdmeditorapi/editor_request_builders_wrong_type_test.go
@@ -1,0 +1,66 @@
+package cdmeditorapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/internal/mocking"
+	jsonserialization "github.com/microsoft/kiota-serialization-json-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the comma-ok type-assertion guard: when the adapter
+// returns a non-nil value whose concrete type doesn't match the expected
+// response type, the verb method must return an error instead of panicking.
+
+func TestNodesRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewNodesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestNodesRequestBuilder_Post_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewNodesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Post(context.Background(), NewNodeCreateRequest(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestNodeItemRequestBuilder_Put_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewNodeItemRequestBuilderInternal(map[string]string{"baseurl": "https://example.com", "node_sys_id": "node123"}, adapter)
+
+	resp, err := builder.Put(context.Background(), NewNodeUpdateRequest(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestValidationRequestBuilder_Get_WrongTypeResponse(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mocking.NewMockParsable(), nil)
+	builder := NewValidationRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	resp, err := builder.Get(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
## Summary
- All 22 typed-response call sites across `cdmapplicationsapi`, `cdmeditorapi`, and `cdmchangesetapi` used a single-value type assertion (`res.(XResponse)`) after the nil-guard added in #582. If the adapter ever returned a non-nil value of an unexpected concrete type, that would panic instead of returning an error.
- Switched all sites to comma-ok assertions (`typedRes, ok := res.(XResponse)`), returning `fmt.Errorf("res is not %T", ...)` on mismatch, matching the pattern already used by `tableapi`.
- Added the `//nolint:dupl` file directive to `cdmchangesetapi` (already present in the other two packages) since the comma-ok boilerplate increased structural similarity across verb methods.
- Added a `_wrong_type_test.go` file per package covering the new error branch for all 22 sites, using `mocking.NewMockParsable()` as a deliberately mismatched response type.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./...` passes
- [x] `golangci-lint run ./cdmapplicationsapi/... ./cdmeditorapi/... ./cdmchangesetapi/...` — 0 issues
- [x] 100% statement coverage on all three packages

Fixes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)