### PR TITLE
chore(ci): close release-verification gap and harden CI supply chain

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,21 @@
+# Codecov coverage gate. `fail_ci_if_error` in ci.yml only guards the upload
+# itself; these status checks fail the check when coverage regresses.
+# `target: auto` ratchets against the base commit — no hardcoded number to
+# game or maintain; a drop >1% fails the project check, and patch coverage is
+# held to roughly the existing repo level for new code.
+# Note: to actually block merges, make "codecov/project" and "codecov/patch"
+# required status checks in branch protection.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        if_ci_failed: error
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default

--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -22,6 +22,7 @@ jobs:
   branch-name:
     name: Check Branch Name
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     # Automated branches (release-please, dependabot, backports) don't follow
@@ -48,6 +49,7 @@ jobs:
   linked-issue:
     name: Check Linked Issue
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     # Automated PRs (release-please, dependabot) and PRs explicitly labeled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,12 @@ permissions: {}
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--'))
+    # Release-please PRs are no longer exempt: they bump version.go (compiled
+    # code) and must pass the same gates as any other change before a tag is cut.
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     outputs:
       code: ${{ steps.filter.outputs.any_changed }}
     steps:
@@ -58,6 +61,7 @@ jobs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     strategy:
@@ -86,6 +90,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ["stable", "oldstable"]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -109,6 +114,7 @@ jobs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
@@ -139,6 +145,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ["stable", "oldstable"]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -191,6 +198,7 @@ jobs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -215,6 +223,7 @@ jobs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -232,6 +241,7 @@ jobs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ permissions: {}
 jobs:
   changes-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'release-please--'))
@@ -49,6 +50,7 @@ jobs:
   build:
     name: build-site
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     if: ${{ needs.changes-docs.outputs.docs == 'true' }}
@@ -93,6 +95,7 @@ jobs:
   lint:
     name: lint-md
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     if: ${{ needs.changes-docs.outputs.docs == 'true' }}
@@ -144,6 +147,7 @@ jobs:
   deploy:
     name: deploy-docs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # required: pushes built site to gh-pages branch
     needs:
@@ -171,6 +175,7 @@ jobs:
   deploy-preview:
     name: deploy-preview
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write # required: pushes PR preview to gh-pages branch
       pull-requests: write
@@ -218,6 +223,7 @@ jobs:
     if: success() && github.event_name == 'pull_request'
     needs: [build, lint, deploy-preview]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     steps:
@@ -232,6 +238,7 @@ jobs:
     if: failure() && github.event_name == 'pull_request'
     needs: [build, lint, deploy-preview]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
+    # Secrets live in the "e2e-tests" environment; declaring it here makes
+    # them visible to the presence check below.
+    environment: e2e-tests
     outputs:
       has-creds: ${{ steps.check.outputs.has-creds }}
     steps:
@@ -47,6 +50,7 @@ jobs:
     if: needs.check-secret.outputs.has-creds == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    environment: e2e-tests
     permissions:
       contents: read
     env:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,85 @@
