### PR TITLE
chore(ci): add label-triggered backport automation for maintenance branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,7 @@ name: Backport
 #
 # Label convention
 #   Label a PR targeting main with one or more labels of the form
-#     backport release/vX.Y        e.g. backport release/v2
+#     backport release/vX.Y        e.g. backport release/v2.4
 #   When the PR merges, this workflow opens one cherry-pick PR per labeled
 #   target branch carrying the same commits. Multiple labels fan out to
 #   multiple branches independently. The labels themselves are provisioned
@@ -13,19 +13,19 @@ name: Backport
 #   (maintenance-label.yml), so cutting release/vX.Y makes its label usable.
 #
 # Behavior
-#   - Missing target: maintenance branches are cut lazily, so a label naming
-#     a branch that does not exist yet is skipped with a ::notice:: instead
-#     of failing the run.
-#   - Conflicts: the backport PR is still opened — as a draft holding the
-#     first encountered conflict — with resolution instructions commented on
-#     the source PR. Import-suffix conflicts (/vN+1 -> /vN) are expected and
-#     resolved by hand; the important part is that nothing fails silently.
+#   - Missing target: maintenance branches are cut lazily, so when a label
+#     names a branch that does not exist yet, the workflow skips it with a
+#     ::notice:: instead of failing the run.
+#   - Conflicts: the action still opens the backport PR as a draft holding
+#     the first encountered conflict, and posts resolution instructions on
+#     the source PR. Expect import-suffix conflicts (/vN+1 -> /vN) and
+#     resolve them by hand; nothing fails silently.
 #
 # Manual fallback period
 #   This automation is new. Until it has proven itself over a few releases,
 #   maintainers may still cherry-pick manually per the contributor playbook
 #   (website/docs/contributing/release-branches.md); the label scheme is the
-#   same, so a missed automated backport can simply be performed by hand.
+#   same, so you can perform a missed automated backport by hand.
 #   After a proving period the manual path becomes the exception, not the
 #   procedure.
 #
@@ -45,7 +45,8 @@ name: Backport
 # Runs on pull_request_target so GITHUB_TOKEN holds write access even when
 # the merged PR came from a fork. Only pinned actions plus a read-only
 # label-parsing step (event data passed via env, never interpolated into the
-# script) execute here; nothing from the PR's ref is checked out or run.
+# script) execute here; this workflow checks out and runs nothing from the
+# PR's ref.
 
 on:
   pull_request_target:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,7 +8,9 @@ name: Backport
 #     backport release/vX.Y        e.g. backport release/v2
 #   When the PR merges, this workflow opens one cherry-pick PR per labeled
 #   target branch carrying the same commits. Multiple labels fan out to
