### PR TITLE
chore: streamline issue templates for lower filing friction

### DIFF
--- a/.agents/skills/bug-reporter/references/bug_report_template.md
+++ b/.agents/skills/bug-reporter/references/bug_report_template.md
@@ -1,63 +1,22 @@
----
-name: "🐞 Bug Report"
-about: "Report an issue to help the project improve."
-title: "[Bug] "
-labels: ["type: bug"]
-assignees: 
+# Bug Report
 
----
+Use this as a reference when generating bug reports. The canonical form is the
+YAML issue template at `.github/ISSUE_TEMPLATE/bug-template.yaml`.
 
-# **🐞 Bug Report**
+## Fields
 
-## **Describe the bug**
-<!-- A clear and concise description of what the bug is. -->
+**SDK Version** — `go list -m github.com/michaeldcanady/servicenow-sdk-go` output or go.mod pin.
 
-*
+**Go Version** — output of `go version`.
 
----
+**Module** — closest matching package (table-api, attachment-api, core / request pipeline, etc.).
 
-### **To Reproduce**
+**What happened?** — clear description of the bug.
 
-<!-- Steps to reproduce the error:
-(e.g.:)
-1. Use x argument / navigate to
-2. Fill this information
-3. Go to...
-4. See error -->
+**What did you expect?** — expected behavior.
 
-<!-- Write the steps here (add or remove as many steps as needed)-->
+**Reproduction** — minimal Go code that triggers the bug. Redact instance URLs and credentials.
 
-1.
-2.
-3.
-4.
+**Error output** — stack trace or error messages, if any.
 
----
-
-### **Expected behaviour**
-<!-- A clear and concise description of what you expected to happen. -->
-
-*
-
----
-
-### **Media prove**
-<!-- If applicable, add screenshots or videos to help explain your problem. -->
-
----
-
-### **Your environment**
-
-<!-- use all the applicable bulleted list elements for this specific issue,
-and remove all the bulleted list elements that are not relevant for this issue. -->
-
-* OS: <!--[e.g. Ubuntu 5.4.0-26-generic x86_64 / Windows 1904 ...]-->
-* Golang version:
-* module version:
-
----
-
-### **Additional context**
-<!-- Add any other context or additional information about the problem here.-->
-
-*
+**Additional context** — related issues, ServiceNow version, plugin config, etc.

--- a/.agents/skills/bug-reporter/scripts/generate_report.sh
+++ b/.agents/skills/bug-reporter/scripts/generate_report.sh
@@ -10,8 +10,8 @@ EXPECTED_BEHAVIOR=$4
 ADDITIONAL_CONTEXT=$5
 OUTPUT_FILE=$6
 
-TEMPLATE_PATH="/workspaces/servicenow-sdk-go/.gemini/skills/bug-reporter/references/bug_report_template.md"
-GATHER_INFO_SCRIPT="/workspaces/servicenow-sdk-go/.gemini/skills/bug-reporter/scripts/gather_info.sh"
+TEMPLATE_PATH="/workspaces/servicenow-sdk-go/.agents/skills/bug-reporter/references/bug_report_template.md"
+GATHER_INFO_SCRIPT="/workspaces/servicenow-sdk-go/.agents/skills/bug-reporter/scripts/gather_info.sh"
 
 if [ -z "$TITLE" ] || [ -z "$DESCRIPTION" ] || [ -z "$OUTPUT_FILE" ]; then
     echo "Error: Missing required arguments (Title, Description, OutputFile)."

--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -6,15 +6,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a bug! Bugs are triaged outside the feature backlog, so please include
-        enough detail (version, code sample, actual vs. expected) for a maintainer to reproduce it quickly.
+        Thanks for the report! Please fill in what you can — a code sample that reproduces the issue is the most helpful thing you can include.
 
   - type: input
     id: sdk-version
     attributes:
       label: SDK Version
-      description: Output of `go list -m github.com/michaeldcanady/servicenow-sdk-go` or your go.mod pin.
-      placeholder: v1.11.2
+      description: "`go list -m github.com/michaeldcanady/servicenow-sdk-go` or your go.mod pin."
+      placeholder: v2.0.0
     validations:
       required: true
 
@@ -22,18 +21,15 @@ body:
     id: go-version
     attributes:
       label: Go Version
-      placeholder: go1.24.1
+      placeholder: go1.25.0
     validations:
       required: true
 
   - type: dropdown
     id: module
     attributes:
-      label: Affected Module / API
-      description: >
-        Used to auto-apply a `module: *` label so contributors can filter issues by area they know.
-        Pick the closest match — see the package list in the repo root if you're not sure which
-        package this maps to.
+      label: Module
+      description: Closest match — see the package list in the repo root if unsure.
       options:
         - table-api
         - attachment-api