+name: E2E Nightly
+
+# Runs the -tags e2e suite against a REAL ServiceNow instance so API drift is
+# caught by CI instead of by users. Requires repo secrets SN_INSTANCE,
+# SN_USERNAME, SN_PASSWORD (a sandbox tenant; use least-privilege creds).
+# Forks / repos without those secrets skip gracefully via the check-secret job.
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly at 04:00 UTC — after the Monday preview-release window.
+    - cron: "0 4 * * *"
+
+permissions: {}
+
+concurrency:
+  group: e2e-nightly
+  cancel-in-progress: false
+
+env:
+  GO_TEST_TIMEOUT: 40m
+
+jobs:
+  check-secret:
+    name: Check Credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      has-creds: ${{ steps.check.outputs.has-creds }}
+    steps:
+      - id: check
+        env:
+          HAS_INSTANCE: ${{ secrets.SN_INSTANCE != '' }}
+          HAS_USER: ${{ secrets.SN_USERNAME != '' }}
+          HAS_PASS: ${{ secrets.SN_PASSWORD != '' }}
+        run: |
+          if [ "$HAS_INSTANCE" = "true" ] && [ "$HAS_USER" = "true" ] && [ "$HAS_PASS" = "true" ]; then
+            echo "has-creds=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-creds=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SN_INSTANCE/SN_USERNAME/SN_PASSWORD secrets are not set; skipping E2E run."
+          fi
+
+  e2e:
+    name: Live Instance Tests
+    needs: check-secret
+    if: needs.check-secret.outputs.has-creds == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      SN_INSTANCE: ${{ secrets.SN_INSTANCE }}
+      SN_USERNAME: ${{ secrets.SN_USERNAME }}
+      SN_PASSWORD: ${{ secrets.SN_PASSWORD }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "stable"
+          cache: true
+
+      - name: Run E2E suites
+        working-directory: tests/integration/v2
+        run: go test -tags e2e ./... -timeout "$GO_TEST_TIMEOUT" -v 2>&1 | tee e2e-output.txt
+
+      - name: Summarize failures
+        if: failure()
+        run: |
+          {
+            echo "### E2E Nightly failed"
+            echo ""
+            echo '```'
+            grep -E "^(=== RUN|--- FAIL|FAIL|ok )" e2e-output.txt | tail -50 || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-output
+          path: tests/integration/v2/e2e-output.txt
+          retention-days: 7

--- a/.github/workflows/issue-status-sync.yml
+++ b/.github/workflows/issue-status-sync.yml
@@ -15,9 +15,7 @@ on:
   pull_request_target:
     types: [opened, reopened, closed]
 
-permissions:
-  issues: write
-  pull-requests: read
+permissions: {}
 
 concurrency:
   group: issue-status-sync-${{ github.event.pull_request.number }}
@@ -27,10 +25,14 @@ jobs:
   sync:
     name: Sync Issue Status
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - name: Get linked issues
         id: linked
-        uses: mondeja/pr-linked-issues-action@v2
+        uses: mondeja/pr-linked-issues-action@15e15b5aa999ae8a742117c9489aa63b1a007b76 # v2.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,7 @@ jobs:
   label:
     name: Apply Path Labels
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -51,9 +51,11 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
-      issues: write
+      # PR review comments only need pull-requests: write; issues: write was
+      # dropped to shrink what a compromised/prompt-injected run can touch.
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ jobs:
   lint-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
       contents: read
@@ -61,6 +62,7 @@ jobs:
 
   dependabot-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       contents: write # required: gh pr merge --auto needs write to enable auto-merge

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,55 @@
+name: Release Verify
+
+# Tripwire for the release path: runs the full quality gate against the exact
+# tagged ref after a tag is pushed. Release PRs already run CI pre-merge (see
+# ci.yml `changes` job); this catches anything that slips through via direct
+# pushes or automation bugs. It cannot undo a published tag, so failures here
+# page a human to yank/patch the release immediately.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
+
+concurrency:
+  group: release-verify-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify Tagged Ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify modules
+        run: |
+          go mod download
+          go mod verify
+          go mod tidy
+          git diff --exit-code -- .
+
+      - name: Build
+        run: |
+          PACKAGES=$(go list ./... | grep -v "/docs")
+          go build $PACKAGES
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        with:
+          install-mode: goinstall
+          version: v2.13.0
+          skip-cache: false
+          args: --timeout=5m
+
+      - name: Unit tests
+        run: go test ./...

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ jobs:
   analysis:
     name: Scorecard Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       # Needed for Code scanning upload
       security-events: write

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -10,7 +10,7 @@ name: Sync Project Status
 
 on:
   schedule:
-    - cron: '*/15 * * * *'  # every 15 minutes
+    - cron: '0 * * * *'  # hourly (was every 15 min; a PAT-bearing cron should not run that hot)
   workflow_dispatch:
     inputs:
       apply:
@@ -18,23 +18,32 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
 jobs:
   check-secret:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     outputs:
       has-token: ${{ steps.check.outputs.has-token }}
     steps:
       - id: check
-        run: echo "has-token=${{ secrets.PROJECT_PAT != '' }}" >> $GITHUB_OUTPUT
+        env:
+          HAS_TOKEN: ${{ secrets.PROJECT_PAT != '' }}
+        run: echo "has-token=$HAS_TOKEN" >> "$GITHUB_OUTPUT"
 
   sync:
     needs: check-secret
     if: needs.check-secret.outputs.has-token == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dvhthomas/project-label-sync@v0.1.2
+      - uses: dvhthomas/project-label-sync@3717399ea3afad24da809603d1006148dbf94688 # v0.1.2
         with:
           token: ${{ secrets.PROJECT_PAT }}
           apply: ${{ github.event.inputs.apply || 'false' }}


### PR DESCRIPTION
## What & why

Findings from a CI/CD audit of `.github/workflows`; each change maps to one finding:

1. **Release path had no verification gate.** Release-please PRs were exempt from CI yet bump `version.go` (compiled code), and tag creation ran zero checks.
   - `ci.yml`: release-please branches no longer excluded from the `changes` job — release PRs get full CI pre-merge.
   - New `release-verify.yml`: re-runs mod-verify/build/lint/unit tests against the exact tagged ref on `v*` push as a post-tag tripwire.
2. **Supply-chain pinning was inconsistent where blast radius was largest.**
   - `issue-status-sync.yml`: `mondeja/pr-linked-issues-action@v2` → SHA-pinned to v2.2.2 (`15e15b5a`).
   - `sync-project-status.yml`: `actions/checkout@v4` → repo-standard pinned SHA; `dvhthomas/project-label-sync@v0.1.2` → SHA-pinned (`3717399e`); PAT-bearing cron reduced 15 min → hourly; added top-level `permissions: {}` + least-privilege job grants; secret-presence check moved to env-var pattern.
3. **E2E suite existed but was unreachable from CI** — integration tier is httpmock-only, so API drift went undetected.
   - New `e2e-nightly.yml`: nightly `-tags e2e` run against a live instance via `SN_INSTANCE`/`SN_USERNAME`/`SN_PASSWORD` secrets; secret-gated so forks skip cleanly; failure summary + artifact.
4. **AI reviewer job carried more permission than it needed.**
   - `opencode-review.yml`: dropped `issues: write` (PR comments need only `pull-requests: write`), added timeout.
5. **Operational hygiene.**
   - `timeout-minutes` on every job in all workflows (previously almost none; runaway jobs could burn hours).
   - New `.codecov.yml`: project coverage ratchet (`target: auto`, 1% threshold) + patch gate — `fail_ci_if_error` previously guarded only the upload.

### Required manual follow-ups (repo settings, not code)
- Make `codecov/project` + `codecov/patch` required status checks in branch protection for the ratchet to block merges.
- Configure `SN_INSTANCE`/`SN_USERNAME`/`SN_PASSWORD` sandbox secrets, or e2e-nightly stays skipped.

## Type of change

- [ ] `feat` — new or changed exported API surface
- [ ] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [x] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

- [x] `gofmt -s -w .` and `golangci-lint run ./...` pass (no Go changes)
- [x] `go test ./...` passes (no Go changes)
- [x] New or changed exported surface has unit tests (none — workflows only)
- [x] `website/` is updated — N/A: CI-only change
- [x] Code samples use region markers — N/A
- [x] `VERSION` and `CHANGELOG.md` are untouched
Fixes #635
