### PR TITLE
chore: add labeled/unlabeled triggers to branch-policy workflow

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -7,6 +7,8 @@ on:
       - reopened
       - edited
       - synchronize
+      - labeled
+      - unlabeled
     branches:
       - main
 


### PR DESCRIPTION
Closes #617

Adds `labeled` and `unlabeled` to the `pull_request.types` trigger in `.github/workflows/branch-policy.yml` so the workflow re-runs when labels change, allowing the `linked-issue` job to correctly evaluate the `no-issue-required` label condition.

**Before:** Workflow only triggered on `opened`, `reopened`, `edited`, `synchronize` — adding a label after PR creation didn't re-evaluate the check.

**After:** Workflow also triggers on `labeled` and `unlabeled`, re-evaluating with the current label set.