### PR TITLE
chore(ci): extend branch protection coverage to release/v* lines

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -11,6 +11,10 @@ on:
       - unlabeled
     branches:
       - main
+      # Maintenance lines get the same PR hygiene as main (#658); the
+      # ruleset-level protections they also need are admin settings — see
+      # docs/release-branch-protection.md for the manual runbook.
+      - "release/**"
 
 permissions: {}
 
@@ -20,9 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Automated branches (release-please, dependabot) don't follow the
-    # human-authored <type>/<kebab-description> convention, so they're exempt.
-    if: ${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.head_ref, 'dependabot/') }}
+    # Automated branches (release-please, dependabot, backports) don't follow
+    # the human-authored <type>/<kebab-description> convention, so they're
+    # exempt.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'backport/') }}
     steps:
       - name: Validate branch name matches <type>/<kebab-description>
         env:

--- a/docs/release-branch-protection.md
+++ b/docs/release-branch-protection.md
@@ -1,0 +1,53 @@
+# Release branch protection runbook
+
+Workflow-level hygiene for `release/v*` PRs is enforced in-repo
+(`.github/workflows/branch-policy.yml` now targets `release/**` too), but
+the hard guarantees — no direct pushes, required reviews, protected history —
+are repository rulesets, which are admin settings outside Actions. This
+runbook captures the exact setup so it survives maintainer turnover
+(#658, ADR 011 rule 3).
+
+## One-time ruleset setup (admin: Settings → Rules → Rulesets)
+
+Create a ruleset named `maintenance-lines`:
+
+| Setting | Value |
+| --- | --- |
+| Targets | Branches matching pattern `release/v*` |
+| Bypass actors | Repository admin (emergency use only) |
+| Require pull request before merging | On |
+| Required approvals | Match whatever `main` requires today |
+| Dismiss stale reviews on new commits | Match `main` |
+| Require status checks to pass | On (see below) |
+| Require branches to be up to date | Match `main` |
+| Require linear history | On |
+| Block force pushes | On |
+| Block deletions | On |
+
+### Required status checks
+
+Do not hand-enumerate check names at ruleset-creation time — a fresh
+`release/vX.Y` branch has no runs yet, and GitHub only offers checks that
+have already reported on the branch. Instead:
+
+1. Cut the branch and open one throwaway PR against it.
+2. Let `ci.yml`, `branch-policy.yml`, and `pr.yml` report once.
+3. Edit the ruleset and require the checks that appeared:
+   the two Branch Policy checks ("Check Branch Name", "Check Linked Issue"),
+   "Validate PR Title", and the CI test/lint jobs relevant to Go changes.
+
+## What workflows already cover (no admin action needed)
+
+- `branch-policy.yml`: branch naming (`backport/…` heads are exempt as
+  automation) and linked-issue checks now run on `release/**` PRs.
+- `pr.yml`: PR title lint already targeted `main` and `release/**`.
+- `ci.yml`: build/test/lint run for any PR touching Go paths, regardless of
+  base branch; pushes to `release/**` were already covered.
+- `labeler.yml` / `CODEOWNERS`: path-based and base-agnostic; no changes
+  were required (#658 audit result).
+
+## Known gap
+
+Direct pushes to `release/v*` bypass PR-event workflows entirely (nothing
+runs, nothing posts) until the ruleset above blocks them. Apply the ruleset
+**before** cutting the first maintenance branch — ADR 011 rule 3 assumes it.


### PR DESCRIPTION
## What & why

Extends branch protection coverage to `release/v*` maintenance lines (ADR 011 rule 3), per the #658 audit:

- `.github/workflows/branch-policy.yml` now targets `release/**` PRs in addition to `main`, so branch naming ("Check Branch Name") and linked-issue hygiene ("Check Linked Issue") apply on maintenance-line PRs too. `backport/…` head branches are exempt as automation, matching how release-please and dependabot heads are treated.
- Audited `ci.yml`, `pr.yml`, `labeler.yml`, `CODEOWNERS`: `pr.yml` already targets `main` + `release/**`; `ci.yml` runs path-filtered for any base; labeler/CODEOWNERS are path-based and base-agnostic — no changes needed there.
- The hard guarantees (no direct pushes, required reviews/status checks, linear history) live in GitHub rulesets, which are admin settings outside Actions. New `docs/release-branch-protection.md` captures the exact ruleset setup, the check-name bootstrap procedure, and the ordering constraint: **apply the ruleset before cutting the first maintenance branch**.

Closes #658. Companion to #660 (ADR 011 + contributor playbook).

## Type of change

- [x] `chore` — CI, tooling, dependencies, or other non-release work

## Checklist

- N/A `gofmt`, `golangci-lint`, `go test`, unit tests — workflow/docs-only change, no Go code touched
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)
- [x] `website/` intentionally not updated — the runbook is an internal engineering doc under `docs/`