-#   multiple branches independently.
+#   multiple branches independently. The labels themselves are provisioned
+#   automatically when a maintenance branch is opened
+#   (maintenance-label.yml), so cutting release/vX.Y makes its label usable.
 #
 # Behavior
 #   - Missing target: maintenance branches are cut lazily, so a label naming

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,136 @@
+name: Backport
+
+# Label-triggered cherry-pick automation for maintenance branches (ADR 011,
+# rules 3-4: fixes land on main first, then move down to release/vX.Y).
+#
+# Label convention
+#   Label a PR targeting main with one or more labels of the form
+#     backport release/vX.Y        e.g. backport release/v2
+#   When the PR merges, this workflow opens one cherry-pick PR per labeled
+#   target branch carrying the same commits. Multiple labels fan out to
+#   multiple branches independently.
+#
+# Behavior
+#   - Missing target: maintenance branches are cut lazily, so a label naming
+#     a branch that does not exist yet is skipped with a ::notice:: instead
+#     of failing the run.
+#   - Conflicts: the backport PR is still opened — as a draft holding the
+#     first encountered conflict — with resolution instructions commented on
+#     the source PR. Import-suffix conflicts (/vN+1 -> /vN) are expected and
+#     resolved by hand; the important part is that nothing fails silently.
+#
+# Manual fallback period
+#   This automation is new. Until it has proven itself over a few releases,
+#   maintainers may still cherry-pick manually per the contributor playbook
+#   (website/docs/contributing/release-branches.md); the label scheme is the
+#   same, so a missed automated backport can simply be performed by hand.
+#   After a proving period the manual path becomes the exception, not the
+#   procedure.
+#
+# Implementation choice: korthout/backport-action over a hand-rolled script.
+#   Its default label_pattern (^backport ([^ ]+)$) already implements our
+#   multi-label fan-out; it handles every merge method (squash included),
+#   cherry-picks with `-x` for an audit trail, and its
+#   `conflict_resolution: draft_commit_conflicts` mode provides exactly the
+#   conflicted-but-opened-PR UX required above — recreating that (push a
+#   conflict-marker branch, open a draft PR, comment on the source PR) in
+#   bash would be real surface area to own and test. One deviation: the
+#   action treats a missing target branch as a hard failure, while our
+#   maintenance branches are cut lazily, so we pre-compute the target list
+#   ourselves (skipping absent branches with a notice) and pass it via
+#   `target_branches` with `label_pattern` disabled.
+#
+# Runs on pull_request_target so GITHUB_TOKEN holds write access even when
+# the merged PR came from a fork. Only pinned actions plus a read-only
+# label-parsing step (event data passed via env, never interpolated into the
+# script) execute here; nothing from the PR's ref is checked out or run.
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
+jobs:
+  backport:
+    name: Cherry-pick merged PR to release/vX.Y
+    # Closed without merging is not a backport candidate; the '"backport '
+    # probe cheaply short-circuits runs with no backport label at all.
+    if: >-
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # push backport branches
+      pull-requests: write # open backport PRs, comment on the source PR
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so cherry-picks across main and release branches
+          # always find their parent commits.
+          fetch-depth: 0
+
+      - name: Select existing target branches
+        id: select
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Only `backport release/vX.Y` (two numeric components) selects a
+          # target; near-misses get a pointed warning so typos surface.
+          PATTERN='^backport[[:space:]](release/v[0-9]+\.[0-9]+)$'
+
+          existing=""
+          while IFS= read -r label; do
+            if [[ ! "$label" =~ $PATTERN ]]; then
+              if [[ "$label" == "backport "* ]]; then
+                echo "::warning::Label '${label}' looks like a backport request but does not match 'backport release/vX.Y'; ignoring."
+              fi
+              continue
+            fi
+
+            branch="${BASH_REMATCH[1]}"
+            rc=0
+            # Maintenance branches are cut lazily; absence is expected and
+            # skipped with a notice, while any other ls-remote failure is real.
+            git ls-remote --exit-code --heads origin "refs/heads/${branch}" >/dev/null 2>&1 || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "::notice::PR #${PR_NUMBER} will be backported to ${branch}."
+              existing="${existing}${branch} "
+            elif [ "$rc" -eq 2 ]; then
+              echo "::notice::Target branch '${branch}' does not exist yet (maintenance branches are cut lazily); skipping backport for it."
+            else
+              echo "::error::git ls-remote failed while checking '${branch}' (exit ${rc}); cannot safely proceed."
+              exit "$rc"
+            fi
+          done < <(jq -r '.[]' <<< "$LABELS_JSON")
+
+          # Trailing space stripped; empty stays empty and disables the next step.
+          echo "existing=${existing% }" >> "$GITHUB_OUTPUT"
+
+      - name: Open cherry-pick PRs
+        id: backport
+        if: steps.select.outputs.existing != ''
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
+        with:
+          # Disabled: targets were resolved (and filtered for existence) above.
+          # Passing `target_branches` directly keeps lazy-cut branches from
+          # reading as hard failures inside the action.
+          label_pattern: ''
+          target_branches: ${{ steps.select.outputs.existing }}
+          # On conflict, still open a draft PR holding the first conflict and
+          # post resolution instructions on the source PR, instead of failing.
+          experimental: |
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -91,6 +91,9 @@ jobs:
 
           # Only `backport release/vX.Y` (two numeric components) selects a
           # target; near-misses get a pointed warning so typos surface.
+          # Legacy maintenance branches named with three components
+          # (release/v1.0.0-era naming) never match here — rename them to
+          # the ADR 011 scheme rather than widening this pattern.
           PATTERN='^backport[[:space:]](release/v[0-9]+\.[0-9]+)$'
 
           existing=""
@@ -111,7 +114,7 @@ jobs:
               echo "::notice::PR #${PR_NUMBER} will be backported to ${branch}."
               existing="${existing}${branch} "
             elif [ "$rc" -eq 2 ]; then
