### PR TITLE
fix: guard nil receiver in NilPointerError.Error()

### DIFF
--- a/internal/new/nil_pointer_error.go
+++ b/internal/new/nil_pointer_error.go
@@ -14,5 +14,9 @@ func NewNilPointerError(text string) *NilPointerError {
 
 // Error returns the error string.
 func (err *NilPointerError) Error() string {
+	if IsNil(err) {
+		return "nil pointer error"
+	}
+
 	return err.s
 }

--- a/internal/new/nil_pointer_error_test.go
+++ b/internal/new/nil_pointer_error_test.go
@@ -1,0 +1,57 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewNilPointerError(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{
+			name: "Successful",
+			test: func(t *testing.T) {
+				err := NewNilPointerError("value is nil")
+
+				assert.Equal(t, "value is nil", err.s)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, test.test)
+	}
+}
+
+func TestNilPointerError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{
+			name: "Successful",
+			test: func(t *testing.T) {
+				err := NewNilPointerError("value is nil")
+
+				assert.Equal(t, "value is nil", err.Error())
+			},
+		},
+		{
+			name: "NilReceiver",
+			test: func(t *testing.T) {
+				var err *NilPointerError
+
+				assert.NotPanics(t, func() {
+					assert.Equal(t, "nil pointer error", err.Error())
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, test.test)
+	}
+}


### PR DESCRIPTION
Error() on a nil *NilPointerError dereferenced the receiver directly and panicked. Guard with IsNil and return a safe default string, consistent with the nil-guard idiom already used elsewhere in this package (e.g. ServicenowError.Error()).

Fixes #583


