### PR TITLE
chore: build golangci-lint from source in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          install-mode: goinstall
+          version: v2.13.0
           skip-cache: false
           args: --timeout=5m
 


### PR DESCRIPTION
## What & why

The **Lint Go Code (stable)** CI job panics during package type-checking instead of reporting lint findings:

```
panic: file requires newer Go version go1.27 (application built with go1.26) [recovered, repanicked]
```

The prebuilt golangci-lint v2.12.2 binary was compiled with Go 1.26; once runner images began shipping Go 1.27 as `stable`, its embedded `go/types` can no longer type-check the stable leg's sources. The `oldstable` leg still passes.

Closes #648.

### Changes

- `install-mode: goinstall` so each matrix leg builds golangci-lint with its own toolchain — immune to future `stable` bumps (otherwise this recurs when Go 1.28 lands).
- Bump `version:` to v2.13.0, which adds explicit Go 1.27 support (golangci/golangci-lint#6642). Pinning an exact release in `goinstall` mode also satisfies the intent of #639.

## Type of change

- [ ] `feat` — new or changed exported API surface
- [ ] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [x] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

- [x] `gofmt -s -w .` and `golangci-lint run ./...` pass
- [x] `go test ./...` passes
- [ ] New or changed exported surface has unit tests — N/A, no exported surface touched
- [ ] `website/` is updated — N/A, CI-only change
- [ ] Code samples use `website/snippets/*.go` region markers — N/A
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

Verification: actionlint + YAML parse clean on ci.yml; local `golangci-lint run --timeout=5m` reports 0 issues.