### PR TITLE
chore(ci): stamp {unreleased} into Deprecated notices on release PRs

### DIFF
--- a/.github/workflows/stamp-deprecations.yml
+++ b/.github/workflows/stamp-deprecations.yml
@@ -49,7 +49,7 @@ jobs:
         id: version
         # Tolerate stray whitespace/CRLF around the version line; the strict
         # guard in the next step still rejects anything malformed.
-        run: echo "version=$(grep -Em1 '^[0-9]+\.[0-9]+\.[0-9]+' VERSION | tr -d ' \r' || true)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(tr -d ' \r' < VERSION | grep -Em1 '^[0-9]+\.[0-9]+\.[0-9]+$' || true)" >> "$GITHUB_OUTPUT"
 
       - name: Replace {unreleased}
         env:

--- a/.github/workflows/stamp-deprecations.yml
+++ b/.github/workflows/stamp-deprecations.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Read pending version
         id: version
-        run: echo "version=$(grep -Em1 '^[0-9]+\.[0-9]+\.[0-9]+$' VERSION || true)" >> "$GITHUB_OUTPUT"
+        # Tolerate stray whitespace/CRLF around the version line; the strict
+        # guard in the next step still rejects anything malformed.
+        run: echo "version=$(grep -Em1 '^[0-9]+\.[0-9]+\.[0-9]+' VERSION | tr -d ' \r' || true)" >> "$GITHUB_OUTPUT"
 
       - name: Replace {unreleased}
         env:
@@ -57,7 +59,7 @@ jobs:
           # prerelease VERSION, so no match -> skip cleanly (placeholders survive
           # preview cycles by design) rather than leaving the check red.
           if [ -z "$VERSION" ]; then
-            echo "No stable x.y.z line in VERSION (weekly preview or missing); skipping stamp."
+            echo "::notice::No stable x.y.z line in VERSION (weekly preview or missing); skipping stamp."
             exit 0
           fi
           # Guard the value before it reaches shell/sed contexts; with digits and

--- a/.github/workflows/stamp-deprecations.yml
+++ b/.github/workflows/stamp-deprecations.yml
@@ -12,7 +12,10 @@ name: Stamp Deprecated Notices
 # - Our own stamp push -> synchronize fires -> clean diff -> no-op.
 #
 # Weekly preview releases are intentionally NOT stamped; placeholders survive
-# preview cycles until the next stable release stamps them.
+# preview cycles until the next stable release stamps them. Both release flows
+# use the same `release-please--` branch prefix, so the discriminator is the
+# VERSION content: only a full-line strict `x.y.z` (stable) is stamped, while a
+# prerelease version (e.g. `2.0.3-rc.1`) skips cleanly.
 
 on:
   pull_request:
@@ -44,19 +47,31 @@ jobs:
 
       - name: Read pending version
         id: version
-        run: echo "version=$(grep -Em1 '^[0-9]+\.[0-9]+\.[0-9]+' VERSION)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(grep -Em1 '^[0-9]+\.[0-9]+\.[0-9]+$' VERSION || true)" >> "$GITHUB_OUTPUT"
 
       - name: Replace {unreleased}
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # End-anchored strict semver only. Weekly preview branches carry a
+          # prerelease VERSION, so no match -> skip cleanly (placeholders survive
+          # preview cycles by design) rather than leaving the check red.
           if [ -z "$VERSION" ]; then
-            echo "::error::No bare x.y.z line found in VERSION; cannot stamp."
-            exit 1
+            echo "No stable x.y.z line in VERSION (weekly preview or missing); skipping stamp."
+            exit 0
           fi
-          # -Z/-0 keeps paths with spaces intact; -r makes an empty match list a no-op.
-          grep -rlZ '{unreleased}' --include='*.go' . | xargs -0 -r \
-            sed -i "s/{unreleased}/${VERSION}/g"
+          # Guard the value before it reaches shell/sed contexts; with digits and
+          # dots only, no metacharacters or sed delimiters can smuggle through.
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::Unexpected VERSION value '${VERSION}'"
+            exit 1
+          }
+          # -Z/-0 keeps paths with spaces intact; -r makes an empty match list a
+          # no-op; --exclude-dir=.git keeps repo metadata out of reach. The sed
+          # address narrows edits to Deprecated notice lines so test fixtures or
+          # snippets that demonstrate the {unreleased} convention are untouched.
+          grep -rlZ --exclude-dir=.git '{unreleased}' --include='*.go' . | xargs -0 -r \
+            sed -i '/\/\/ Deprecated:/ s/{unreleased}/'"${VERSION}"'/g'
 
       - name: Push stamp commit
         env:
@@ -69,15 +84,25 @@ jobs:
           git add -A
           git commit -m "docs: stamp ${VERSION} into Deprecated notices"
           for attempt in 1 2 3; do
+            SHA=$(git rev-parse HEAD)
             if git push origin "HEAD:${HEAD_REF}"; then
