### PR TITLE
chore(ci): add release-please job scoped to release/v* maintenance branches

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -9,13 +9,23 @@ name: Stable Release
 #                      config bookkeeping nor the manifest state can ever
 #                      collide with main's during cross-line merges.
 #
-# Cutting a maintenance line:
+# Cutting a maintenance line (bootstrap needs one PR because the ruleset
+# from #658 blocks direct pushes to release/v*):
 #   1. git branch release/v2.4 v2.4.5 && git push origin release/v2.4
-#   2. On that branch, commit .release-please-manifest.release.json seeded
-#      with the line's last released version (for example {"." : "2.4.5"}) —
+#      -> the push fires this workflow once; without a seeded manifest the
+#         maintenance job skips cleanly with a notice (no red run).
+#   2. Open a PR against the new branch adding
+#      .release-please-manifest.release.json seeded with the line's last
+#      released version (for example {"." : "2.4.5"}) and merge it.
 #      release-please computes the next tag from that seeded baseline, never
 #      from main's manifest, which is what keeps vX.Y.Z tags landing on the
 #      right branch.
+#
+# Tag namespace: both configs emit plain vX.Y.Z tags, so cut a line only
+# after main has moved past that line's major (ADR 011 rule 1); until v3
+# tags its first stable, a main fix and a same-version maintenance bump
+# could otherwise race for the identical tag name.
+#
 # Rehearsal before the first real v2.x drop: repeat steps 1-2 on a scratch
 # branch (for example release/v2.4-dryrun), push a throwaway `fix:` commit,
 # confirm the opened release PR and tag target, close it, delete the scratch
@@ -58,7 +68,20 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # A freshly cut line has no manifest until its bootstrap PR merges, and
+      # the branch push itself fires this workflow — skip cleanly instead of
+      # failing on the missing file.
+      - name: Check seeded manifest
+        id: manifest
+        run: |
+          if [ -f .release-please-manifest.release.json ]; then
+            echo "seeded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No .release-please-manifest.release.json on this line yet; open the bootstrap PR described in this workflow's header, merge it, and the next push releases normally."
+          fi
+
       - name: Create maintenance release
+        if: steps.manifest.outputs.seeded == 'true'
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -63,6 +63,7 @@ jobs:
   # feat: -> minor (vX.Y+1.0), fix:/perf: -> patch, all else -> no release.
   release-please-maintenance:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: startsWith(github.ref, 'refs/heads/release/v')
     permissions:
       contents: write

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -12,13 +12,14 @@ name: Stable Release
 # Cutting a maintenance line:
 #   1. git branch release/v2.4 v2.4.5 && git push origin release/v2.4
 #   2. On that branch, commit .release-please-manifest.release.json seeded
-#      with the line's last released version, e.g. {"." : "2.4.5"} —
-#      release-please computes the next tag from THIS baseline, never from
-#      main's manifest, which is what keeps vX.Y.Z tags landing on the right
-#      branch.
+#      with the line's last released version (for example {"." : "2.4.5"}) —
+#      release-please computes the next tag from that seeded baseline, never
+#      from main's manifest, which is what keeps vX.Y.Z tags landing on the
+#      right branch.
 # Rehearsal before the first real v2.x drop: repeat steps 1-2 on a scratch
-# branch (e.g. release/v2.4-dryrun), push a throwaway `fix:` commit, confirm
-# the opened release PR and tag target, close it, delete the scratch branch.
+# branch (for example release/v2.4-dryrun), push a throwaway `fix:` commit,
+# confirm the opened release PR and tag target, close it, delete the scratch
+# branch.
 
 on:
   push:
@@ -48,7 +49,7 @@ jobs:
   # release-please no-ops (opens nothing) when a line has no commits since
   # its last tag, so pushing non-release chores to release/* is harmless.
   # Conventional Commits drive bump level exactly as on main:
-  # feat: -> minor (vX.Y+1.0), fix:/perf:/chore-with-footnote -> patch.
+  # feat: -> minor (vX.Y+1.0), fix:/perf: -> patch, all else -> no release.
   release-please-maintenance:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/release/v')

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -69,6 +69,13 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # The manifest check inspects files, and runners start with an empty
+      # workspace, so the pushed ref must be checked out before the guard.
+      - name: Check out the pushed ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
       # A freshly cut line has no manifest until its bootstrap PR merges, and
       # the branch push itself fires this workflow — skip cleanly instead of
       # failing on the missing file.
@@ -88,3 +95,6 @@ jobs:
         with:
           config-file: release-please-config.release.json
           manifest-file: .release-please-manifest.release.json
