### PR TITLE
fix: restore and extend nil-receiver guard on error Error() methods

### DIFF
--- a/credentials/error.go
+++ b/credentials/error.go
@@ -1,5 +1,7 @@
 package credentials
 
+import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"
+
 // CredentialError represents an error related to credentials or authentication.
 type CredentialError struct {
 	// Message is the error message associated with the credential error.
@@ -25,6 +27,9 @@ func NewCredentialError(message string) *CredentialError {
 
 // Error returns the error message associated with the CredentialError.
 func (e *CredentialError) Error() string {
+	if conversion.IsNil(e) {
+		return "nil credential error"
+	}
 	return e.Message
 }
 

--- a/credentials/error_test.go
+++ b/credentials/error_test.go
@@ -55,3 +55,13 @@ func TestCredentialError_Error(t *testing.T) {
 		})
 	}
 }
+
+// A typed-nil *CredentialError must return a safe string instead of panicking,
+// matching the nil-receiver guard on NilPointerError (#591).
+func TestCredentialError_Error_NilReceiver(t *testing.T) {
+	var e *CredentialError
+
+	var got string
+	assert.NotPanics(t, func() { got = e.Error() })
+	assert.Equal(t, "nil credential error", got)
+}

--- a/internal/nil_pointer_error.go
+++ b/internal/nil_pointer_error.go
@@ -1,5 +1,7 @@
 package internal
 
+import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"
+
 // NilPointerError represents a nil pointer when a value pointer is expected.
 type NilPointerError struct {
 	s string
@@ -14,5 +16,8 @@ func NewNilPointerError(text string) *NilPointerError {
 
 // Error returns the error string.
 func (err *NilPointerError) Error() string {
+	if conversion.IsNil(err) {
+		return "nil pointer error"
+	}
 	return err.s
 }

--- a/internal/nil_pointer_error_test.go
+++ b/internal/nil_pointer_error_test.go
@@ -76,23 +76,13 @@ func TestNilPointerError_Error(t *testing.T) {
 	}
 }
 
-// Curveball (see write-unit-tests skill, step 6): a nil *NilPointerError
-// panics on Error() instead of returning a safe value, because Error()
-// dereferences the receiver directly with no nil-guard. This is the same
-// "typed nil" trap that conversion.IsNil exists elsewhere in this repo to
-// avoid - any caller that ends up with a nil *NilPointerError stored in an
-// error-typed variable (e.g. a function returning (*NilPointerError)(nil), nil
-// mistakenly, or a struct field left at its zero value) will crash the first
-// time something calls .Error() on it, such as fmt.Errorf("%w", err) or a
-// logger. Left as a skipped, documented case rather than "fixed" here since
-// silently changing production code isn't this test pass's call - reported to
-// the user instead.
+// A typed-nil *NilPointerError must return a safe string instead of panicking.
+// The guard was added in #591 and regressed by the v2 rework (#600); this test
+// (previously skipped as a known bug) now protects the restored guard.
 func TestNilPointerError_Error_NilReceiver(t *testing.T) {
-	t.Skip("BUG: (*NilPointerError)(nil).Error() panics with a nil pointer dereference instead of returning a safe string")
-
 	var err *NilPointerError
 
-	assert.NotPanics(t, func() {
-		_ = err.Error()
-	})
+	var got string
+	assert.NotPanics(t, func() { got = err.Error() })
+	assert.Equal(t, "nil pointer error", got)
 }

--- a/internal/oauth2/token_error.go
+++ b/internal/oauth2/token_error.go
@@ -1,6 +1,10 @@
 package oauth2
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"
+)
 
 // TokenError represents an error returned by the OAuth2 server during token exchange or management.
 type TokenError struct {
@@ -18,6 +22,9 @@ type TokenError struct {
 
 // Error returns the string representation of the TokenError.
 func (e *TokenError) Error() string {
+	if conversion.IsNil(e) {
+		return "nil oauth2 token error"
+	}
 	msg := fmt.Sprintf("oauth2 error: %s", e.Err)
 	if e.ErrorDescription != "" {
 		msg += fmt.Sprintf(" (%s)", e.ErrorDescription)

--- a/internal/oauth2/token_error_test.go
+++ b/internal/oauth2/token_error_test.go
@@ -60,3 +60,13 @@ func TestTokenError_ErrorsAs(t *testing.T) {
 	assert.Equal(t, "invalid_grant", tokenErr.Err)
 	assert.Equal(t, 400, tokenErr.StatusCode)
 }
+
+// A typed-nil *TokenError must return a safe string instead of panicking,
+// matching the nil-receiver guard on NilPointerError (#591).
+func TestTokenError_Error_NilReceiver(t *testing.T) {
+	var e *TokenError
+
+	var got string
+	assert.NotPanics(t, func() { got = e.Error() })
+	assert.Equal(t, "nil oauth2 token error", got)
+}


### PR DESCRIPTION
## What

Restores the nil-receiver guard on `NilPointerError.Error()` (added in #591, dropped by the v2 rework #600) and extends the same `conversion.IsNil` guard to the sibling `Error()` methods that panic identically on a typed-nil receiver: `CredentialError` and `TokenError`.

## Why

A typed-nil error value (e.g. a function that returns `(*NilPointerError)(nil)` stored in an `error`, or a zero-value error field) panics with a nil pointer dereference the first time it is formatted (`fmt.Errorf("%w", err)`, a logger, etc.) instead of returning a safe string. #591 fixed this for `NilPointerError`; the v2 rework (#600) moved the file to `internal/` and dropped the guard, reintroducing the panic. `CredentialError` and `TokenError` share the same bug and never had the guard.

The repo already documented this: `TestNilPointerError_Error_NilReceiver` existed as a `t.Skip`-ped known-bug test. This PR un-skips it now that the guard is restored.

## How tested

- Un-skipped `TestNilPointerError_Error_NilReceiver` (now passing).
- Added `TestCredentialError_Error_NilReceiver` and `TestTokenError_Error_NilReceiver`.
- `go test ./...` green, `go vet` clean. All existing tests preserved; the change is additive.