-              echo "::notice::Target branch '${branch}' does not exist yet (maintenance branches are cut lazily); skipping backport for it."
+              echo "::notice::No branch named '${branch}' exists (maintenance branches are cut lazily, so absence is normal). If you meant a legacy three-component branch (e.g. release/v1.0.0), rename it to the release/vX.Y scheme first."
             else
               echo "::error::git ls-remote failed while checking '${branch}' (exit ${rc}); cannot safely proceed."
               exit "$rc"
@@ -128,7 +131,10 @@ jobs:
         with:
           # Disabled: targets were resolved (and filtered for existence) above.
           # Passing `target_branches` directly keeps lazy-cut branches from
-          # reading as hard failures inside the action.
+          # reading as hard failures inside the action. Verified against the
+          # pinned SHA: main.ts maps an empty input to `undefined`, and
+          # findTargetBranchesFromLabels returns [] for that — label scanning
+          # is fully off, not "matches everything".
           label_pattern: ''
           target_branches: ${{ steps.select.outputs.existing }}
           # On conflict, still open a draft PR holding the first conflict and

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,7 +40,11 @@ name: Backport
 #   action treats a missing target branch as a hard failure, while our
 #   maintenance branches are cut lazily, so we pre-compute the target list
 #   ourselves (skipping absent branches with a notice) and pass it via
-#   `target_branches` with `label_pattern` disabled.
+#   `target_branches` with `label_pattern` disabled. The disable uses '^$'
+#   (matches nothing — GitHub forbids empty label names) rather than the
+#   empty string, so no upstream change could silently reinterpret '' as a
+#   match-everything regex and turn arbitrary labels into cherry-pick
+#   targets.
 #
 # Runs on pull_request_target so GITHUB_TOKEN holds write access even when
 # the merged PR came from a fork. Only pinned actions plus a read-only
@@ -89,11 +93,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Only `backport release/vX.Y` (two numeric components) selects a
-          # target; near-misses get a pointed warning so typos surface.
-          # Legacy maintenance branches named with three components
-          # (release/v1.0.0-era naming) never match here — rename them to
-          # the ADR 011 scheme rather than widening this pattern.
+          # Only `backport release/vX.Y` (two numeric components, the ADR 011
+          # scheme) selects a target; near-misses get a pointed warning so
+          # typos surface.
           PATTERN='^backport[[:space:]](release/v[0-9]+\.[0-9]+)$'
 
           existing=""
@@ -114,7 +116,7 @@ jobs:
               echo "::notice::PR #${PR_NUMBER} will be backported to ${branch}."
               existing="${existing}${branch} "
             elif [ "$rc" -eq 2 ]; then
-              echo "::notice::No branch named '${branch}' exists (maintenance branches are cut lazily, so absence is normal). If you meant a legacy three-component branch (e.g. release/v1.0.0), rename it to the release/vX.Y scheme first."
+              echo "::notice::No branch named '${branch}' exists (maintenance branches are cut lazily, so absence is normal — cut it per ADR 011 rule 4 and re-add the label)."
             else
               echo "::error::git ls-remote failed while checking '${branch}' (exit ${rc}); cannot safely proceed."
               exit "$rc"
@@ -135,7 +137,7 @@ jobs:
           # pinned SHA: main.ts maps an empty input to `undefined`, and
           # findTargetBranchesFromLabels returns [] for that — label scanning
           # is fully off, not "matches everything".
-          label_pattern: ''
+          label_pattern: '^$' # matches nothing; see implementation-choice note above
           target_branches: ${{ steps.select.outputs.existing }}
           # On conflict, still open a draft PR holding the first conflict and
           # post resolution instructions on the source PR, instead of failing.

