### PR TITLE
chore: run CI when integration test files or feature files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,15 @@ on:
     paths:
       - "**.go"
       - "!docs/snippets/**"
-      - "tests/integration/features/**"
+      - "tests/integration/**"
+      - "**/*.feature"
       - ".github/workflows/ci.yml"
   pull_request:
     paths:
       - "**.go"
       - "!docs/snippets/**"
-      - "tests/integration/features/**"
+      - "tests/integration/**"
+      - "**/*.feature"
       - ".github/workflows/ci.yml"
       - ".golangci.yml"
 
@@ -46,7 +48,8 @@ jobs:
           files: |
             **.go
             !docs/snippets/**
-            tests/integration/features/**
+            tests/integration/**
+            **/*.feature
             .github/workflows/ci.yml
 
   check-go:


### PR DESCRIPTION
## What & why

PR #650 changed only `tests/integration/v2/go.mod` + `go.sum`, yet the **Integration Tests (mocked)** job never ran — its fix went to CI unverified. Two independent filter bugs caused this:

1. **`go.mod`/`go.sum` (and non-`.go` files under `tests/integration/`) never matched.** The `changes` job and workflow-level `paths` filters only match `**.go`, `tests/integration/features/**`, and `.github/workflows/ci.yml`.
2. **`tests/integration/features/**` is a dead pattern** — feature files actually live at `tests/integration/v2/features/**`, so even `.feature`-only changes never triggered CI.

### Changes

- Replace `tests/integration/features/**` with `tests/integration/**` in all three filter locations (`push.paths`, `pull_request.paths`, and the `changes` job's `files`), so any change under the integration suite — `go.mod`, `go.sum`, steps, support, mockdata, features — triggers the test jobs.
- Add `**/*.feature` so Gherkin files anywhere trigger the suite.

Verified with `actionlint` and by simulating the exact pattern set with `picomatch` (the matcher tj-actions/changed-files and GitHub's path filters use): `tests/integration/v2/go.mod`, `go.sum`, `features/table/crud.feature`, and `steps/table_steps.go` now match; `docs/snippets/**` exclusion still works; unrelated paths (`README.md`) still don't trigger.

Related: #647, #650.

## Type of change

- [ ] `feat` — new or changed exported API surface
- [ ] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [x] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

- [x] `gofmt -s -w .` and `golangci-lint run ./...` pass — N/A, workflow-only change
- [x] `go test ./...` passes — N/A, workflow-only change
- [ ] New or changed exported surface has unit tests — N/A, no exported surface touched
- [ ] `website/` is updated — N/A, CI-only change
- [ ] Code samples use `website/snippets/*.go` region markers — N/A
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)