-              exit 0
+              git fetch origin "${HEAD_REF}"
+              # A trivially-successful no-op push must not read as green when it
+              # dropped our commit; verify the remote tip actually contains it.
+              if git merge-base --is-ancestor "${SHA}" "origin/${HEAD_REF}"; then
+                exit 0
+              fi
+              echo "::error::Push reported success but remote tip lacks ${SHA}."
+              exit 1
             fi
             # Likely raced with release-please force-updating the branch; pick up
-            # its state and try again. If the rebase can't apply cleanly we fail,
-            # but that force-push triggers another synchronize event, which re-runs us.
+            # its state and try again. A conflicting rebase is aborted (not
+            # swallowed) so the retry keeps failing fast-forward and the run ends
+            # red instead of silently dropping the stamp; that force-push also
+            # triggers another synchronize event, which re-runs us.
             sleep $((attempt * 10))
             git fetch origin "${HEAD_REF}"
-            git rebase "origin/${HEAD_REF}" >/dev/null 2>&1 || true
+            git rebase "origin/${HEAD_REF}" >/dev/null 2>&1 || { git rebase --abort || true; }
           done
           echo "::error::Could not push stamp commit; the next synchronize event will retry."
           exit 1

--- a/.github/workflows/stamp-deprecations.yml
+++ b/.github/workflows/stamp-deprecations.yml
@@ -1,0 +1,83 @@
+name: Stamp Deprecated Notices
+
+# Deprecation notices are authored as
+#   // Deprecated: deprecated since v{unreleased}. [use X instead.]
+# and this workflow replaces {unreleased} with the pending version on the
+# release-please branch, so the tagged commit (and therefore pkg.go.dev docs)
+# carries the final version instead of a placeholder.
+#
+# - Branch created  -> pull_request.opened fires -> stamp.
+# - More commits merge while the PR is open -> release-please force-updates
+#   the branch (wiping any prior stamp) -> synchronize fires -> re-stamp.
+# - Our own stamp push -> synchronize fires -> clean diff -> no-op.
+#
+# Weekly preview releases are intentionally NOT stamped; placeholders survive
+# preview cycles until the next stable release stamps them.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  stamp:
+    name: Replace {unreleased} with pending version
+    if: ${{ startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout release PR branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Read pending version
+        id: version
+        run: echo "version=$(grep -Em1 '^[0-9]+\.[0-9]+\.[0-9]+' VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Replace {unreleased}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "::error::No bare x.y.z line found in VERSION; cannot stamp."
+            exit 1
+          fi
+          # -Z/-0 keeps paths with spaces intact; -r makes an empty match list a no-op.
+          grep -rlZ '{unreleased}' --include='*.go' . | xargs -0 -r \
+            sed -i "s/{unreleased}/${VERSION}/g"
+
+      - name: Push stamp commit
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          git diff --quiet && exit 0
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "docs: stamp ${VERSION} into Deprecated notices"
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:${HEAD_REF}"; then
+              exit 0
+            fi
+            # Likely raced with release-please force-updating the branch; pick up
+            # its state and try again. If the rebase can't apply cleanly we fail,
+            # but that force-push triggers another synchronize event, which re-runs us.
+            sleep $((attempt * 10))
+            git fetch origin "${HEAD_REF}"
+            git rebase "origin/${HEAD_REF}" >/dev/null 2>&1 || true
+          done
+          echo "::error::Could not push stamp commit; the next synchronize event will retry."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,3 +175,10 @@ majors) — **never edit `VERSION` or `CHANGELOG.md` by hand.**
 `scripts/`, or other pipeline plumbing is `chore:`, never `fix:`/`feat:`, even when it fixes a
 broken run. These don't affect the published SDK and must not appear in `CHANGELOG.md` as a fix
 or feature.
+
+**Deprecation notices use a `{unreleased}` placeholder** — write
+`// Deprecated: deprecated since v{unreleased}. [use X instead.]`. The
+`stamp-deprecations` workflow replaces `{unreleased}` with the pending version on the
+release-please branch before it merges, so the tagged commit (and pkg.go.dev docs) carries the
+final version. Weekly preview releases are not stamped; placeholders survive preview cycles until
+the next stable release stamps them.


### PR DESCRIPTION
## Summary
- Adds a `stamp-deprecations` workflow that replaces the `{unreleased}` placeholder in `// Deprecated:` notices with the pending version on the `release-please--*` release PR branch (triggered on `opened`/`synchronize`), so the tagged commit — and therefore pkg.go.dev docs — carries the final version instead of a placeholder.
- Weekly preview releases are intentionally not stamped; placeholders survive preview cycles until the next stable release stamps them.
- Includes push-retry/rebase handling for the race where release-please force-updates the branch mid-run; the resulting `synchronize` event self-heals.
- Documents the `{unreleased}` deprecation-notice convention in CLAUDE.md.

## Testing
- `actionlint .github/workflows/stamp-deprecations.yml` passes.
- grep/sed replacement pipeline verified in a scratch dir (correct stamping; empty match is a no-op).