### PR TITLE
chore: add project management automation and triage docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -1,7 +1,7 @@
 name: "Bug Report"
 description: Report something that's broken or behaving unexpectedly in the SDK.
 title: "[Bug]: "
-labels: ["type: bug", "state: new"]
+labels: ["type: bug", "status: new"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,7 +1,7 @@
 name: "Feature Request"
 description: Request a new capability or enhancement (e.g. support for a new ServiceNow API, auth method, or SDK ergonomics improvement).
 title: "[Story]: "
-labels: ["type: feature", "state: new"]
+labels: ["type: feature", "status: new"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/issue-status-sync.yml
+++ b/.github/workflows/issue-status-sync.yml
@@ -1,0 +1,75 @@
+# Sync issue status labels when PRs open/close.
+#
+# - PR opened/reopened → linked issues get "status: in progress"
+# - PR closed (not merged) → linked issues revert to "status: reviewed"
+# - PR merged → GitHub auto-closes issues natively via "Closes #N"
+#
+# Uses mondeja/pr-linked-issues-action for finding linked issues (well-maintained,
+# 1k+ stars), with minimal bash for the label updates.
+#
+# Security: Runs on pull_request_target with author association check.
+
+name: Issue Status Sync
+
+on:
+  pull_request_target:
+    types: [opened, reopened, closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: issue-status-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync Issue Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get linked issues
+        id: linked
+        uses: mondeja/pr-linked-issues-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          include-closed-issues: false
+
+      - name: Mark issues in-progress (PR opened)
+        if: >-
+          steps.linked.outputs.issues != '' &&
+          (github.event.action == 'opened' || github.event.action == 'reopened') &&
+          contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUES: ${{ steps.linked.outputs.issues }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra nums <<< "$ISSUES"
+          for n in "${nums[@]}"; do
+            echo "Marking issue #$n as in-progress"
+            gh issue edit "$n" --repo "$REPO" --remove-label "status: new" 2>/dev/null || true
+            gh issue edit "$n" --repo "$REPO" --remove-label "status: reviewed" 2>/dev/null || true
+            gh issue edit "$n" --repo "$REPO" --add-label "status: in progress" 2>/dev/null || true
+          done
+
+      - name: Revert issue status (PR closed without merge)
+        if: >-
+          steps.linked.outputs.issues != '' &&
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == false &&
+          contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUES: ${{ steps.linked.outputs.issues }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra nums <<< "$ISSUES"
+          for n in "${nums[@]}"; do
+            echo "Reverting issue #$n to reviewed"
+            gh issue edit "$n" --repo "$REPO" --remove-label "status: in progress" 2>/dev/null || true
+            gh issue edit "$n" --repo "$REPO" --add-label "status: reviewed" 2>/dev/null || true
+          done

--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -1,0 +1,48 @@
+# Bidirectional sync between project board Status field and issue labels.
+#
+# - Move issue to "In Progress" on board → "status: in progress" label added
+# - Add "status: in progress" label → board Status updates to "🏗 In progress"
+# - Conflicts resolved by timestamp (most recent wins)
+
+name: Sync Project Status
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # every 15 minutes
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply changes (false = preview only)'
+        type: boolean
+        default: false
+
+jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        run: echo "has-token=${{ secrets.SYNC_PROJECT_SYNC_TOKEN_PROVIDER_PEM != '' }}" >> $GITHUB_OUTPUT
+  sync:
+    needs: check-secret
+    if: needs.check-secret.outputs.has-token == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SYNC_PROJECT_SYNC_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.SYNC_PROJECT_SYNC_TOKEN_PROVIDER_PEM }}
+
+    name: Sync labels ↔ project status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dvhthomas/project-label-sync@v0.1.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          apply: ${{ github.event.inputs.apply || 'false' }}

--- a/.project-label-sync.yml
+++ b/.project-label-sync.yml
@@ -1,0 +1,13 @@
+project-url: https://github.com/users/michaeldcanady/projects/7
+field: Status
+mapping:
+  "🤷‍♂️ Needs Triage":
+    - "status: new"
+  "🔖 Backlog - Ready":
+    - "status: reviewed"
+  "🏗 In progress":
+    - "status: in progress"
+  "👀 In review":
+    - "status: in review"
+  "❌ Won't do":
+    - "status: wontfix"

--- a/docs/TRIAGE.md
+++ b/docs/TRIAGE.md
@@ -1,0 +1,243 @@
+# Issue Triage Process
+
+This document defines how issues are triaged, prioritized, and managed in the `servicenow-sdk-go` repository.
+
+---
+
+## Overview
+
+Triage is the process of reviewing new issues, assessing their priority, and ensuring they're ready for work.
+
+**Key principles:**
+- Every issue gets a priority label during triage
+- Priority is based on a repeatable rubric, not gut feeling
+- Status labels track workflow state; priority labels track importance
+- Milestone membership is a priority signal, not a duplicate taxonomy
+
+---
+
+## Issue Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> New: Issue filed via template
+    New --> Triaged: Maintainer assesses priority (status: reviewed)
+    Triaged --> Ready: Prioritized, deps resolved
+    Ready --> In Progress: Work begins (status: in progress)
+    In Progress --> In Review: PR opened
+    In Review --> Done: PR merged
+
+    New --> Duplicate: Already exists (status: duplicate)
+    New --> Invalid: Doesn't seem right (status: invalid)
+    New --> Wontfix: Will not be worked on (status: wontfix)
+
+    Triaged --> Blocked: Waiting on external factor (status: blocked)
+    Blocked --> Triaged: Blocker resolved
+
+    In Review --> In Progress: Changes requested
+```
+
+---
+
+## Label Taxonomy
+
+### Priority Labels (Scoring Rubric)
+
+| Label              | Score | Description                     |
+| ------------------ | ----- | ------------------------------- |
+| `priority: urgent` | 6     | Blocks a release or active work |
+| `priority: high`   | 5     | Should be picked up soon        |
+| `priority: medium` | 4     | Worth doing, no rush            |
+| `priority: low`    | 2-3   | Nice to have, no urgency        |
+
+### Status Labels (Workflow State)
+
+| Label                 | Meaning                                                    |
+| --------------------- | ---------------------------------------------------------- |
+| `status: new`         | Newly filed, not yet triaged                               |
+| `status: reviewed`    | Triaged, ready for work                                    |
+| `status: in progress` | Actively being worked on (auto-set when PR linked)         |
+| `status: blocked`     | Blocked on another issue, decision, or external dependency |
+| `status: duplicate`   | Already exists                                             |
+| `status: invalid`     | Doesn't seem right                                         |
+| `status: wontfix`     | Will not be worked on                                      |
+
+### Type Labels
+
+| Label                 | When to Use                                   |
+| --------------------- | --------------------------------------------- |
+| `type: bug`           | Something is broken or behaving unexpectedly  |
+| `type: feature`       | New capability or enhancement                 |
+| `type: refactor`      | Code quality improvement, no behavior change  |
+| `type: documentation` | Docs, README, comments                        |
+| `type: devops`        | CI/CD, workflows, scripts, tooling            |
+| `type: epic`          | Large body of work tracked via linked stories |
+| `type: test`          | Test infrastructure or coverage improvements  |
+
+### Module Labels
+
+Auto-applied by PR based on changed files. For issues, select from the "Affected Module / API" dropdown in the template.
+
+---
+
+## Priority Scoring Rubric
+
+Score = **Impact + Risk-of-delay** (2-6 range)
+
+### Impact (1-3)
+
+How many consumers are affected, and how badly?
+
+| Score | Description                                                                                                    |
+| ----- | -------------------------------------------------------------------------------------------------------------- |
+| 1     | Cosmetic, docs-only, or affects an edge case / rarely-used module                                              |
+| 2     | Affects a commonly-used module (`tableapi`, `core`, `credentials`) or degrades DX without breaking correctness |
+| 3     | Silent-failure / incorrect-behavior risk, a breaking change forced onto consumers, or blocks a milestone       |
+
+### Risk-of-delay (1-3)
+
+What gets worse the longer this sits?
+
+| Score | Description                                                                                         |
+| ----- | --------------------------------------------------------------------------------------------------- |
+| 1     | Nothing; can sit indefinitely with no compounding cost                                              |
+| 2     | Accumulates tech debt or blocks a handful of other open issues                                      |
+| 3     | Free now and expensive forever after (breaking changes, naming decisions) or already in a milestone |
+
+### Score to Priority Mapping
+
+| Score | Priority           | Rationale                                            |
+| ----- | ------------------ | ---------------------------------------------------- |
+| 6     | `priority: urgent` | Both dimensions maxed                                |
+| 5     | `priority: high`   | One dimension maxed, the other at 2                  |
+| 4     | `priority: medium` | Both dimensions at 2, or a 3+1 split                 |
+| 2-3   | `priority: low`    | Both dimensions minimal, or only one mildly elevated |
+
+### Effort as Tie-Breaker
+
+Effort (1-3) is **not** an input to the score. It's used only to order issues within the same priority tier (cheaper first).
+
+| Score | Description                                                             |
+| ----- | ----------------------------------------------------------------------- |
+| 1     | Small, contained to one file/package, no design questions               |
+| 2     | Spans a few packages or needs a design decision but not an ADR          |
+| 3     | Cross-cutting, ADR-shaped, or touches request-builder/model conventions |
+
+### Milestone Floor Rule
+
+If an issue is in a milestone, its priority is **floored at `high`**, regardless of the raw score. This ensures milestone work is never buried under non-milestone noise.
+
+- A milestone issue with Score 4 → `priority: high` (floored up)
+- A milestone issue with Score 5 → `priority: high` (already at tier)
+- A milestone issue with Score 6 → `priority: urgent` (stays at tier)
+
+---
+
+## Triage Workflow
+
+```mermaid
+flowchart TD
+    Start([New issue arrives]) --> Check{Required fields<br/>complete?}
+    
+    Check -->|No| RequestInfo[Comment requesting<br/>missing info]
+    RequestInfo --> Wait[Wait for<br/>reporter response]
+    Wait --> Check
+    
+    Check -->|Yes| Classify[Set type: label<br/>Set module: label]
+    Classify --> Score[Score issue<br/>Impact + Risk]
+    Score --> Milestone{In a<br/>milestone?}
+    
+    Milestone -->|Yes| Floor[Apply floor rule<br/>minimum priority: high]
+    Milestone -->|No| SetPriority[Set priority: label]
+    Floor --> SetPriority
+    
+    SetPriority --> Status{Issue<br/>status?}
+    
+    Status -->|Ready| Reviewed[status: reviewed]
+    Status -->|Blocked| Blocked[status: blocked<br/>comment blocker]
+    Status -->|Duplicate| Dup[status: duplicate<br/>link original]
+    Status -->|Invalid| Invalid[status: invalid<br/>comment why]
+    Status -->|Won't fix| Wontfix[status: wontfix<br/>comment rationale]
+    
+    Reviewed --> Done([Triage complete])
+    Blocked --> Done
+    Dup --> Done
+    Invalid --> Done
+    Wontfix --> Done
+```
+
+### For the Maintainer
+
+1. **Check the issue is complete**
+   - Required fields filled (version, reproduction, expected behavior)
+   - If incomplete: comment requesting missing info, add `status: new` (no priority yet)
+
+2. **Classify the issue**
+   - Set `type:` label (bug, feature, refactor, etc.)
+   - Set `module:` label if clear from the template dropdown
+
+3. **Score the issue**
+   - Assess Impact (1-3)
+   - Assess Risk-of-delay (1-3)
+   - Calculate score = Impact + Risk
+   - Apply milestone floor rule if applicable
+   - Set `priority:` label based on score table
+
+4. **Set status**
+   - If ready for work: `status: reviewed`
+   - If blocked: `status: blocked` + comment explaining blocker
+   - If duplicate: `status: duplicate` + link to original
+   - If invalid: `status: invalid` + comment explaining why
+   - If won't fix: `status: wontfix` + comment explaining rationale
+
+5. **Optional: Set effort**
+   - Use the `Size` field on the project board (XS/S/M/L/XL)
+   - Map rubric Effort 1→S, 2→M, 3→L
+
+### Re-scoring Triggers
+
+Revisit an issue's priority when:
+- The issue receives new comments that change its scope
+- A PR references the issue and the actual work differs from the estimate
+- The issue is reopened after being closed
+- A milestone's scope changes
+
+---
+
+## Quick Reference
+
+### Scoring Example
+
+**Issue: "Bug in tableapi pagination returns wrong cursor"**
+
+- **Impact**: 3 (affects commonly-used module, incorrect behavior)
+- **Risk-of-delay**: 2 (accumulates tech debt, blocks users)
+- **Score**: 5 → `priority: high`
+
+**Issue: "Add license headers to Go files"**
+
+- **Impact**: 1 (cosmetic, no behavior change)
+- **Risk-of-delay**: 1 (can sit indefinitely)
+- **Score**: 2 → `priority: low`
+
+**Issue: "Error types should be in errors/ package" (in v2.0.0 milestone)**
+
+- **Impact**: 2 (affects DX, not correctness)
+- **Risk-of-delay**: 3 (breaking change, free now, expensive after release)
+- **Score**: 5 → `priority: high` (already at tier)
+- **Milestone floor**: No change (5 ≥ high threshold)
+
+### Common Mistakes
+
+1. **Don't** use Effort as an input to priority. A cheap fix isn't automatically high priority.
+2. **Don't** force all milestone issues to `urgent`. Use the floor rule to differentiate.
+3. **Don't** skip scoring because "it's obviously important." The rubric exists for consistency.
+4. **Don't** leave issues without a priority label after triage. Every issue needs one.
+
+---
+
+## References
+
+- [Issue Prioritization System Proposal](proposals/issue-prioritization-system.md)
+- [Project Management Redesign](proposals/project-management-system-redesign.md)
+- [Contributing Guide](../website/docs/contributing/conventions.md)

--- a/docs/proposals/issue-prioritization-system.md
+++ b/docs/proposals/issue-prioritization-system.md
@@ -56,8 +56,9 @@ it).
   `priority: urgent` (3 tiers). `priority: medium` does **not** exist yet —
   this spec adds it (see Design and Adoption plan below); it needs to be created
   before or during the retroactive scoring pass, not as a separate step.
-- **`state:` labels** track triage/workflow status independently:
-  `state: new`, `state: reviewed`, `state: in progress`, `state: blocked`.
+- **`status:` labels** track triage/workflow status independently:
+  `status: new`, `status: reviewed`, `status: blocked`, `status: duplicate`, `status: invalid`, `status: wontfix`.
+  (Note: The original `state:` prefix was removed in Phase 1 of the project management redesign; `status:` is the canonical prefix.)
 - **`type:` labels** classify the kind of work: `type: bug`,
   `type: feature`, `type: refactor`, `type: documentation`, `type: devops`,
   `type: epic`, `type: test`.

--- a/docs/proposals/project-management-system-redesign.md
+++ b/docs/proposals/project-management-system-redesign.md
@@ -1,0 +1,212 @@
+# Project Management System Audit & Recommendation
+
+## Executive Summary
+
+The servicenow-sdk-go repository has **multiple overlapping project management systems** that create confusion and fragmentation. This audit identifies the gaps and proposes a unified system.
+
+---
+
+## Current State Audit
+
+### What Exists Today
+
+| System                   | Location                     | Status                               |
+| ------------------------ | ---------------------------- | ------------------------------------ |
+| **Specs**                | `specs/001-007/`             | 7 specs, varying completion          |
+| **ADRs**                 | `docs/adr/001-010`           | 10 decisions documented              |
+| **GitHub Issues**        | Issues #555-#568 + others    | Recently migrated from local tracker |
+| **GitHub Project Board** | Project #7                   | 41 items, sprint-focused views       |
+| **Priority Proposal**    | `docs/proposals/`            | Designed but not implemented         |
+| **CLAUDE.md**            | Root                         | Detailed architecture context        |
+| **Contributing Guide**   | `website/docs/contributing/` | Comprehensive                        |
+
+### Critical Gaps Identified
+
+#### 1. **No Work Item Linkage**
+- Specs have `tasks.md` with checkboxes, but these aren't linked to GitHub issues
+- No traceability from spec → issue → PR → release
+- Example: `specs/002-v2-release-prep/tasks.md` has 25 tasks, none linked to issues
+
+#### 2. **Dual Priority Systems**
+- Labels: `priority: low/high/urgent` (missing `medium`)
+- Project field: `Priority` (single-select, already exists)
+- Proposal: Impact + Risk-of-delay rubric (not implemented)
+- **Result**: Inconsistent prioritization, no scoring
+
+#### 3. **Status Confusion**
+- `state:` labels: `new`, `reviewed`, `in progress`, `blocked`
+- `Status` field: `Needs Triage`, `Backlog - Ready`, `In progress`, `In review`, `Done`, `Backlog - Not Ready`, `Won't do`
+- **Result**: Two overlapping taxonomies, unclear which is authoritative
+
+#### 4. **No Sprint/Iteration Cadence**
+- `Sprint` iteration field exists on project board
+- `Size` field exists (XS/S/M/L/XL)
+- No actual sprint planning or time-boxed iterations
+- **Result**: Backlog-only, no delivery rhythm
+
+#### 5. **Missing Post-v2 Roadmap**
+- Only one milestone: `v2.0.0` (now released)
+- No `v2.1.0`, `v3.0.0`, or feature milestones
+- **Result**: No forward-looking planning visibility
+
+#### 6. **Spec System Underutilized**
+- Specs are comprehensive (user stories, acceptance criteria, tasks)
+- But: No status tracking, no completion %, no linkage to implementation
+- Example: `specs/001-prerelease-workflow` is "Draft" status but appears implemented
+
+---
+
+## Recommended New System
+
+### Principles
+1. **Single source of truth**: GitHub Issues as the work item hub
+2. **Lightweight specs**: Only for cross-cutting/architectural work
+3. **Clear ownership**: Every issue has an assignee
+4. **Time-boxed delivery**: Milestones with target dates
+5. **Automated status**: Reduce manual labeling burden
+
+### Proposed Structure
+
+#### 1. Issue Taxonomy (Simplified)
+
+**Remove** `state:` labels entirely. Use GitHub Project `Status` field only:
+
+| Status        | Meaning                                            |
+| ------------- | -------------------------------------------------- |
+| `Backlog`     | Triaged, not yet prioritized for work              |
+| `Ready`       | Prioritized, dependencies resolved, ready to start |
+| `In Progress` | Actively being worked                              |
+| `In Review`   | PR open, awaiting review                           |
+| `Done`        | Merged and verified                                |
+
+**Keep** `type:` labels (bug, feature, refactor, documentation, devops, epic, test)
+
+**Keep** `module:` labels (table-api, core, credentials, etc.)
+
+**Implement** priority rubric from proposal:
+- `priority: urgent` (Score 6)
+- `priority: high` (Score 5)
+- `priority: medium` (Score 4) - **create this**
+- `priority: low` (Score 2-3)
+
+#### 2. Milestone Structure
+
+Replace single `v2.0.0` with quarterly milestones:
+
+```
+v2.1.0 (Q4 2026) - API surface expansion
+v2.2.0 (Q1 2027) - Developer experience
+v3.0.0 (Q3 2027) - Next major (if needed)
+```
+
+Each milestone has:
+- Target date
+- Description of scope
+- Issues assigned via `milestone:` field
+
+#### 3. Spec System (Reduced)
+
+**Keep specs only for**:
+- Cross-cutting architectural changes (error handling, model patterns)
+- New API module blueprints
+- Breaking change proposals
+
+**Don't create specs for**:
+- Bug fixes
+- Single-file changes
+- Documentation updates
+
+**Spec lifecycle**:
+```
+Draft → Approved → In Progress → Complete
+```
+
+#### 4. Project Board Views
+
+Replace current sprint-focused views:
+
+| View               | Filter                 | Sort                 | Purpose               |
+| ------------------ | ---------------------- | -------------------- | --------------------- |
+| **Triage**         | `Status = Backlog`     | Priority score desc  | What needs a look     |
+| **Ready to Start** | `Status = Ready`       | Priority score desc  | What to work on next  |
+| **In Progress**    | `Status = In Progress` | Assignee             | Active work           |
+| **In Review**      | `Status = In Review`   | Created asc          | PRs awaiting review   |
+| **By Module**      | All                    | Group by `module:`   | Module health         |
+| **By Priority**    | All                    | Group by `priority:` | Priority distribution |
+| **Release Prep**   | Milestone = current    | Status               | Release readiness     |
+
+#### 5. Automation Opportunities
+
+| Automation                                   | Trigger       | Action               |
+| -------------------------------------------- | ------------- | -------------------- |
+| Auto-assign `state: new` → `Status: Backlog` | Issue created | Set initial status   |
+| Auto-set `Status: In Review`                 | PR opened     | Move issue status    |
+| Auto-set `Status: Done`                      | PR merged     | Close issue          |
+| Priority score calculation                   | Label changed | Update project field |
+| Milestone progress                           | Issue closed  | Update milestone %   |
+
+#### 6. Documentation Updates
+
+Update these files to reflect new system:
+
+| File                         | Changes                                    |
+| ---------------------------- | ------------------------------------------ |
+| `CONTRIBUTING.md`            | Add priority rubric, issue lifecycle       |
+| `CLAUDE.md`                  | Update subagent conventions for new labels |
+| `website/docs/contributing/` | Add project management guide               |
+| `docs/TRIAGE.md`             | **New** - triage process documentation     |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Cleanup (Week 1)
+- [ ] Close/archive completed specs (001, 002, 003, 004, 005, 006)
+- [ ] Create `priority: medium` label
+- [ ] Retroactively score all open issues using rubric
+- [ ] Remove duplicate `state:` labels from issues (keep `Status` field)
+
+### Phase 2: Structure (Week 2)
+- [ ] Create v2.1.0 milestone with target date
+- [ ] Create new project board views (Triage, Ready, In Progress, In Review)
+- [ ] Migrate v2.0.0 milestone issues to v2.1.0 or close
+- [ ] Document triage process in `docs/TRIAGE.md`
+
+### Phase 3: Automation (Week 3)
+- [ ] GitHub Action: Auto-set status on PR open/merge
+- [ ] GitHub Action: Sync priority label ↔ project field
+- [ ] Update CLAUDE.md subagent conventions
+
+### Phase 4: Adoption (Ongoing)
+- [ ] Triage all new issues within 48 hours
+- [ ] Weekly review of `Backlog` → `Ready` promotion
+- [ ] Monthly milestone progress review
+
+---
+
+## Metrics for Success
+
+| Metric                            | Current | Target             |
+| --------------------------------- | ------- | ------------------ |
+| Issues without priority label     | ~50%    | <10%               |
+| Issues without assignee           | ~80%    | <20%               |
+| Average time from `New` → `Ready` | Unknown | <7 days            |
+| Milestone completion rate         | N/A     | >80% on-time       |
+| Spec-to-issue linkage             | 0%      | 100% for new specs |
+
+---
+
+## Next Steps
+
+1. **Review this audit** with maintainer
+2. **Prioritize which phases** to implement first
+3. **Create GitHub Issue** to track this project management improvement
+4. **Assign owner** for implementation
+
+---
+
+## Open Questions
+
+1. Do you want to implement this full system, or start with a subset?
+2. Should we keep the spec system for future work, or retire it entirely?
+3. What's your preferred sprint cadence (if any) - weekly, bi-weekly, monthly, or none?

--- a/specs/003-robust-testing-framework/spec.md
+++ b/specs/003-robust-testing-framework/spec.md
@@ -4,7 +4,9 @@
 
 **Created**: 2026-06-16
 
-**Status**: Draft
+**Status**: Archived
+
+> **Archived**: This spec is fully implemented. All 30 tasks completed. Testing framework is in place with unit mocks (`internal/mocking/`), Godog integration tests (`tests/integration/`), and CI coverage reporting.
 
 **Input**: User description: "Build a robust testing framework for this project."
 

--- a/specs/004-internal-package-migration/plan.md
+++ b/specs/004-internal-package-migration/plan.md
@@ -1,5 +1,9 @@
 # Spec: Internal Package Migration
 
+## Status: Archived
+
+> **Archived**: This spec is fully implemented. The `core/` package exists at project root with all public types (`BaseRequestBuilder`, `ServiceNowError`, `PageIterator`, etc.). All API modules import from `core/` instead of `internal/`.
+
 ## Objective
 Audit the `internal` package and migrate components that should be publicly accessible to a new `core` package, ensuring the SDK is extensible and its error handling is accessible to users.
 

--- a/specs/004-v2-refinement-and-readiness/spec.md
+++ b/specs/004-v2-refinement-and-readiness/spec.md
@@ -1,5 +1,9 @@
 # Specification: v2.0 Refinement & Readiness
 
+## Status: Archived
+
+> **Archived**: This spec is fully implemented. All *2 suffixes removed, HEAD methods implemented, error mapping centralized in `core.DefaultErrorMapping()`, and multipart helpers in place.
+
 ## 1. Introduction
 The v2.0 release of the ServiceNow SDK for Go is a major milestone. While the primary goal is removing deprecated code, this specification addresses the secondary goal of ensuring the resulting codebase is of production-grade quality, idiomatic, and fully featured.
 

--- a/specs/005-v2-comprehensive-refinement/plan.md
+++ b/specs/005-v2-comprehensive-refinement/plan.md
@@ -1,5 +1,9 @@
 # Implementation Plan: v2.0 Comprehensive Refinement
 
+## Status: Archived
+
+> **Archived**: This spec is mostly implemented. Directory renaming complete, error mapping centralized, HEAD methods implemented. Only pluggable logging (Phase 4) was not implemented - can be a separate spec if needed.
+
 ## Objective
 Finalize the ServiceNow SDK for Go v2.0 release with a production-grade architecture, idiomatic Go patterns, and robust error handling. This plan focus on architectural cleanup and explicit error mapping while deferring CI-breaking changes.
 

--- a/website/docs/contributing/conventions.md
+++ b/website/docs/contributing/conventions.md
@@ -137,6 +137,36 @@ contract in brief:
   `go test ./...` (config: `.golangci.yml`; `just build|lint|fmt` wrap the
   same commands).
 
+## Issue triage and labels
+
+Issues use the following label taxonomy:
+
+**Priority** (score = Impact + Risk-of-delay):
+
+| Label | Score | Description |
+|-------|-------|-------------|
+| `priority: urgent` | 6 | Blocks a release or active work |
+| `priority: high` | 5 | Should be picked up soon |
+| `priority: medium` | 4 | Worth doing, no rush |
+| `priority: low` | 2-3 | Nice to have, no urgency |
+
+**Type labels:** `type: bug`, `type: feature`, `type: refactor`, `type: documentation`, `type: devops`, `type: epic`, `type: test`
+
+**Module labels:** Auto-applied by PR based on changed files (e.g., `module: table-api`, `module: core`).
+
+**Status** (workflow state, auto-synced by automation):
+
+| Label | Meaning |
+|-------|---------|
+| `status: new` | Newly filed, not yet triaged |
+| `status: reviewed` | Triaged, ready for work |
+| `status: in progress` | Actively being worked on (set automatically when a PR is linked) |
+| `status: blocked` | Blocked on another issue, decision, or external dependency |
+
+> **Automation:** When you open a PR with `Closes #N` in the description, the linked issue automatically moves to `status: in progress`. When the PR is closed without merge, it reverts to `status: reviewed`. Merged PRs close issues via GitHub's native behavior.
+
+For the full triage process, scoring rubric, and examples, see [Issue Triage Process](https://github.com/michaeldcanady/servicenow-sdk-go/blob/main/docs/TRIAGE.md).
+
 ## Documentation conventions
 
 - A PR that changes exported API surface updates the docs site (`website/`)


### PR DESCRIPTION
## Summary

Adds project management automation and triage documentation to streamline issue workflow.

### Changes

- **issue-status-sync.yml**: Automatically marks linked issues as  when a PR is opened, reverts on close without merge
- **sync-project-status.yml**: Bidirectional sync between project board Status field and issue  labels using 
- **.project-label-sync.yml**: Config mapping project Status values to issue labels
- **docs/TRIAGE.md**: Complete triage process with Mermaid lifecycle diagram, scoring rubric, and label taxonomy
- Updated issue templates to use  label
- Updated contributing conventions with status labels table
- Archived completed specs (003, 004, 004-internal, 005)

### Setup Required

1. Create a classic PAT with  scope
2. Add  secret to repo settings
3. Run sync-project-status workflow manually first to preview

### Testing

- [ ] Verify  label is added when PR is linked to issue
- [ ] Run sync-project-status workflow to test label ↔ project Status sync