### PR TITLE
chore: pin actions/checkout in weekly-release.yml

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       should_release: ${{ steps.determine.outputs.should_release }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Needed to fetch all tags
 


### PR DESCRIPTION
## Summary

Pins `actions/checkout@v7.0.1` to commit hash `3d3c42e5` in `.github/workflows/weekly-release.yml`.

Resolves Scorecard Pinned-Dependencies alert #85.