--- a/.github/workflows/maintenance-label.yml
+++ b/.github/workflows/maintenance-label.yml
@@ -1,0 +1,59 @@
+name: Maintenance label sync
+
+# When a maintenance branch is cut lazily (ADR 011 rule 2), its companion
+# backport label must exist before the first PR can be labeled for it —
+# otherwise the Backport workflow's label probe silently finds nothing.
+# This provisions the label the moment the branch appears, so cutting
+# `release/vX.Y` is sufficient to make `backport release/vX.Y` usable.
+#
+# Labels are mutable repo settings with no declarative file form, so this
+# is inherently an API call from CI; it stays idempotent and scoped to
+# exactly one well-formed branch name per run.
+
+on:
+  create
+
+permissions: {}
+
+jobs:
+  ensure-backport-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # labels live under the Issues API
+    if: >-
+      github.event.ref_type == 'branch' &&
+      startsWith(github.event.ref, 'release/v')
+    steps:
+      - name: Ensure backport label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.ref }}
+        run: |
+          set -euo pipefail
+
+          # Only well-formed maintenance line names (release/vX.Y, two numeric
+          # components — same shape the Backport workflow's pattern expects)
+          # get a label; anything else under release/ is ignored.
+          LABEL="backport ${BRANCH#release/v}"
+          if [[ ! "$LABEL" =~ ^backport\ release/v[0-9]+\.[0-9]+$ ]]; then
+            echo "::notice::'${BRANCH}' is not a release/vX.Y maintenance line; no label provisioned."
+            exit 0
+          fi
+
+          # Idempotent create: "already exists" is success here (e.g. a branch
+          # re-created after deletion); any OTHER failure aborts loudly rather
+          # than leaving the branch without its label.
+          if ! gh label create "$LABEL" \
+              --repo "$REPO" \
+              --color "76A5E8" \
+              --description "Cherry-pick merged changes into ${BRANCH}" ; then
+            if gh label view "$LABEL" --repo "$REPO" >/dev/null 2>&1; then
+              echo "Label '${LABEL}' already exists; continuing."
+            else
+              echo "::error::Failed to create the '${LABEL}' label."
+              exit 1
+            fi
+          fi
+
+          echo "::notice::Label '${LABEL}' is available for backport targeting."

--- a/.github/workflows/maintenance-label.yml
+++ b/.github/workflows/maintenance-label.yml
@@ -34,8 +34,9 @@ jobs:
 
           # Only well-formed maintenance line names (release/vX.Y, two numeric
           # components — same shape the Backport workflow's pattern expects)
-          # get a label; anything else under release/ is ignored.
-          LABEL="backport ${BRANCH#release/v}"
+          # get a label; anything else under release/ is ignored. Keep the
+          # literal 'release/' segment when deriving: strip only 'release/'.
+          LABEL="backport release/${BRANCH#release/}"
           if [[ ! "$LABEL" =~ ^backport\ release/v[0-9]+\.[0-9]+$ ]]; then
             echo "::notice::'${BRANCH}' is not a release/vX.Y maintenance line; no label provisioned."
             exit 0

--- a/.github/workflows/maintenance-label.yml
+++ b/.github/workflows/maintenance-label.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
           # Idempotent create: "already exists" is success here (e.g. a branch
-          # re-created after deletion); any OTHER failure aborts loudly rather
+          # re-created after deletion); any other failure aborts loudly rather
           # than leaving the branch without its label.
           if ! gh label create "$LABEL" \
               --repo "$REPO" \


### PR DESCRIPTION
## What & why

Implements label-triggered backport automation (ADR 011 rule 3): merging a PR to `main` labeled `backport release/vX.Y` opens cherry-pick PR(s) against the matching maintenance branch(es).

- Uses `korthout/backport-action` (SHA-pinned v4.6.0) for multi-label fan-out, `-x` cherry-picks, and conflict UX (`draft_commit_conflicts`: conflicts become draft PRs holding the first conflict, plus a comment on the source PR — never a silent no-op).
- A pre-filter script step resolves labels to *existing* branches via `git ls-remote`, so lazily-cut lines that don't exist yet are skipped with a `::notice::` instead of failing the job.
- Least privilege: top-level `permissions: {}`, job-level `contents: write` + `pull-requests: write`.
- Header comments document the label convention and its manual-fallback period until this lands.

Closes #656. Companion to #660 (ADR 011 + contributor playbook).

## Type of change

- [x] `chore` — CI, tooling, dependencies, or other non-release work

## Checklist

- N/A `gofmt`, `golangci-lint`, `go test`, unit tests — workflow-only change, no Go code touched
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)
- [x] `website/` intentionally not updated here — behavior is documented by the playbook in #660


## Update: label provisioning

Cutting a maintenance branch no longer requires hand-creating its `backport release/vX.Y` label first: a `create`-event workflow (`maintenance-label.yml`) provisions the label idempotently the moment a well-formed `release/vX.Y` branch appears, closing the gap where a missing label made the Backport workflow silently no-op.
