### PR TITLE
chore(ci): add opencode big-pickle first-pass PR review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,77 @@
+name: OpenCode Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+  issue_comment:
+    types:
+      - created
+
+concurrency:
+  group: opencode-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  review:
+    name: AI Code Review (opencode/big-pickle)
+    # Auto-review when an owner / member / collaborator opens, reopens, or
+    # marks a PR ready for review. Skip auto-review when the PR description
+    # contains `/no-bot-review`. Manual re-review (including for outside
+    # contributions) when an owner / member / collaborator comments
+    # `/oc review` or `/opencode review`; the explicit trigger overrides the
+    # skip marker.
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        (
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR'
+        ) &&
+        !contains(github.event.pull_request.body, '/no-bot-review')
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        (
+          contains(github.event.comment.body, ' /oc review') ||
+          startsWith(github.event.comment.body, '/oc review') ||
+          contains(github.event.comment.body, ' /opencode review') ||
+          startsWith(github.event.comment.body, '/opencode review')
+        ) &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Comment-triggered runs start on the default branch; switch to the PR
+      # head so opencode reviews the PR's code.
+      - if: github.event_name == 'issue_comment'
+        run: gh pr checkout "${{ github.event.issue.number }}" --repo "$GITHUB_REPOSITORY"
+
+      - name: Run opencode review
+        uses: Barmore-Genc/opencode-pr-reviewer@d34c66bc5c72cb84b6b7c1572c2752b16fdfe339 # v1
+        with:
+          model: opencode/big-pickle
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          user-comment: ${{ github.event.comment.body }}


### PR DESCRIPTION
## What & why

Adds `.github/workflows/opencode-review.yml`, which runs an opencode-powered first-pass code review on every PR using the OpenCode Zen model `opencode/big-pickle` (free stealth model) via [opencode-review](https://github.com/marketplace/actions/opencode-review), posting the verdict as a single PR comment that is edited as the run progresses.

Behavior:

- **Auto-review** when a PR is opened, reopened, or marked ready for review by an `OWNER`/`MEMBER`/`COLLABORATOR`.
- **On-demand re-review** by commenting `/oc review` or `/opencode review` (trusted users only) — covers follow-up reviews after pushes and outside contributions, which don't auto-trigger.
- Per-PR opt-out with `/no-bot-review` in the description; the explicit comment trigger overrides it.

Implementation notes:

- Kept as a **standalone workflow** rather than a job inside `pr.yml`: it needs an extra `issue_comment` trigger and write permissions that `pr.yml` deliberately doesn't grant globally (a comment would otherwise spuriously fire `lint-title`/`dependabot-merge`).
- Action SHA-pinned (`Barmore-Genc/opencode-pr-reviewer@d34c66bc… # v1`) per repo policy; checkout reuses the pinned v7 SHA from `ci.yml`; top-level `permissions: {}` with minimal per-job grants.
- Uses the safe `pull_request` event (not `pull_request_target`) so fork PRs can't reach repo secrets; per-PR concurrency group so overlapping triggers cancel instead of racing on the same comment.
- Validated with `actionlint`.

> **Note:** requires one new repository secret before reviews succeed: `OPENCODE_API_KEY` — a free key from <https://opencode.ai/auth>. "Free" on Zen means no per-token cost, but requests still must carry a key.

## Type of change

- [x] `chore` — CI, tooling, dependencies, or other non-release work

## Checklist

<!-- Only check items relevant to your change type. -->

- [ ] `gofmt -s -w .` and `golangci-lint run ./...` pass
- [ ] `go test ./...` passes
- [ ] New or changed exported surface has unit tests
- [ ] `website/` is updated (or explain why not below)
- [ ] Code samples use `website/snippets/*.go` region markers, not inline in pages
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

<!-- If docs or tests are intentionally untouched, say why: -->

Workflow-only change (`chore`): no Go code is touched, so lint/tests/exported-surface items are N/A; no user-facing SDK behavior changed, so no `website/` update is needed. `VERSION`/`CHANGELOG.md` untouched per release-please policy (CI changes never appear in the changelog).