@@ -58,22 +54,21 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: A clear description of the bug.
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: What did you expect to happen?
+      label: What did you expect?
     validations:
       required: true
 
   - type: textarea
     id: repro
     attributes:
-      label: Minimal Reproduction
-      description: A minimal Go code sample that reproduces the issue. Redact any real instance URLs or credentials.
+      label: Reproduction
+      description: Minimal Go code that triggers the bug. Redact instance URLs and credentials.
       render: go
     validations:
       required: true
@@ -81,42 +76,15 @@ body:
   - type: textarea
     id: error-output
     attributes:
-      label: Error Output / Stack Trace (if any)
+      label: Error output (if any)
       render: shell
-    validations:
-      required: false
-
-  - type: dropdown
-    id: difficulty
-    attributes:
-      label: Estimated Difficulty (maintainer use)
-      description: >
-        Leave as "not triaged yet" if you're filing this — a maintainer sets this during triage so
-        contributors browsing issues can self-select work matching their skill level/available time.
-      options:
-        - not triaged yet
-        - good first issue (single module, no design decisions)
-        - intermediate (touches one module, some design judgment)
-        - advanced (cross-cutting or requires design discussion)
     validations:
       required: false
 
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional Context
-      description: Anything else — related issues, ServiceNow instance version/plugin config, etc.
+      label: Additional context
+      description: Related issues, ServiceNow version/plugin config, etc.
     validations:
       required: false
-
-  - type: checkboxes
-    id: checklist
-    attributes:
-      label: Before submitting
-      options:
-        - label: I searched existing issues (including closed ones) for a duplicate of this bug.
-          required: true
-        - label: I reproduced this on the latest released version.
-          required: true
-        - label: I included a minimal reproduction, not just a description.
-          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,73 +1,39 @@
 name: "Feature Request"
