### PR TITLE
chore(ci): fix integration go.mod parse error and lint job Go 1.27 panic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          install-mode: goinstall
+          version: v2.13.0
           skip-cache: false
           args: --timeout=5m
 

--- a/tests/integration/v2/go.mod
+++ b/tests/integration/v2/go.mod
@@ -1,4 +1,4 @@
-module github.com/michaeldcanady/servicenow-sdk-go/tests/integration/v2
+module github.com/michaeldcanady/servicenow-sdk-go/v2/tests/integration/v2
 
 go 1.25.0
 
@@ -6,7 +6,7 @@ require (
 	github.com/cucumber/godog v0.15.1
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/joho/godotenv v1.5.1
-	github.com/michaeldcanady/servicenow-sdk-go/v2 v0.0.0
+	github.com/michaeldcanady/servicenow-sdk-go/v2 v2.0.0-00010101000000-000000000000
 	github.com/microsoft/kiota-abstractions-go v1.9.4
 	github.com/microsoft/kiota-http-go v1.5.6
 )

--- a/tests/integration/v2/go.sum
+++ b/tests/integration/v2/go.sum
@@ -60,7 +60,6 @@ github.com/microsoft/kiota-serialization-text-go v1.1.3 h1:8z7Cebn0YAAr++xswVgfd
 github.com/microsoft/kiota-serialization-text-go v1.1.3/go.mod h1:NDSvz4A3QalGMjNboKKQI9wR+8k+ih8UuagNmzIRgTQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
@@ -78,8 +77,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
+github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=


### PR DESCRIPTION
## What & why

Two CI jobs on `main` are red for reasons unrelated to any recent code change:

- **Integration Tests (mocked)** fails at `go.mod` parse time: the nested `tests/integration/v2` module required the SDK at `v0.0.0`, invalid for a `/v2` module path (must be ≥ v2). Closes #647.
- **Lint Go Code (stable)** panics — the prebuilt golangci-lint v2.12.2 binary (built with Go 1.26) can't type-check Go 1.27 sources now that runner images ship 1.27 as `stable`. Closes #648.

### #647 — `tests/integration/v2/go.mod`

- Require the SDK as the zero pseudo-version sentinel (`v2.0.0-00010101000000-000000000000`) instead of a published version: it satisfies the `/v2` parse rule while making explicit that resolution always defers to the enclosing checkout via the existing `replace => ../../../` directive — and fails loudly if that replace is ever dropped, rather than silently pinning to a release.
- Align the module path with the `/v2/...` import paths used across the suite (`.../servicenow-sdk-go/v2/tests/integration/v2`); under the old declaration those 44 imports could never resolve once the parse error was fixed.
- `go.sum`: testify hash updates from `go mod tidy` only; tidy is idempotent.

### #648 — `.github/workflows/ci.yml` (`lint-go`)

- `install-mode: goinstall` so each matrix leg builds golangci-lint with its own toolchain — immune to future `stable` bumps (this will otherwise recur when Go 1.28 lands).
- Bump `version:` to v2.13.0, which adds explicit Go 1.27 support (golangci/golangci-lint#6642). Also satisfies the pin-to-released-version intent of #639.

## Type of change

- [ ] `feat` — new or changed exported API surface
- [ ] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [x] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

- [x] `gofmt -s -w .` and `golangci-lint run ./...` pass
- [x] `go test ./...` passes
- [ ] New or changed exported surface has unit tests — N/A, no exported surface touched
- [ ] `website/` is updated — N/A, CI-only change
- [ ] Code samples use `website/snippets/*.go` region markers — N/A
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

Verification: exact CI command (`SN_OFFLINE=true ... go test -tags integration ./...`) passes all scenarios; actionlint + YAML parse clean on ci.yml; local `golangci-lint run --timeout=5m` reports 0 issues.