### PR TITLE
fix: add missing request-adapter nil-guards to Head methods

### DIFF
--- a/attachmentapi/attachment_request_builder.go
+++ b/attachmentapi/attachment_request_builder.go
@@ -150,6 +150,10 @@ func (rB *AttachmentRequestBuilder) Head(ctx context.Context, requestConfigurati
 		return nil, err
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	errorMapping := core.DefaultErrorMapping()
 	if err = rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, errorMapping); err != nil {
 		return nil, err

--- a/attachmentapi/attachment_request_builder_test.go
+++ b/attachmentapi/attachment_request_builder_test.go
@@ -94,6 +94,15 @@ func TestAttachmentRequestBuilder_Head_NilBuilder(t *testing.T) {
 	require.ErrorIs(t, err, snerrors.ErrNilRequestBuilder)
 }
 
+func TestAttachmentRequestBuilder_Head_NilRequestAdapter(t *testing.T) {
+	builder := NewAttachmentRequestBuilderInternal(map[string]string{}, nil)
+
+	headers, err := builder.Head(context.Background(), nil)
+
+	assert.Nil(t, headers)
+	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+}
+
 func TestAttachmentRequestBuilder_Builders(t *testing.T) {
 	adapter := &mocking.MockRequestAdapter{}
 	builder := NewAttachmentRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)

--- a/batchapi/batch_request_builder.go
+++ b/batchapi/batch_request_builder.go
@@ -63,6 +63,10 @@ func (rB *BatchRequestBuilder) Head(ctx context.Context, requestConfiguration *B
 		return nil, err
 	}
 
+	if conversion.IsNil(rB.GetRequestAdapter()) {
+		return nil, snerrors.ErrNilRequestAdapter
+	}
+
 	errorMapping := core.DefaultErrorMapping()
 
 	if err = rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, errorMapping); err != nil {

--- a/batchapi/batch_request_builder_test.go
+++ b/batchapi/batch_request_builder_test.go
@@ -447,6 +447,17 @@ func TestBatchRequestBuilder_Head(t *testing.T) {
 			},
 		},
 		{
+			name: "Nil request adapter",
+			test: func(t *testing.T) {
+				builder := NewBatchRequestBuilderInternal(map[string]string{}, nil)
+
+				responseHeaders, err := builder.Head(context.Background(), nil)
+
+				require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
+				assert.Nil(t, responseHeaders)
+			},
+		},
+		{
 			name: "Successful",
 			test: func(t *testing.T) {
 				mockPathParameters := map[string]string{"baseurl": "https://mock.service-now.com"}


### PR DESCRIPTION
## Summary
- Closes #566 for the two verb methods it missed: `AttachmentRequestBuilder.Head` and `BatchRequestBuilder.Head` call `RequestAdapter.SendNoContent` with no nil-guard on the adapter, unlike every other verb method fixed in #581.
- Added the standard `conversion.IsNil(rB.GetRequestAdapter())` → `snerrors.ErrNilRequestAdapter` guard to both, matching the pattern already used across the SDK.
- Added a unit test per method asserting `errors.Is(err, snerrors.ErrNilRequestAdapter)`, per #566's acceptance criteria.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./attachmentapi/... ./batchapi/...`
- [x] Repo-wide scan confirms no other verb method calling `GetRequestAdapter().Send*` is still missing the guard

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>