-description: Request a new capability or enhancement (e.g. support for a new ServiceNow API, auth method, or SDK ergonomics improvement).
-title: "[Story]: "
+description: Request a new capability or enhancement (e.g. a new API module, auth method, or DX improvement).
+title: "[Feature]: "
 labels: ["type: feature", "status: new"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to request a feature! Please fill this out as completely as you can —
-        the more concrete the "so that" clause and acceptance criteria, the faster this can be scoped,
-        prioritized, and picked up by a contributor.
+        Use the "Job to be done" format — the more concrete, the easier it is to scope and prioritize.
 
   - type: textarea
-    id: user-story
+    id: job-to-be-done
     attributes:
-      label: User Story
-      description: State this as "As a <persona>, I want <capability>, so that <outcome>."
-      placeholder: |
-        As a Go developer integrating with ServiceNow's Import Set API,
-        I want to insert records into a staging table,
-        so that I can trigger transform maps without hand-building HTTP calls.
-    validations:
-      required: true
-
-  - type: textarea
-    id: problem
-    attributes:
-      label: What problem does this solve?
-      description: What can't you do today? What's the workaround, if any?
-    validations:
-      required: true
-
-  - type: textarea
-    id: acceptance-criteria
-    attributes:
-      label: Acceptance Criteria
+      label: Job to be done
       description: >
-        What has to be true for this to be considered done? A short checklist helps a contributor
-        scope the work and know when they're finished, without waiting on back-and-forth.
+        Please describe the situation, what you want to be able to do, and why you believe the action is necessary by filling out the provided template.
       placeholder: |
-        - [ ] `<X>RequestBuilder` supports `Get`/`Post`/... following the existing constructor triad
-        - [ ] Unit tests cover happy path + at least one error case
-        - [ ] Package Readme.md documents the endpoint
+        When [situation],
+        I want to [action],
+        so I can [outcome].
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: proposed-solution
     attributes:
-      label: Proposed Solution (optional)
-      description: If you have an idea of the API surface, request builder shape, or config style, sketch it here.
-    validations:
-      required: false
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives Considered (optional)
-      description: Other approaches you've tried or considered, and why they fell short.
+      label: Proposed solution (optional)
+      description: If you have a specific API shape, builder pattern, or config style in mind, sketch it here.
     validations:
       required: false
 
   - type: dropdown
     id: module
     attributes:
-      label: Affected Module / API
-      description: >
-        Used to auto-apply a `module: *` label so contributors can filter issues by area they know.
-        Pick the closest match — see the package list in the repo root if you're not sure which
-        package this maps to.
+      label: Module
+      description: Closest match — pick "new module" if this doesn't exist yet.
       options:
         - table-api
         - attachment-api
@@ -83,54 +49,16 @@ body:
         - app-service-api
         - authentication / credentials
         - core / request pipeline
-        - all / cross-cutting
-        - documentation
-        - CI
-        - GitHub
         - new module (doesn't exist yet)
+        - documentation
         - other / not sure
     validations:
       required: true
 
-  - type: dropdown
-    id: difficulty
-    attributes:
-      label: Estimated Difficulty (maintainer use)
-      description: >
-        Leave as "not triaged yet" if you're filing this — a maintainer sets this during triage so
-        contributors browsing issues can self-select work matching their skill level/available time.
-      options:
-        - not triaged yet
-        - good first issue (single module, no design decisions)
-        - intermediate (touches one module, some design judgment)
-        - advanced (cross-cutting or requires design discussion)
-    validations:
-      required: false
-
-  - type: input
-    id: version
-    attributes:
-      label: Target Version (optional)
-      description: If you have a preference for which SDK version should include this, note it here.
-    validations:
-      required: false
-
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional Context
-      description: Links to related issues/PRs, relevant ServiceNow docs, or anything else useful.
+      label: Additional context
+      description: Related issues/PRs, ServiceNow docs links, etc.
     validations:
       required: false
-
-  - type: checkboxes
-    id: checklist
-    attributes:
-      label: Before submitting
-      options:
-        - label: I searched existing issues (including closed ones) for a duplicate of this request.
-          required: true
-        - label: I checked the latest release to confirm this doesn't already exist.
-          required: true
-        - label: I've given this a clear, descriptive title.
-          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,36 @@
-<!-- PR title must be a Conventional Commit line, e.g. `feat(tableapi): add display-value support` — CI lints it and it becomes the squash commit. -->
+<!--
+  PR title MUST be a Conventional Commit line — CI lints it and it becomes the squash commit.
+  Examples:
+    feat(tableapi): add display-value support
+    fix(credentials): handle expired refresh token
+    chore(ci): update golangci-lint version
+    docs: fix broken link in tableapi README
+-->
 
 ## What & why
 
-<!-- Short description of the change and the problem it solves. Link related issues. -->
+<!-- Short description of the change and the problem it solves. Link related issues with "Closes #123". -->
+
+## Type of change
+
+<!-- Check one. This determines which checklist items apply. -->
+
+- [ ] `feat` — new or changed exported API surface
+- [ ] `fix` — bug fix
+- [ ] `refactor` — internal improvement, no behavior change
+- [ ] `docs` — documentation only
+- [ ] `chore` — CI, tooling, dependencies, or other non-release work
+- [ ] `test` — test coverage or infrastructure
 
 ## Checklist
 
-- [ ] `gofmt -s -w .`, `golangci-lint run ./...`, and `go test ./...` pass locally
+<!-- Only check items relevant to your change type. -->
+
+- [ ] `gofmt -s -w .` and `golangci-lint run ./...` pass
+- [ ] `go test ./...` passes
 - [ ] New or changed exported surface has unit tests
-- [ ] **Docs:** the docs site (`website/`) is updated — or no exported surface changed / explain below why no docs change is needed
-- [ ] Code samples live in `website/snippets/*.go` region markers (compiled by CI), not inline in pages
+- [ ] `website/` is updated (or explain why not below)
+- [ ] Code samples use `website/snippets/*.go` region markers, not inline in pages
 - [ ] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)
 
-<!-- If docs are intentionally untouched, say why: -->
+<!-- If docs or tests are intentionally untouched, say why: -->


### PR DESCRIPTION
## What & why

Streamlined both public issue templates to reduce filing friction while preserving all information a maintainer needs for triage.

**Bug Report** (122 → 90 lines):
- Removed "Estimated Difficulty" dropdown — maintainer-only triage field, not reporter input
- Removed 3 "Before submitting" checkboxes — `blank_issues_enabled: false` already prevents empty submissions
- Shortened intro, labels, and descriptions

**Feature Request** (136 → 61 lines, 55% reduction):
- Replaced "User Story" + "Problem" + "Acceptance Criteria" with a single **"Job to be done"** field (`When [situation], I want to [action], so I can [outcome]`)
- Removed "Alternatives Considered", "Target Version", difficulty dropdown, and pre-submit checkboxes
- Changed title prefix from `[Story]:` to `[Feature]:`

**Bug reporter skill** (`.agents/skills/bug-reporter/`):
- Fixed stale `.gemini/` paths → `.agents/`
- Updated reference template to match new YAML form fields

## Checklist
- [ ] `gofmt -s -w .`, `golangci-lint run ./...`, and `go test ./...` pass locally
- [ ] New or changed exported surface has unit tests
- [ ] **Docs:** the docs site (`website/`) is updated -- or no exported surface changed / explain below why no docs change is needed
- [ ] Code samples live in `website/snippets/*.go` region markers (compiled by CI), not inline in pages
- [ ] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

No exported surface changed — templates are GitHub config, not Go code.
