### PR TITLE
docs: drop ALL-CAPS emphasis in docs.yml comment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Docs linting is scoped by event type (#661):
-      #   * PRs lint ONLY the markdown files changed relative to the base,
+      #   * PRs lint only the markdown files changed relative to the base,
       #     so pre-existing violations in untouched files can't gate an
       #     unrelated docs change.
       #   * main pushes keep the full-tree scan — that is where whole-repo


### PR DESCRIPTION
## What & why

One-word follow-up to the Google documentation style sweep: lowercase `only` instead of `ONLY` in the docs-lint scoping comment.

Part of the style audit across all release-branch automation work; follow-up to #661 as implemented in #666.

## Type of change

- [x] `chore` — CI, tooling, dependencies, or other non-release work

## Checklist

- N/A code/tests — comment-only change; `actionlint` clean