+          # Operate on this maintenance line; without this pin the action
+          # computes releases against the repository's default branch (main).
+          target-branch: ${{ github.ref_name }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -12,13 +12,14 @@ name: Stable Release
 # Cutting a maintenance line:
 #   1. git branch release/v2.4 v2.4.5 && git push origin release/v2.4
 #   2. On that branch, commit .release-please-manifest.release.json seeded
-#      with the line's last released version, e.g. {"." : "2.4.5"} —
-#      release-please computes the next tag from THIS baseline, never from
-#      main's manifest, which is what keeps vX.Y.Z tags landing on the right
-#      branch.
+#      with the line's last released version (for example {"." : "2.4.5"}) —
+#      release-please computes the next tag from that seeded baseline, never
+#      from main's manifest, which is what keeps vX.Y.Z tags landing on the
+#      right branch.
 # Rehearsal before the first real v2.x drop: repeat steps 1-2 on a scratch
-# branch (e.g. release/v2.4-dryrun), push a throwaway `fix:` commit, confirm
-# the opened release PR and tag target, close it, delete the scratch branch.
+# branch (for example release/v2.4-dryrun), push a throwaway `fix:` commit,
+# confirm the opened release PR and tag target, close it, delete the scratch
+# branch.
 
 on:
   push:
@@ -49,7 +50,7 @@ jobs:
   # release-please no-ops (opens nothing) when a line has no commits since
   # its last tag, so pushing non-release chores to release/* is harmless.
   # Conventional Commits drive bump level exactly as on main:
-  # feat: -> minor (vX.Y+1.0), fix:/perf:/chore-with-footnote -> patch.
+  # feat: -> minor (vX.Y+1.0), fix:/perf: -> patch, all else -> no release.
   release-please-maintenance:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/release/v')

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,15 +1,38 @@
 name: Stable Release
 
+# Releases are produced per-branch (#659 / ADR 011):
+#   * main          -> next-major line, driven by release-please-config.json
+#                      and the default .release-please-manifest.json.
+#   * release/vX.Y  -> maintenance lines (ADR 011 rule 6), driven by
+#                      release-please-config.release.json and their own
+#                      .release-please-manifest.release.json so neither the
+#                      config bookkeeping nor the manifest state can ever
+#                      collide with main's during cross-line merges.
+#
+# Cutting a maintenance line:
+#   1. git branch release/v2.4 v2.4.5 && git push origin release/v2.4
+#   2. On that branch, commit .release-please-manifest.release.json seeded
+#      with the line's last released version, e.g. {"." : "2.4.5"} —
+#      release-please computes the next tag from THIS baseline, never from
+#      main's manifest, which is what keeps vX.Y.Z tags landing on the right
+#      branch.
+# Rehearsal before the first real v2.x drop: repeat steps 1-2 on a scratch
+# branch (e.g. release/v2.4-dryrun), push a throwaway `fix:` commit, confirm
+# the opened release PR and tag target, close it, delete the scratch branch.
+
 on:
   push:
     branches:
       - main
+      - "release/v*"
 
 permissions: {}
 
 jobs:
+  # Next-major line: unchanged behavior, now explicitly scoped to main.
   release-please:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
       issues: write
@@ -20,3 +43,23 @@ jobs:
         id: release
         with:
           config-file: release-please-config.json
+
+  # Maintenance lines: same action, alternate config + isolated manifest.
+  # release-please no-ops (opens nothing) when a line has no commits since
+  # its last tag, so pushing non-release chores to release/* is harmless.
+  # Conventional Commits drive bump level exactly as on main:
+  # feat: -> minor (vX.Y+1.0), fix:/perf:/chore-with-footnote -> patch.
+  release-please-maintenance:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/release/v')
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Create maintenance release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        id: release
+        with:
+          config-file: release-please-config.release.json
+          manifest-file: .release-please-manifest.release.json

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -9,13 +9,23 @@ name: Stable Release
 #                      config bookkeeping nor the manifest state can ever
 #                      collide with main's during cross-line merges.
 #
-# Cutting a maintenance line:
+# Cutting a maintenance line (bootstrap needs one PR because the ruleset
+# from #658 blocks direct pushes to release/v*):
 #   1. git branch release/v2.4 v2.4.5 && git push origin release/v2.4
-#   2. On that branch, commit .release-please-manifest.release.json seeded
-#      with the line's last released version (for example {"." : "2.4.5"}) —
+#      -> the push fires this workflow once; without a seeded manifest the
+#         maintenance job skips cleanly with a notice (no red run).
+#   2. Open a PR against the new branch adding
+#      .release-please-manifest.release.json seeded with the line's last
+#      released version (for example {"." : "2.4.5"}) and merge it.
 #      release-please computes the next tag from that seeded baseline, never
 #      from main's manifest, which is what keeps vX.Y.Z tags landing on the
 #      right branch.
+#
+# Tag namespace: both configs emit plain vX.Y.Z tags, so cut a line only
+# after main has moved past that line's major (ADR 011 rule 1); until v3
+# tags its first stable, a main fix and a same-version maintenance bump
+# could otherwise race for the identical tag name.
+#
 # Rehearsal before the first real v2.x drop: repeat steps 1-2 on a scratch
 # branch (for example release/v2.4-dryrun), push a throwaway `fix:` commit,
 # confirm the opened release PR and tag target, close it, delete the scratch
@@ -59,7 +69,20 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # A freshly cut line has no manifest until its bootstrap PR merges, and
+      # the branch push itself fires this workflow — skip cleanly instead of
+      # failing on the missing file.
+      - name: Check seeded manifest
+        id: manifest
+        run: |
+          if [ -f .release-please-manifest.release.json ]; then
+            echo "seeded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No .release-please-manifest.release.json on this line yet; open the bootstrap PR described in this workflow's header, merge it, and the next push releases normally."
+          fi
+
       - name: Create maintenance release
+        if: steps.manifest.outputs.seeded == 'true'
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,16 +1,39 @@
 name: Stable Release
 
+# Releases are produced per-branch (#659 / ADR 011):
+#   * main          -> next-major line, driven by release-please-config.json
+#                      and the default .release-please-manifest.json.
+#   * release/vX.Y  -> maintenance lines (ADR 011 rule 6), driven by
+#                      release-please-config.release.json and their own
+#                      .release-please-manifest.release.json so neither the
+#                      config bookkeeping nor the manifest state can ever
+#                      collide with main's during cross-line merges.
+#
+# Cutting a maintenance line:
+#   1. git branch release/v2.4 v2.4.5 && git push origin release/v2.4
+#   2. On that branch, commit .release-please-manifest.release.json seeded
+#      with the line's last released version, e.g. {"." : "2.4.5"} —
+#      release-please computes the next tag from THIS baseline, never from
+#      main's manifest, which is what keeps vX.Y.Z tags landing on the right
+#      branch.
+# Rehearsal before the first real v2.x drop: repeat steps 1-2 on a scratch
+# branch (e.g. release/v2.4-dryrun), push a throwaway `fix:` commit, confirm
+# the opened release PR and tag target, close it, delete the scratch branch.
+
 on:
   push:
     branches:
       - main
+      - "release/v*"
 
 permissions: {}
 
 jobs:
+  # Next-major line: unchanged behavior, now explicitly scoped to main.
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
       issues: write
@@ -21,3 +44,23 @@ jobs:
         id: release
         with:
           config-file: release-please-config.json
+
+  # Maintenance lines: same action, alternate config + isolated manifest.
+  # release-please no-ops (opens nothing) when a line has no commits since
+  # its last tag, so pushing non-release chores to release/* is harmless.
+  # Conventional Commits drive bump level exactly as on main:
+  # feat: -> minor (vX.Y+1.0), fix:/perf:/chore-with-footnote -> patch.
+  release-please-maintenance:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/release/v')
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Create maintenance release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        id: release
+        with:
+          config-file: release-please-config.release.json
+          manifest-file: .release-please-manifest.release.json

--- a/.github/workflows/stamp-deprecations.yml
+++ b/.github/workflows/stamp-deprecations.yml
@@ -11,6 +11,10 @@ name: Stamp Deprecated Notices
 #   the branch (wiping any prior stamp) -> synchronize fires -> re-stamp.
 # - Our own stamp push -> synchronize fires -> clean diff -> no-op.
 #
+# Maintenance release PRs (release/v* targets) get the same stamping so
+# {unreleased} never ships in a tagged maintenance line. Base-branch caveat:
+# GitHub evaluates this file from the PR's base ref, so lines cut before this
+# filter landed need the updated file synced onto them via PR.
 # Weekly preview releases are intentionally NOT stamped; placeholders survive
 # preview cycles until the next stable release stamps them. Both release flows
 # use the same `release-please--` branch prefix, so the discriminator is the
@@ -24,6 +28,7 @@ on:
       - synchronize
     branches:
       - main
+      - "release/v*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/release-please-config.release.json
+++ b/release-please-config.release.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "go",
+  "separate-pull-requests": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
+  "packages": {
+    ".": {
+      "package-name": "github.com/michaeldcanady/servicenow-sdk-go",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        "VERSION",
+        "version.go"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What & why

Adds a release-please path for maintenance lines so patch/minor releases can be cut from `release/v*` branches without touching main's bookkeeping (ADR 011 rule 6):

- Second job `release-please-maintenance` fires on refs matching `release/v*`, using an alternate config (`release-please-config.release.json`, mirroring main's shape) plus its own manifest file (`.release-please-manifest.release.json`) so neither config bookkeeping nor version state can collide with main's during cross-line merges.
- Conventional Commits drive bump level exactly as on main: `feat:` → minor (`vX.(Y+1).0`), `fix:` → patch. `release-please` no-ops when a line has no commits since its last tag.
- The original job is now explicitly scoped to `main`; trigger list extended to `'release/v*'`.
- Header comments carry the operational runbook inline: seeding the maintenance manifest at branch cut (`{"." : "2.4.5"}` style baseline) and the scratch-branch dry-run procedure to rehearse before the first real v2.x drop.

Closes #659. Companion to #660 (ADR 011 + contributor playbook).

## Type of change

- [x] `chore` — CI, tooling, dependencies, or other non-release work

## Checklist

- N/A `gofmt`, `golangci-lint`, `go test`, unit tests — workflow/config-only change, no Go code touched
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)
- [x] `website/` intentionally not updated here — behavior is documented by the playbook in #660
