### PR TITLE
fix(cdm): pass core.DefaultErrorMapping() instead of literal nil

### DIFF
--- a/cdmapplicationsapi/applications_request_builders.go
+++ b/cdmapplicationsapi/applications_request_builders.go
@@ -100,7 +100,7 @@ func (rB *DeployablesRequestBuilder) Delete(ctx context.Context, config *Deploya
 			requestInfo.AddQueryParameters(*config.QueryParameters)
 		}
 	}
-	return rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, nil)
+	return rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, core.DefaultErrorMapping())
 }
 
 // Put updates deployables.
@@ -125,7 +125,7 @@ func (rB *DeployablesRequestBuilder) Put(ctx context.Context, body *DeployableUp
 	if err != nil {
 		return nil, err
 	}
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateDeployableUpdateResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateDeployableUpdateResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (rB *SharedComponentsRequestBuilder) Delete(ctx context.Context, config *Sh
 			requestInfo.AddQueryParameters(*config.QueryParameters)
 		}
 	}
-	return rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, nil)
+	return rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, core.DefaultErrorMapping())
 }
 
 // Put updates shared components.
@@ -201,7 +201,7 @@ func (rB *SharedComponentsRequestBuilder) Put(ctx context.Context, body *SharedC
 	if err != nil {
 		return nil, err
 	}
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateSharedComponentUpdateResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateSharedComponentUpdateResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (rB *UploadStatusItemRequestBuilder) Get(ctx context.Context, config *Uploa
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (rB *ExportsRequestBuilder) Get(ctx context.Context, config *ExportsRequest
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateExportsResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateExportsResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +384,7 @@ func (rB *ExportItemStatusRequestBuilder) Get(ctx context.Context, config *Expor
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateExportStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateExportStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (rB *ExportItemContentRequestBuilder) Get(ctx context.Context, config *Expo
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internal.ContentTypeApplicationOctetStream)
-	res, err := rB.GetRequestAdapter().SendPrimitive(ctx, requestInfo, "[]byte", nil)
+	res, err := rB.GetRequestAdapter().SendPrimitive(ctx, requestInfo, "[]byte", core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +509,7 @@ func (rB *SharedLibrariesComponentsApplicationsRequestBuilder) Get(ctx context.C
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateSharedLibrariesComponentsApplicationsResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateSharedLibrariesComponentsApplicationsResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +584,7 @@ func (rB *UploadsComponentsRequestBuilder) Post(ctx context.Context, body *Compo
 	if err != nil {
 		return nil, err
 	}
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -637,7 +637,7 @@ func (rB *UploadsComponentsVarsRequestBuilder) Post(ctx context.Context, body *C
 	if err != nil {
 		return nil, err
 	}
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +685,7 @@ func (rB *UploadsCollectionsRequestBuilder) Post(ctx context.Context, body *Coll
 	if err != nil {
 		return nil, err
 	}
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -738,7 +738,7 @@ func (rB *UploadsCollectionsFileRequestBuilder) Post(ctx context.Context, media 
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
 	requestInfo.SetStreamContentAndContentType(media.GetData(), media.GetContentType())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -803,7 +803,7 @@ func (rB *UploadsDeployablesFileRequestBuilder) Post(ctx context.Context, media 
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
 	requestInfo.SetStreamContentAndContentType(media.GetData(), media.GetContentType())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateUploadStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}

--- a/cdmapplicationsapi/applications_request_builders_test.go
+++ b/cdmapplicationsapi/applications_request_builders_test.go
@@ -660,6 +660,38 @@ func TestDeployablesRequestBuilder_Put_HappyAndError(t *testing.T) {
 	}
 }
 
+// isDefaultErrorMapping reports whether the given argument is a non-nil
+// abstractions.ErrorMappings with core.DefaultErrorMapping()'s status-code keys.
+func isDefaultErrorMapping(v any) bool {
+	mapping, ok := v.(abstractions.ErrorMappings)
+	if !ok || mapping == nil {
+		return false
+	}
+	for _, code := range []string{"400", "401", "403", "404", "429", "5XX", "XXX"} {
+		if _, ok := mapping[code]; !ok {
+			return false
+		}
+	}
+	return len(mapping) == 7
+}
+
+// TestDeployablesRequestBuilder_Put_PassesDefaultErrorMapping guards against #565:
+// CDM builders previously passed literal nil instead of core.DefaultErrorMapping(),
+// so ServiceNow API errors never mapped to a typed core.ServiceNowError.
+func TestDeployablesRequestBuilder_Put_PassesDefaultErrorMapping(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("GetSerializationWriterFactory").Return(jsonserialization.NewJsonSerializationWriterFactory())
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(isDefaultErrorMapping)).
+		Return(core.NewBaseServiceNowItemResponse[*UploadStatusResult](CreateUploadStatusResultFromDiscriminatorValue), nil)
+
+	builder := NewDeployablesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	_, err := builder.Put(context.Background(), NewDeployableUpdateRequest(), nil)
+
+	require.NoError(t, err)
+	adapter.AssertExpectations(t)
+}
+
 func TestSharedComponentsRequestBuilder_Delete_HappyAndError(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/cdmchangesetapi/changeset_request_builders.go
+++ b/cdmchangesetapi/changeset_request_builders.go
@@ -80,7 +80,7 @@ func (rB *ChangesetsRequestBuilder) Get(ctx context.Context, config *ChangesetsR
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateChangesetsResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateChangesetsResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (rB *ChangesetsRequestBuilder) Delete(ctx context.Context, config *Changese
 			requestInfo.AddQueryParameters(*config.QueryParameters)
 		}
 	}
-	return rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, nil)
+	return rB.GetRequestAdapter().SendNoContent(ctx, requestInfo, core.DefaultErrorMapping())
 }
 
 // ChangesetActivityRequestBuilder handles /changesets/activity endpoint.
@@ -147,7 +147,7 @@ func (rB *ChangesetActivityRequestBuilder) Get(ctx context.Context, config *Chan
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateChangesetActivityResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateChangesetActivityResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (rB *CommitStatusItemRequestBuilder) Get(ctx context.Context, config *Commi
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateCommitStatusResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateCommitStatusResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (rB *ImpactedSharedComponentsRequestBuilder) Get(ctx context.Context, confi
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateImpactedSharedComponentsResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateImpactedSharedComponentsResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (rB *ImpactedDeployablesRequestBuilder) Get(ctx context.Context, config *Im
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateImpactedDeployablesResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateImpactedDeployablesResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +354,7 @@ func (rB *ImpactedDeployablesBySysIDRequestBuilder) Get(ctx context.Context, con
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateImpactedDeployablesBySysIDResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateImpactedDeployablesBySysIDResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}

--- a/cdmchangesetapi/changeset_request_builders_test.go
+++ b/cdmchangesetapi/changeset_request_builders_test.go
@@ -650,3 +650,34 @@ func TestImpactedDeployablesBySysIDRequestBuilder_Get_HappyAndError(t *testing.T
 		})
 	}
 }
+
+// isDefaultErrorMapping reports whether the given argument is a non-nil
+// abstractions.ErrorMappings with core.DefaultErrorMapping()'s status-code keys.
+func isDefaultErrorMapping(v any) bool {
+	mapping, ok := v.(abstractions.ErrorMappings)
+	if !ok || mapping == nil {
+		return false
+	}
+	for _, code := range []string{"400", "401", "403", "404", "429", "5XX", "XXX"} {
+		if _, ok := mapping[code]; !ok {
+			return false
+		}
+	}
+	return len(mapping) == 7
+}
+
+// TestChangesetsRequestBuilder_Get_PassesDefaultErrorMapping guards against #565:
+// CDM builders previously passed literal nil instead of core.DefaultErrorMapping(),
+// so ServiceNow API errors never mapped to a typed core.ServiceNowError.
+func TestChangesetsRequestBuilder_Get_PassesDefaultErrorMapping(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(isDefaultErrorMapping)).
+		Return(core.NewBaseServiceNowCollectionResponse[*ChangesetResult](CreateChangesetResultFromDiscriminatorValue), nil)
+
+	builder := NewChangesetsRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	_, err := builder.Get(context.Background(), nil)
+
+	require.NoError(t, err)
+	adapter.AssertExpectations(t)
+}

--- a/cdmeditorapi/editor_request_builders.go
+++ b/cdmeditorapi/editor_request_builders.go
@@ -79,7 +79,7 @@ func (rB *NodesRequestBuilder) Get(ctx context.Context, config *NodesRequestBuil
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateNodesResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateNodesResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (rB *NodesRequestBuilder) Post(ctx context.Context, body NodeCreateRequest,
 	if err != nil {
 		return nil, err
 	}
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateNodeResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateNodeResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (rB *NodeItemRequestBuilder) Put(ctx context.Context, body NodeUpdateReques
 	if err != nil {
 		return nil, err
 	}
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateNodeResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateNodeResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (rB *ValidationRequestBuilder) Get(ctx context.Context, config *ValidationR
 		}
 	}
 	requestInfo.Headers.TryAdd(internalhttp.RequestHeaderAccept.String(), internalhttp.ContentTypeApplicationJSON.String())
-	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateValidationResponseFromDiscriminatorValue, nil)
+	res, err := rB.GetRequestAdapter().Send(ctx, requestInfo, CreateValidationResponseFromDiscriminatorValue, core.DefaultErrorMapping())
 	if err != nil {
 		return nil, err
 	}

--- a/cdmeditorapi/editor_request_builders_test.go
+++ b/cdmeditorapi/editor_request_builders_test.go
@@ -261,3 +261,34 @@ func TestValidationRequestBuilder_NilRequestAdapterGuards(t *testing.T) {
 	require.ErrorIs(t, err, snerrors.ErrNilRequestAdapter)
 	assert.Nil(t, resp)
 }
+
+// isDefaultErrorMapping reports whether the given argument is a non-nil
+// abstractions.ErrorMappings with core.DefaultErrorMapping()'s status-code keys.
+func isDefaultErrorMapping(v any) bool {
+	mapping, ok := v.(abstractions.ErrorMappings)
+	if !ok || mapping == nil {
+		return false
+	}
+	for _, code := range []string{"400", "401", "403", "404", "429", "5XX", "XXX"} {
+		if _, ok := mapping[code]; !ok {
+			return false
+		}
+	}
+	return len(mapping) == 7
+}
+
+// TestNodesRequestBuilder_Get_PassesDefaultErrorMapping guards against #565:
+// CDM builders previously passed literal nil instead of core.DefaultErrorMapping(),
+// so ServiceNow API errors never mapped to a typed core.ServiceNowError.
+func TestNodesRequestBuilder_Get_PassesDefaultErrorMapping(t *testing.T) {
+	adapter := mocking.NewMockRequestAdapter()
+	mockRes := core.NewBaseServiceNowCollectionResponse[*NodeResultModel](CreateNodeResultFromDiscriminatorValue)
+	adapter.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(isDefaultErrorMapping)).Return(mockRes, nil)
+
+	builder := NewNodesRequestBuilderInternal(map[string]string{"baseurl": "https://example.com"}, adapter)
+
+	_, err := builder.Get(context.Background(), nil)
+
+	require.NoError(t, err)
+	adapter.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- The three CDM api packages (`cdmapplicationsapi`, `cdmchangesetapi`, `cdmeditorapi`) passed literal `nil` as the error-mapping argument on every `Send`/`SendNoContent`/`SendPrimitive` call, so ServiceNow API errors from these packages never mapped to a typed `core.ServiceNowError`, unlike every other module in the SDK.
- All affected calls now pass `core.DefaultErrorMapping()`, matching the SDK-wide convention.
- Added a regression test per package asserting the mocked adapter receives `core.DefaultErrorMapping()`'s exact status-code map, which would have caught the original bug.

Fixes #565

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`