### PR TITLE
fix(ci): propagate go test exit code through tee in e2e-nightly

### DIFF
--- a/.claude/agents/docs-gitgraph-converter.md
+++ b/.claude/agents/docs-gitgraph-converter.md
@@ -1,0 +1,72 @@
+---
+name: docs-gitgraph-converter
+description: Converts ASCII-art git/branch/workflow diagrams in the ServiceNow SDK's docs site (website/docs/**) into Docusaurus-rendered Mermaid diagrams — gitGraph for branch/flow diagrams, flowchart for pipelines. Use whenever asked to add, fix, or modernize a diagram in website/docs, proactively after writing a multi-line ASCII diagram into any docs page, or when a reviewer flags ASCII art in a docs PR.
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You are converting hand-drawn ASCII diagrams in the ServiceNow Go SDK's
+documentation site (`website/docs/**`) into Mermaid diagrams that Docusaurus
+renders natively. The site already enables Mermaid
+(`website/docusaurus.config.ts` sets `mermaid: true` under markdown options
+and loads `@docusaurus/theme-mermaid`), so any fenced block whose language is
+exactly ```` ```mermaid ```` renders — you never need to touch the config.
+
+## Why this matters here
+
+This repo's docs are reviewed hard for clarity. A diagram that can be read
+against its adjacent prose is worse than no diagram (PR #660's review caught
+an ASCII flow whose arrow label pointed downstream while the rule said fixes
+land upstream-first). Your job is fidelity: the Mermaid output must encode
+the SAME directionality, labels, and caveats as the source material — never
+just prettier shapes.
+
+## How to convert
+
+1. Read the surrounding prose section FIRST and extract the claims the
+   diagram must express. List them before drawing anything.
+2. Pick the diagram type:
+   - Branch/merge/tag flows over time → `gitGraph`
+   - Pipelines, decision trees, component relationships → `flowchart` (or
+     `graph`)
+   - Sequence of calls between actors → `sequenceDiagram`
+3. For `gitGraph`, remember its fixed semantics: the first drawn branch is
+   the trunk; `branch`/`checkout`/`commit`/`merge` statements are sequential;
+   tags via `tag:` on commits; `type: HIGHLIGHT` for emphasis points. Map the
+   prose's direction of change onto commit order so reading top-to-bottom
+   matches the text's causal order.
+4. Always include `accTitle:` and `accDescr:` lines summarizing what the
+   diagram shows — screen readers get nothing else from Mermaid.
+5. Keep node/commit labels short (a few words). Long explanations belong in
+   the prose after the diagram, not crammed into labels.
+6. Replace the ASCII block wholesale; adjust neighboring sentences only where
+   they referenced ASCII-specific wording (e.g. "the diagonal"), keeping the
+   ~80-column wrap style used across `website/docs`.
+7. Fenced Mermaid blocks are invisible to the Vale prose linter, but any
+   prose you edit around them must stay lint-clean (contractions, no "e.g.",
+   punctuation inside quotes).
+
+## Constraints
+
+- Only `.md`/`.mdx` files under `website/docs/` plus, if genuinely required,
+  `website/docusaurus.config.ts`. Never modify SDK Go code or workflows.
+- Do not reflow unrelated sections of the file.
+- If the ASCII diagram encodes something Mermaid cannot express faithfully
+  (e.g. annotations pointing at specific arrows), say so explicitly in your
+  final message rather than silently dropping the nuance — propose the
+  closest encoding and flag the loss.
+
+## Verification
+
+- Confirm the fence language is lowercase `mermaid` and the block is closed.
+- Re-read your diagram against the prose claims list from step 1 and state,
+  claim by claim, how each is encoded.
+- You cannot render Mermaid locally; treat careful syntax checking
+  (balanced statements, valid keywords) as mandatory and note rendering as
+  unverified in your report.
+
+## Output
+
+Report: file(s) changed, the claims list and how each maps into the diagram,
+any expressive fidelity lost, and the exact commit made (message + sha).
+Commit with Conventional Commits style (`docs(contributing): ...`) and never
+push unless explicitly instructed by the orchestrator.

--- a/.claude/agents/docs-gitgraph-converter.md
+++ b/.claude/agents/docs-gitgraph-converter.md
@@ -13,16 +13,16 @@ exactly ```` ```mermaid ```` renders — you never need to touch the config.
 
 ## Why this matters here
 
-This repo's docs are reviewed hard for clarity. A diagram that can be read
-against its adjacent prose is worse than no diagram (PR #660's review caught
-an ASCII flow whose arrow label pointed downstream while the rule said fixes
+This repo's docs are reviewed hard for clarity. A diagram that contradicts
+its adjacent prose is worse than no diagram (PR #660's review caught an
+ASCII flow whose arrow label pointed downstream while the rule said fixes
 land upstream-first). Your job is fidelity: the Mermaid output must encode
-the SAME directionality, labels, and caveats as the source material — never
-just prettier shapes.
+the **same** directionality, labels, and caveats as the source material —
+never just prettier shapes.
 
 ## How to convert
 
-1. Read the surrounding prose section FIRST and extract the claims the
+1. Read the surrounding prose section first and extract the claims the
    diagram must express. List them before drawing anything.
 2. Pick the diagram type:
    - Branch/merge/tag flows over time → `gitGraph`

--- a/.github/styles/config/vocabularies/Vale/accept.txt
+++ b/.github/styles/config/vocabularies/Vale/accept.txt
@@ -204,3 +204,4 @@ CIs?('s)?
 Godog
 (?i)mockable
 (?i)preconfigured
+(?i)triage(d|s)?

--- a/docs/adr/011-release-branches-and-cross-major-flow.md
+++ b/docs/adr/011-release-branches-and-cross-major-flow.md
@@ -1,0 +1,99 @@
+# ADR 011: Release branches are lazily cut, downstream-only, and never silently diverge
+
+## Status
+
+Accepted
+
+## Context
+
+The v2 launch left `main` (v1) and `release/v2` significantly drifted, because
+new development landed on `release/v2` while `main` stayed on v1. Go's
+semantic-import-versioning module paths make this especially expensive to
+recover from: every touched file carries `/v1` vs `/v2` import suffixes, so
+cross-line merges conflict in nearly every file and effectively become
+rewrites rather than merges. Drift between major lines therefore compounds
+fast and does not heal on its own.
+
+Tooling reinforces the problem today: release-please fires only on `main`
+(`.github/workflows/stable-release.yml`), so there is no supported path for
+patching — or extending — a shipped major once `main` has moved on. That gap
+becomes acute whenever a new ServiceNow API surface ships mid-cycle that
+consumers still pinned to the previous major want *now*, not at the next
+major release.
+
+Alternatives considered:
+
+1. **GitFlow-style per-major development** — develop v2 work directly on
+   `release/v2`, as happened before. Rejected: this *is* the drift incident;
+   the failure mode is structural, not incidental.
+2. **Tags-only, no maintenance branches** — cut an ephemeral branch per
+   patch, tag, delete. Rejected: once more than one patch accumulates,
+   the line needs a durable target for PRs, required CI, and a
+   release-please config; repeated ad-hoc cuts invite inconsistency.
+3. **Preemptive branch per minor (`release/vX.Y.0` at every minor)** —
+   rejected: most minors never receive a patch, and idle long-lived
+   branches are exactly how silent drift happens again.
+
+## Decision
+
+Adopt trunk-first development with lazily-cut, downstream-only maintenance
+branches (maintainer decision, 2026-08-21):
+
+1. **`main` is always the tip of the next major's development.**
+2. **Maintenance branches are named `release/vX.Y`** (no patch segment) and
+   are **created lazily** from the last `vX.Y.*` tag at first need —
+   `git branch release/v2.x v2.4.5 && git push origin release/v2.x`. Tags
+   are immutable, so when the branch is cut is irrelevant; never cut one
+   preemptively.
+3. **Downstream-only within a major:** fixes land on `main` first, then move
+   down via a label-triggered backport action (`backport release/v2.x`
+   opens the cherry-pick PR). Direct pushes to `release/*` are blocked;
+   all changes arrive by PR with required CI.
+4. **Cross-major features** (a new ServiceNow capability arriving while
+   `main` develops the next major):
+   - Useful for both majors and small/portable (typical new API module) —
+     build on `main`, ship in the next major, then open a matching PR
+     against `release/vX.Y`, rewriting the import suffix (`/vN+1` → `/vN`).
+   - Useful for both but touching diverged core — build on `main`; backport
+     only if consumer demand justifies the port cost, otherwise document
+     the change as next-major-only in its PR.
+   - Old-major-only by design (depends on prior-major model shapes) — PR
+     targets `release/vX.Y` directly and ships as a **minor** bump
+     (`feat:` → `vX.(Y+1).0`), but triggers rule 5 below.
+5. **Drift is tracked debt, never silent:** any merge into `release/v*`
+   without backport provenance automatically opens a `needs-forward-port`
+   issue ("assess porting #N to `main`"). It closes only by porting the
+   change up or by recording an explicit "won't port" rationale.
+6. **Releases off maintenance lines are batched and demand-driven**, driven
+   by Conventional Commits through a second release-please configuration
+   scoped to `release/v*` refs. Weekly preview releases remain `main`-only.
+   `VERSION` and `CHANGELOG.md` stay release-please-owned on every branch —
+   never hand-edited.
+7. **EOL policy:** the current major's latest minor receives fixes and
+   features; the prior major receives critical/security fixes only; its
+   `release/*` branch is deleted at EOL with an announcement in the release
+   notes. Forgotten long-lived branches are how the v2 incident happens
+   twice.
+
+Follow-up tooling work implied by this decision: a `stable-release` job
+keyed on `release/v*` refs with an alternate release-please config, the
+backport label action, the forward-port tracker workflow, and
+`branch-policy.yml` updates covering `release/*`.
+
+## Consequences
+
+- **Pros:** drift becomes visible, tracked debt instead of silent
+  divergence; consumers on shipped majors get a predictable path to fixes
+  and selected features; maintenance releases gain real CI, changelogs, and
+  tagging via release-please instead of hand-run tags.
+- **Cons:** cross-major ports stay semi-manual — import-suffix differences
+  conflict in nearly every touched file, so ports must be kept small;
+  two release-please configs and several new workflows add maintenance
+  surface; rules 4–5 depend on reviewer discipline that automation only
+  partially enforces.
+- **Rule for future release questions:** do not create preemptive
+  `release/*` branches, never land feature work on a maintenance branch
+  without completing the forward-port assessment, and do not treat a
+  maintenance branch as a development trunk — if v2-era work starts feeling
+  like active development again, that is the signal to re-evaluate the EOL
+  clock, not to grow the branch.

--- a/docs/adr/011-release-branches-and-cross-major-flow.md
+++ b/docs/adr/011-release-branches-and-cross-major-flow.md
@@ -6,8 +6,8 @@ Accepted
 
 ## Context
 
-The v2 launch left `main` (v1) and `release/v2` significantly drifted, because
-new development landed on `release/v2` while `main` stayed on v1. Go's
+The v2 launch drifted `main` (v1) and `release/v2` apart: new development
+landed on `release/v2` while `main` stayed on v1. Go's
 semantic-import-versioning module paths make this especially expensive to
 recover from: every touched file carries `/v1` vs `/v2` import suffixes, so
 cross-line merges conflict in nearly every file and effectively become
@@ -16,9 +16,9 @@ fast and does not heal on its own.
 
 Tooling reinforces the problem today: release-please fires only on `main`
 (`.github/workflows/stable-release.yml`), so there is no supported path for
-patching — or extending — a shipped major once `main` has moved on. That gap
-becomes acute whenever a new ServiceNow API surface ships mid-cycle that
-consumers still pinned to the previous major want *now*, not at the next
+patching — or extending — a shipped major once `main` moves on. That gap
+becomes acute whenever a new ServiceNow API surface ships mid-cycle and
+consumers pinned to the previous major want it *now*, not at the next
 major release.
 
 Alternatives considered:
@@ -46,9 +46,9 @@ branches (maintainer decision, 2026-08-21):
    are immutable, so when the branch is cut is irrelevant; never cut one
    preemptively.
 3. **Downstream-only within a major:** fixes land on `main` first, then move
-   down via a label-triggered backport action (`backport release/v2.x`
-   opens the cherry-pick PR). Direct pushes to `release/*` are blocked;
-   all changes arrive by PR with required CI.
+   down via a label-triggered backport action (`backport release/vX.Y`
+   opens the cherry-pick PR). Branch protection blocks direct pushes to
+   `release/*`; all changes arrive by PR with required CI.
 4. **Cross-major features** (a new ServiceNow capability arriving while
    `main` develops the next major):
    - Useful for both majors and small/portable (typical new API module) —
@@ -64,18 +64,19 @@ branches (maintainer decision, 2026-08-21):
    without backport provenance automatically opens a `needs-forward-port`
    issue ("assess porting #N to `main`"). It closes only by porting the
    change up or by recording an explicit "won't port" rationale.
-6. **Releases off maintenance lines are batched and demand-driven**, driven
-   by Conventional Commits through a second release-please configuration
-   scoped to `release/v*` refs. Weekly preview releases remain `main`-only.
+6. **Maintenance releases are batched and demand-driven:** Conventional
+   Commits on `release/v*` refs feed a second release-please configuration.
+   Weekly preview releases remain `main`-only.
    `VERSION` and `CHANGELOG.md` stay release-please-owned on every branch —
    never hand-edited.
 7. **EOL policy:** vocabulary — *current* means the highest tagged major,
-   *prior* any tagged major below it. The current major's latest minor
+   *prior* means any tagged major below it. The current major's latest minor
    receives fixes and features until the successor major tags its first
    stable release; from that moment every prior major drops to
-   critical/security fixes only. Its `release/*` branch is deleted at EOL
-   with an announcement in the release notes. Forgotten long-lived branches
-   are how the v2 incident happens twice.
+   critical/security fixes only. Maintainers delete the prior major's
+   `release/*` branch at EOL and announce the retirement in the release
+   notes. Forgotten long-lived branches are how the v2 incident happens
+   twice.
 
 The contributor-facing walkthrough of these rules — where changes land,
 how to manage backports and forward-ports, and worked examples — lives on
@@ -98,8 +99,8 @@ backport label action, the forward-port tracker workflow, and
   surface; rules 4–5 depend on reviewer discipline that automation only
   partially enforces.
 - **Rule for future release questions:** do not create preemptive
-  `release/*` branches, never land feature work on a maintenance branch
+  `release/*` branches, do not land feature work on a maintenance branch
   without completing the forward-port assessment, and do not treat a
-  maintenance branch as a development trunk — if v2-era work starts feeling
-  like active development again, that is the signal to re-evaluate the EOL
-  clock, not to grow the branch.
+  maintenance branch as a development trunk. If maintenance-line work
+  starts feeling like active development again, that is the cue to
+  re-evaluate the EOL clock, not to grow the branch.

--- a/docs/adr/011-release-branches-and-cross-major-flow.md
+++ b/docs/adr/011-release-branches-and-cross-major-flow.md
@@ -75,6 +75,10 @@ branches (maintainer decision, 2026-08-21):
    notes. Forgotten long-lived branches are how the v2 incident happens
    twice.
 
+The contributor-facing walkthrough of these rules — where changes land,
+how to manage backports and forward-ports, and worked examples — lives on
+the docs site at `website/docs/contributing/release-branches.md`.
+
 Follow-up tooling work implied by this decision: a `stable-release` job
 keyed on `release/v*` refs with an alternate release-please config, the
 backport label action, the forward-port tracker workflow, and

--- a/docs/adr/011-release-branches-and-cross-major-flow.md
+++ b/docs/adr/011-release-branches-and-cross-major-flow.md
@@ -42,7 +42,7 @@ branches (maintainer decision, 2026-08-21):
 1. **`main` is always the tip of the next major's development.**
 2. **Maintenance branches are named `release/vX.Y`** (no patch segment) and
    are **created lazily** from the last `vX.Y.*` tag at first need —
-   `git branch release/v2.x v2.4.5 && git push origin release/v2.x`. Tags
+   `git branch release/v2.4 v2.4.5 && git push origin release/v2.4`. Tags
    are immutable, so when the branch is cut is irrelevant; never cut one
    preemptively.
 3. **Downstream-only within a major:** fixes land on `main` first, then move
@@ -69,11 +69,13 @@ branches (maintainer decision, 2026-08-21):
    scoped to `release/v*` refs. Weekly preview releases remain `main`-only.
    `VERSION` and `CHANGELOG.md` stay release-please-owned on every branch —
    never hand-edited.
-7. **EOL policy:** the current major's latest minor receives fixes and
-   features; the prior major receives critical/security fixes only; its
-   `release/*` branch is deleted at EOL with an announcement in the release
-   notes. Forgotten long-lived branches are how the v2 incident happens
-   twice.
+7. **EOL policy:** vocabulary — *current* means the highest tagged major,
+   *prior* any tagged major below it. The current major's latest minor
+   receives fixes and features until the successor major tags its first
+   stable release; from that moment every prior major drops to
+   critical/security fixes only. Its `release/*` branch is deleted at EOL
+   with an announcement in the release notes. Forgotten long-lived branches
+   are how the v2 incident happens twice.
 
 The contributor-facing walkthrough of these rules — where changes land,
 how to manage backports and forward-ports, and worked examples — lives on

--- a/website/docs/contributing/conventions.md
+++ b/website/docs/contributing/conventions.md
@@ -152,9 +152,9 @@ Issues use the following label taxonomy:
 
 **Type labels:** `type: bug`, `type: feature`, `type: refactor`, `type: documentation`, `type: devops`, `type: epic`, `type: test`
 
-**Module labels:** Auto-applied by PR based on changed files (e.g., `module: table-api`, `module: core`).
+**Module labels:** Applied automatically by PR based on changed files (for example, `module: table-api`, `module: core`).
 
-**Status** (workflow state, auto-synced by automation):
+**Status** (workflow state, synced automatically):
 
 | Label | Meaning |
 |-------|---------|

--- a/website/docs/contributing/release-branches.md
+++ b/website/docs/contributing/release-branches.md
@@ -1,0 +1,177 @@
+---
+title: Release branches & cross-major flow
+description: >-
+  How fixes and features reach shipped majors while main develops the next
+  one — lazily-cut release/vX.Y branches, label-driven backports, tracked
+  forward-ports, and the rules that keep the lines from drifting apart.
+---
+
+# Release branches & cross-major flow
+
+At most points in this project's life, two major lines are alive at once:
+`main` develops the next major, while consumers stay pinned to shipped ones.
+This page explains where your change lands, how patches and features reach an
+older major, and the rules that exist because we already lived the failure
+mode once — during the v1→v2 transition, `main` and `release/v2` drifted so
+far apart they effectively became different codebases.
+
+The deep rationale lives in [ADR 011](https://github.com/michaeldcanady/servicenow-sdk-go/blob/main/docs/adr/011-release-branches-and-cross-major-flow.md);
+this page is the day-to-day version.
+
+## The mental model
+
+Four rules explain almost every decision on this page:
+
+| Rule | Meaning |
+| --- | --- |
+| `main` is next-major trunk | All new development lands on `main`, always. It is the tip of the next major version. |
+| Tags are cut points | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so branches are created **only when first needed**, never preemptively. |
+| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It is never a second development trunk. |
+| Drift must be tracked, never silent | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision. |
+
+```
+main ────────────●──────●──────●──▶  next major (e.g. v3-dev)
+                  \
+                   \  every fix lands here FIRST…
+                    \
+release/v2.4 ────────●──────●────▶  …then moves down by cherry-pick PR
+      ▲              │
+      └─ cut lazily from tag v2.4.5 the day it's first needed
+```
+
+## Creating a maintenance branch
+
+Create one only when something real needs it: a critical fix, a security
+patch, or an old-major-only feature. Cut it from the **last tag** of that
+minor line, not from `main`:
+
+```bash
+git fetch --tags
+git branch release/v2.4 v2.4.5
+git push origin release/v2.4
+```
+
+Naming rules:
+
+- `release/vX.Y` — major plus **minor**, no patch segment.
+- One branch per actively-patched minor line — in practice, the latest
+  minor of each supported major. If a feature release ships `v2.5.0` from a
+  `release/v2.4` branch, later `v2.5.*` patches get a fresh
+  `release/v2.5` cut at `v2.5.0`; the older branch is retired unless it
+  still has patch work in flight.
+- Never create a branch "for symmetry" or ahead of need. An idle long-lived
+  branch is how silent drift starts.
+
+## Where does my change land?
+
+| Your change | Lands on |
+| --- | --- |
+| Bug fix, dependency bump, doc fix affecting both majors | `main`, then backport (next section) |
+| New ServiceNow feature useful for both majors, small/portable | `main`, then port down to `release/vX.Y` |
+| New ServiceNow feature useful for both majors, but touching core code that has diverged between majors | `main` only, unless consumer demand justifies the port cost — document the decision in the PR |
+| Feature that only makes sense on the old major (depends on prior-major model shapes) | `release/vX.Y` directly — see [old-major-only features](#landing-an-old-major-only-feature) |
+| Anything else speculative | Don't. Ask in an issue first. |
+
+## Backporting fixes (`main` → `release/vX.Y`)
+
+Fixes land on `main` first, always — even if the reporter is stuck on the
+old major. Then:
+
+1. Add the label **`backport release/vX.Y`** to the merged PR (or ask a
+   maintainer to).
+2. Automation opens a cherry-pick PR against `release/vX.Y`.
+3. Review and merge it like any other PR. Required CI runs there too.
+
+When the cherry-pick conflicts — common across majors — expect the import
+paths to be the culprit: every file's module suffix differs
+(`/v3/...` vs `/v2/...`). Rewrite the suffix mechanically, resolve the
+remainder by hand, and keep backport PRs small enough that this stays
+tractable. A fix too tangled to port cheaply is a signal to discuss whether
+it should be ported at all, not a reason to force it.
+
+Direct pushes to `release/*` are blocked. Everything arrives by PR.
+
+## Landing an old-major-only feature
+
+Sometimes a new ServiceNow capability should ship to consumers who cannot
+move majors yet. When the feature depends on prior-major shapes:
+
+1. Branch `feat/<name>-v2` off `release/v2.x` and open the PR **against the
+   release branch**.
+2. Use Conventional Commits as everywhere else — a `feat:` merge bumps the
+   maintenance line's **minor** (`v2.(Y+1).0`), a `fix:` bumps the patch.
+   `release-please` opens the release PR from the alternate config; never
+   hand-edit `VERSION` or `CHANGELOG.md` on any branch.
+3. Because this change did not come from `main`, automation immediately
+   opens a **`needs-forward-port`** issue asking whether the feature should
+   also reach `main`. That's expected and fine — see next section.
+
+## Forward-port tracking (`release/vX.Y` → `main`)
+
+Any merge into `release/v*` without backport provenance triggers a
+`needs-forward-port` issue ("assess porting #N to `main`"). Closing it
+takes exactly one of two actions:
+
+- **Port it**: open the matching PR against `main` (import suffix goes the
+  other direction this time), and close the issue with its number.
+- **Decline it**: close the issue with a short written rationale — e.g.
+  "v3 replaced the model layer this builds on". A recorded decision is
+  progress; silence is drift.
+
+This is the mechanism that makes the one exception to "downstream-only"
+safe: divergence can happen, but it can never happen invisibly.
+
+## Worked example: a new ServiceNow API ships today
+
+`main` is mid-v3-development. ServiceNow publishes a new endpoint, and v2
+users are asking for it now.
+
+**Path A — both majors want it (the usual case):**
+
+1. Build the module on `main` against `/v3`, following the
+   [module playbook](add-api-module.md). It ships in the next v3 release.
+2. Cut `release/v2.x` from the latest `v2.*` tag if it doesn't exist yet.
+3. Open a second PR carrying the same package to `release/v2.x`, rewriting
+   import suffixes `/v3` → `/v2`. New modules port well — they're
+   self-contained packages.
+4. Both lines ship the capability; the two PRs reference each other.
+
+**Path B — v2-only by design:** the feature leans on v2-era model shapes,
+or v3 has restructured the area it touches. Land it directly on
+`release/v2.x` (previous section); answer the resulting
+`needs-forward-port` issue honestly — "will port once v3 settles" or
+"won't port because…" are both acceptable answers.
+
+Either way, batch the release: maintenance releases are demand-driven, not
+one-tag-per-merge.
+
+## Hard rules
+
+- ❌ No direct pushes to `release/*` — PRs only, required CI green.
+- ❌ No preemptive `release/*` branches.
+- ❌ No feature development on a maintenance branch without accepting the
+  forward-port assessment that follows it.
+- ❌ No independent parallel implementation of the same concept on two
+  major lines — one PR per concept per direction, cross-referenced.
+- ❌ Never hand-edit `VERSION` or `CHANGELOG.md` — on any branch.
+- ✅ Fixes on `main` first, labels second, cherry-pick third.
+
+## Retiring a maintenance branch
+
+Support windows are deliberate, not accidental (ADR 011, rule 7):
+
+- Current major's latest minor: fixes **and** selected features.
+- Previous major: critical and security fixes only.
+- At end of support, the `release/*` branch is deleted and the retirement
+  is announced in the release notes. If a maintenance branch starts feeling
+  like active development again, that's the signal to revisit the EOL clock
+  — not to keep growing the branch.
+
+:::note[Status]
+The automation described here (backport label action, forward-port tracker,
+maintenance-line release job, branch protection) lands incrementally; until
+each piece exists, perform its step manually and say so in the PR
+description. Tracking issues live under the
+[`type: devops`](https://github.com/michaeldcanady/servicenow-sdk-go/issues?q=is%3Aopen+label%3A%22type%3A+devops%22)
+label.
+:::

--- a/website/docs/contributing/release-branches.md
+++ b/website/docs/contributing/release-branches.md
@@ -24,17 +24,19 @@ Four rules explain almost every decision on this page:
 
 | Rule | Meaning |
 | --- | --- |
-| `main` is next-major trunk | All new development lands on `main`, always. It is the tip of the next major version. |
+| `main` is next-major trunk | All new development lands on `main`, always. It's the tip of the next major version. |
 | Tags are cut points | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so branches are created **only when first needed**, never preemptively. |
-| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It is never a second development trunk. |
+| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It's never a second development trunk. |
 | Drift must be tracked, never silent | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision. |
 
 ```
+          every fix lands here FIRST…
+             ▼
 main ────────────●──────●──────●──▶  next major (e.g. v3-dev)
                   \
-                   \  every fix lands here FIRST…
+                   \   …then each lands downstream by cherry-pick PR
                     \
-release/v2.4 ────────●──────●────▶  …then moves down by cherry-pick PR
+release/v2.4 ────────●──────●────▶  maintenance line
       ▲              │
       └─ cut lazily from tag v2.4.5 the day it's first needed
 ```
@@ -79,7 +81,7 @@ old major. Then:
 
 1. Add the label **`backport release/vX.Y`** to the merged PR (or ask a
    maintainer to).
-2. Automation opens a cherry-pick PR against `release/vX.Y`.
+2. Automation (#656) opens a cherry-pick PR against the maintenance branch.
 3. Review and merge it like any other PR. Required CI runs there too.
 
 When the cherry-pick conflicts — common across majors — expect the import
@@ -93,16 +95,16 @@ Direct pushes to `release/*` are blocked. Everything arrives by PR.
 
 ## Landing an old-major-only feature
 
-Sometimes a new ServiceNow capability should ship to consumers who cannot
+Sometimes a new ServiceNow capability should ship to consumers who can't
 move majors yet. When the feature depends on prior-major shapes:
 
-1. Branch `feat/<name>-v2` off `release/v2.x` and open the PR **against the
+1. Branch `feat/<name>-v2` off `release/v2.4` and open the PR **against the
    release branch**.
 2. Use Conventional Commits as everywhere else — a `feat:` merge bumps the
    maintenance line's **minor** (`v2.(Y+1).0`), a `fix:` bumps the patch.
-   `release-please` opens the release PR from the alternate config; never
-   hand-edit `VERSION` or `CHANGELOG.md` on any branch.
-3. Because this change did not come from `main`, automation immediately
+   `release-please` opens the release PR from the alternate config (#659);
+   never hand-edit `VERSION` or `CHANGELOG.md` on any branch.
+3. Because this change didn't come from `main`, automation immediately
    opens a **`needs-forward-port`** issue asking whether the feature should
    also reach `main`. That's expected and fine — see next section.
 
@@ -114,14 +116,14 @@ takes exactly one of two actions:
 
 - **Port it**: open the matching PR against `main` (import suffix goes the
   other direction this time), and close the issue with its number.
-- **Decline it**: close the issue with a short written rationale — e.g.
-  "v3 replaced the model layer this builds on". A recorded decision is
-  progress; silence is drift.
+- **Decline it**: close the issue with a short written rationale, for
+  example: "v3 replaced the model layer this builds on." A recorded decision
+  is progress; silence is drift.
 
 This is the mechanism that makes the one exception to "downstream-only"
 safe: divergence can happen, but it can never happen invisibly.
 
-## Worked example: a new ServiceNow API ships today
+## Worked example: A new ServiceNow API ships today
 
 `main` is mid-v3-development. ServiceNow publishes a new endpoint, and v2
 users are asking for it now.
@@ -130,15 +132,15 @@ users are asking for it now.
 
 1. Build the module on `main` against `/v3`, following the
    [module playbook](add-api-module.md). It ships in the next v3 release.
-2. Cut `release/v2.x` from the latest `v2.*` tag if it doesn't exist yet.
-3. Open a second PR carrying the same package to `release/v2.x`, rewriting
+2. Cut `release/v2.4` from the latest `v2.*` tag if it doesn't exist yet.
+3. Open a second PR carrying the same package to `release/v2.4`, rewriting
    import suffixes `/v3` → `/v2`. New modules port well — they're
    self-contained packages.
 4. Both lines ship the capability; the two PRs reference each other.
 
 **Path B — v2-only by design:** the feature leans on v2-era model shapes,
 or v3 has restructured the area it touches. Land it directly on
-`release/v2.x` (previous section); answer the resulting
+`release/v2.4` (previous section); answer the resulting
 `needs-forward-port` issue honestly — "will port once v3 settles" or
 "won't port because…" are both acceptable answers.
 
@@ -147,7 +149,8 @@ one-tag-per-merge.
 
 ## Hard rules
 
-- ❌ No direct pushes to `release/*` — PRs only, required CI green.
+- ❌ No direct pushes to `release/*` (branch protection, #658) — PRs only,
+  required CI green.
 - ❌ No preemptive `release/*` branches.
 - ❌ No feature development on a maintenance branch without accepting the
   forward-port assessment that follows it.
@@ -158,10 +161,16 @@ one-tag-per-merge.
 
 ## Retiring a maintenance branch
 
-Support windows are deliberate, not accidental (ADR 011, rule 7):
+Support windows are deliberate, not accidental (ADR 011, rule 7).
+Vocabulary: *current* means the highest tagged major; *prior* means any
+tagged major below it.
 
-- Current major's latest minor: fixes **and** selected features.
-- Previous major: critical and security fixes only.
+- The current major's latest minor receives fixes **and** selected features.
+- The transition is explicit: the day the successor major tags its **first
+  stable release**, every prior major drops to critical/security fixes only.
+  Until that tag exists, the latest released major stays feature-eligible —
+  that window is what makes [old-major-only features](#landing-an-old-major-only-feature)
+  possible while the next major is still in development.
 - At end of support, the `release/*` branch is deleted and the retirement
   is announced in the release notes. If a maintenance branch starts feeling
   like active development again, that's the signal to revisit the EOL clock

--- a/website/docs/contributing/release-branches.md
+++ b/website/docs/contributing/release-branches.md
@@ -22,12 +22,12 @@ this page is the day-to-day version.
 
 Four rules explain almost every decision on this page:
 
-| Rule | Meaning |
-| --- | --- |
-| `main` is next-major trunk | All new development lands on `main`, always. It is the tip of the next major version. |
-| Tags are cut points | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so branches are created **only when first needed**, never preemptively. |
-| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It is never a second development trunk. |
-| Drift must be tracked, never silent | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision. |
+| Rule                                 | Meaning                                                                                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main` is next-major trunk           | All new development lands on `main`, always. It is the tip of the next major version.                                                                                                                   |
+| Tags are cut points                  | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so branches are created **only when first needed**, never preemptively. |
+| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It is never a second development trunk.                                                                 |
+| Drift must be tracked                | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision.                                       |
 
 ```
 main ────────────●──────●──────●──▶  next major (e.g. v3-dev)
@@ -64,21 +64,20 @@ Naming rules:
 
 ## Where does my change land?
 
-| Your change | Lands on |
-| --- | --- |
-| Bug fix, dependency bump, doc fix affecting both majors | `main`, then backport (next section) |
-| New ServiceNow feature useful for both majors, small/portable | `main`, then port down to `release/vX.Y` |
+| Your change                                                                                            | Lands on                                                                                      |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Bug fix, dependency bump, doc fix affecting both majors                                                | `main`, then backport (next section)                                                          |
+| New ServiceNow feature useful for both majors, small/portable                                          | `main`, then port down to `release/vX.Y`                                                      |
 | New ServiceNow feature useful for both majors, but touching core code that has diverged between majors | `main` only, unless consumer demand justifies the port cost — document the decision in the PR |
-| Feature that only makes sense on the old major (depends on prior-major model shapes) | `release/vX.Y` directly — see [old-major-only features](#landing-an-old-major-only-feature) |
-| Anything else speculative | Don't. Ask in an issue first. |
+| Feature that only makes sense on the old major (depends on prior-major model shapes)                   | `release/vX.Y` directly — see [old-major-only features](#landing-an-old-major-only-feature)   |
+| Anything else speculative                                                                              | Don't. Ask in an issue first.                                                                 |
 
 ## Backporting fixes (`main` → `release/vX.Y`)
 
 Fixes land on `main` first, always — even if the reporter is stuck on the
 old major. Then:
 
-1. Add the label **`backport release/vX.Y`** to the merged PR (or ask a
-   maintainer to).
+1. Add the label **`backport release/vX.Y`** to the merged PR (or ask a maintainer to).
 2. Automation opens a cherry-pick PR against `release/vX.Y`.
 3. Review and merge it like any other PR. Required CI runs there too.
 
@@ -96,54 +95,33 @@ Direct pushes to `release/*` are blocked. Everything arrives by PR.
 Sometimes a new ServiceNow capability should ship to consumers who cannot
 move majors yet. When the feature depends on prior-major shapes:
 
-1. Branch `feat/<name>-v2` off `release/v2.x` and open the PR **against the
-   release branch**.
-2. Use Conventional Commits as everywhere else — a `feat:` merge bumps the
-   maintenance line's **minor** (`v2.(Y+1).0`), a `fix:` bumps the patch.
-   `release-please` opens the release PR from the alternate config; never
-   hand-edit `VERSION` or `CHANGELOG.md` on any branch.
-3. Because this change did not come from `main`, automation immediately
-   opens a **`needs-forward-port`** issue asking whether the feature should
-   also reach `main`. That's expected and fine — see next section.
+1. Branch `feat/<name>-v2` off `release/v2.x` and open the PR **against the release branch**.
+2. Use Conventional Commits as everywhere else — a `feat:` merge bumps the maintenance line's **minor** (`v2.(Y+1).0`), a `fix:` bumps the patch. `release-please` opens the release PR from the alternate config; never hand-edit `VERSION` or `CHANGELOG.md` on any branch.
+3. Because this change did not come from `main`, automation immediately opens a **`needs-forward-port`** issue asking whether the feature should also reach `main`. That's expected and fine — see next section.
 
 ## Forward-port tracking (`release/vX.Y` → `main`)
 
-Any merge into `release/v*` without backport provenance triggers a
-`needs-forward-port` issue ("assess porting #N to `main`"). Closing it
-takes exactly one of two actions:
+Any merge into `release/v*` without backport provenance triggers a `needs-forward-port` issue ("assess porting #N to `main`"). Closing it takes exactly one of two actions:
 
-- **Port it**: open the matching PR against `main` (import suffix goes the
-  other direction this time), and close the issue with its number.
-- **Decline it**: close the issue with a short written rationale — e.g.
-  "v3 replaced the model layer this builds on". A recorded decision is
-  progress; silence is drift.
+- **Port it**: open the matching PR against `main` (import suffix goes the other direction this time), and close the issue with its number.
+- **Decline it**: close the issue with a short written rationale — e.g. "v3 replaced the model layer this builds on". A recorded decision is progress; silence is drift.
 
-This is the mechanism that makes the one exception to "downstream-only"
-safe: divergence can happen, but it can never happen invisibly.
+This is the mechanism that makes the one exception to "downstream-only" safe: divergence can happen, but it can never happen invisibly.
 
 ## Worked example: a new ServiceNow API ships today
 
-`main` is mid-v3-development. ServiceNow publishes a new endpoint, and v2
-users are asking for it now.
+`main` is mid-v3-development. ServiceNow publishes a new endpoint, and v2 users are asking for it now.
 
 **Path A — both majors want it (the usual case):**
 
-1. Build the module on `main` against `/v3`, following the
-   [module playbook](add-api-module.md). It ships in the next v3 release.
+1. Build the module on `main` against `/v3`, following the [module playbook](add-api-module.md). It ships in the next v3 release.
 2. Cut `release/v2.x` from the latest `v2.*` tag if it doesn't exist yet.
-3. Open a second PR carrying the same package to `release/v2.x`, rewriting
-   import suffixes `/v3` → `/v2`. New modules port well — they're
-   self-contained packages.
+3. Open a second PR carrying the same package to `release/v2.x`, rewriting import suffixes `/v3` → `/v2`. New modules port well — they're self-contained packages.
 4. Both lines ship the capability; the two PRs reference each other.
 
-**Path B — v2-only by design:** the feature leans on v2-era model shapes,
-or v3 has restructured the area it touches. Land it directly on
-`release/v2.x` (previous section); answer the resulting
-`needs-forward-port` issue honestly — "will port once v3 settles" or
-"won't port because…" are both acceptable answers.
+**Path B — v2-only by design:** the feature leans on v2-era model shapes, or v3 has restructured the area it touches. Land it directly on `release/v2.x` (previous section); answer the resulting `needs-forward-port` issue honestly — "will port once v3 settles" or "won't port because…" are both acceptable answers.
 
-Either way, batch the release: maintenance releases are demand-driven, not
-one-tag-per-merge.
+Either way, batch the release: maintenance releases are demand-driven, not one-tag-per-merge.
 
 ## Hard rules
 
@@ -162,16 +140,8 @@ Support windows are deliberate, not accidental (ADR 011, rule 7):
 
 - Current major's latest minor: fixes **and** selected features.
 - Previous major: critical and security fixes only.
-- At end of support, the `release/*` branch is deleted and the retirement
-  is announced in the release notes. If a maintenance branch starts feeling
-  like active development again, that's the signal to revisit the EOL clock
-  — not to keep growing the branch.
+- At end of support, the `release/*` branch is deleted and the retirement is announced in the release notes. If a maintenance branch starts feeling like active development again, that's the signal to revisit the EOL clock — not to keep growing the branch.
 
 :::note[Status]
-The automation described here (backport label action, forward-port tracker,
-maintenance-line release job, branch protection) lands incrementally; until
-each piece exists, perform its step manually and say so in the PR
-description. Tracking issues live under the
-[`type: devops`](https://github.com/michaeldcanady/servicenow-sdk-go/issues?q=is%3Aopen+label%3A%22type%3A+devops%22)
-label.
+The automation described here (backport label action, forward-port tracker, maintenance-line release job, branch protection) lands incrementally; until each piece exists, perform its step manually and say so in the PR description. Tracking issues live under the [`type: devops`](https://github.com/michaeldcanady/servicenow-sdk-go/issues?q=is%3Aopen+label%3A%22type%3A+devops%22) label.
 :::

--- a/website/docs/contributing/release-branches.md
+++ b/website/docs/contributing/release-branches.md
@@ -29,16 +29,18 @@ Four rules explain almost every decision on this page:
 | Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It's never a second development trunk. |
 | Drift must be tracked, never silent | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision. |
 
-```
-          every fix lands here FIRST…
-             ▼
-main ────────────●──────●──────●──▶  next major (e.g. v3-dev)
-                  \
-                   \   …then each lands downstream by cherry-pick PR
-                    \
-release/v2.4 ────────●──────●────▶  maintenance line
-      ▲              │
-      └─ cut lazily from tag v2.4.5 the day it's first needed
+```mermaid
+gitGraph
+   accTitle: Release branch flow - fixes land upstream first
+   accDescr: main is the trunk where every fix lands first; release/v2.4 is cut lazily from tag v2.4.5 and receives each fix afterwards as a cherry-pick copy.
+   commit id: "v2.4.5" tag: "v2.4.5"
+   branch release/v2.4
+   checkout main
+   commit id: "fix lands here FIRST" type: HIGHLIGHT
+   checkout release/v2.4
+   commit id: "cherry-pick copy (-x)"
+   checkout main
+   commit id: "next major work continues"
 ```
 
 ## Creating a maintenance branch

--- a/website/docs/contributing/release-branches.md
+++ b/website/docs/contributing/release-branches.md
@@ -22,12 +22,12 @@ this page is the day-to-day version.
 
 Four rules explain almost every decision on this page:
 
-| Rule                                 | Meaning                                                                                                                                                                                                 |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `main` is next-major trunk           | All new development lands on `main`, always. It is the tip of the next major version.                                                                                                                   |
-| Tags are cut points                  | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so branches are created **only when first needed**, never preemptively. |
-| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It is never a second development trunk.                                                                 |
-| Drift must be tracked                | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision.                                       |
+| Rule | Meaning |
+| --- | --- |
+| `main` is next-major trunk | All new development lands on `main`, always. It is the tip of the next major version. |
+| Tags are cut points | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so branches are created **only when first needed**, never preemptively. |
+| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It is never a second development trunk. |
+| Drift must be tracked, never silent | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision. |
 
 ```
 main ────────────●──────●──────●──▶  next major (e.g. v3-dev)
@@ -64,20 +64,21 @@ Naming rules:
 
 ## Where does my change land?
 
-| Your change                                                                                            | Lands on                                                                                      |
-| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Bug fix, dependency bump, doc fix affecting both majors                                                | `main`, then backport (next section)                                                          |
-| New ServiceNow feature useful for both majors, small/portable                                          | `main`, then port down to `release/vX.Y`                                                      |
+| Your change | Lands on |
+| --- | --- |
+| Bug fix, dependency bump, doc fix affecting both majors | `main`, then backport (next section) |
+| New ServiceNow feature useful for both majors, small/portable | `main`, then port down to `release/vX.Y` |
 | New ServiceNow feature useful for both majors, but touching core code that has diverged between majors | `main` only, unless consumer demand justifies the port cost — document the decision in the PR |
-| Feature that only makes sense on the old major (depends on prior-major model shapes)                   | `release/vX.Y` directly — see [old-major-only features](#landing-an-old-major-only-feature)   |
-| Anything else speculative                                                                              | Don't. Ask in an issue first.                                                                 |
+| Feature that only makes sense on the old major (depends on prior-major model shapes) | `release/vX.Y` directly — see [old-major-only features](#landing-an-old-major-only-feature) |
+| Anything else speculative | Don't. Ask in an issue first. |
 
 ## Backporting fixes (`main` → `release/vX.Y`)
 
 Fixes land on `main` first, always — even if the reporter is stuck on the
 old major. Then:
 
-1. Add the label **`backport release/vX.Y`** to the merged PR (or ask a maintainer to).
+1. Add the label **`backport release/vX.Y`** to the merged PR (or ask a
+   maintainer to).
 2. Automation opens a cherry-pick PR against `release/vX.Y`.
 3. Review and merge it like any other PR. Required CI runs there too.
 
@@ -95,33 +96,54 @@ Direct pushes to `release/*` are blocked. Everything arrives by PR.
 Sometimes a new ServiceNow capability should ship to consumers who cannot
 move majors yet. When the feature depends on prior-major shapes:
 
-1. Branch `feat/<name>-v2` off `release/v2.x` and open the PR **against the release branch**.
-2. Use Conventional Commits as everywhere else — a `feat:` merge bumps the maintenance line's **minor** (`v2.(Y+1).0`), a `fix:` bumps the patch. `release-please` opens the release PR from the alternate config; never hand-edit `VERSION` or `CHANGELOG.md` on any branch.
-3. Because this change did not come from `main`, automation immediately opens a **`needs-forward-port`** issue asking whether the feature should also reach `main`. That's expected and fine — see next section.
+1. Branch `feat/<name>-v2` off `release/v2.x` and open the PR **against the
+   release branch**.
+2. Use Conventional Commits as everywhere else — a `feat:` merge bumps the
+   maintenance line's **minor** (`v2.(Y+1).0`), a `fix:` bumps the patch.
+   `release-please` opens the release PR from the alternate config; never
+   hand-edit `VERSION` or `CHANGELOG.md` on any branch.
+3. Because this change did not come from `main`, automation immediately
+   opens a **`needs-forward-port`** issue asking whether the feature should
+   also reach `main`. That's expected and fine — see next section.
 
 ## Forward-port tracking (`release/vX.Y` → `main`)
 
-Any merge into `release/v*` without backport provenance triggers a `needs-forward-port` issue ("assess porting #N to `main`"). Closing it takes exactly one of two actions:
+Any merge into `release/v*` without backport provenance triggers a
+`needs-forward-port` issue ("assess porting #N to `main`"). Closing it
+takes exactly one of two actions:
 
-- **Port it**: open the matching PR against `main` (import suffix goes the other direction this time), and close the issue with its number.
-- **Decline it**: close the issue with a short written rationale — e.g. "v3 replaced the model layer this builds on". A recorded decision is progress; silence is drift.
+- **Port it**: open the matching PR against `main` (import suffix goes the
+  other direction this time), and close the issue with its number.
+- **Decline it**: close the issue with a short written rationale — e.g.
+  "v3 replaced the model layer this builds on". A recorded decision is
+  progress; silence is drift.
 
-This is the mechanism that makes the one exception to "downstream-only" safe: divergence can happen, but it can never happen invisibly.
+This is the mechanism that makes the one exception to "downstream-only"
+safe: divergence can happen, but it can never happen invisibly.
 
 ## Worked example: a new ServiceNow API ships today
 
-`main` is mid-v3-development. ServiceNow publishes a new endpoint, and v2 users are asking for it now.
+`main` is mid-v3-development. ServiceNow publishes a new endpoint, and v2
+users are asking for it now.
 
 **Path A — both majors want it (the usual case):**
 
-1. Build the module on `main` against `/v3`, following the [module playbook](add-api-module.md). It ships in the next v3 release.
+1. Build the module on `main` against `/v3`, following the
+   [module playbook](add-api-module.md). It ships in the next v3 release.
 2. Cut `release/v2.x` from the latest `v2.*` tag if it doesn't exist yet.
-3. Open a second PR carrying the same package to `release/v2.x`, rewriting import suffixes `/v3` → `/v2`. New modules port well — they're self-contained packages.
+3. Open a second PR carrying the same package to `release/v2.x`, rewriting
+   import suffixes `/v3` → `/v2`. New modules port well — they're
+   self-contained packages.
 4. Both lines ship the capability; the two PRs reference each other.
 
-**Path B — v2-only by design:** the feature leans on v2-era model shapes, or v3 has restructured the area it touches. Land it directly on `release/v2.x` (previous section); answer the resulting `needs-forward-port` issue honestly — "will port once v3 settles" or "won't port because…" are both acceptable answers.
+**Path B — v2-only by design:** the feature leans on v2-era model shapes,
+or v3 has restructured the area it touches. Land it directly on
+`release/v2.x` (previous section); answer the resulting
+`needs-forward-port` issue honestly — "will port once v3 settles" or
+"won't port because…" are both acceptable answers.
 
-Either way, batch the release: maintenance releases are demand-driven, not one-tag-per-merge.
+Either way, batch the release: maintenance releases are demand-driven, not
+one-tag-per-merge.
 
 ## Hard rules
 
@@ -140,8 +162,16 @@ Support windows are deliberate, not accidental (ADR 011, rule 7):
 
 - Current major's latest minor: fixes **and** selected features.
 - Previous major: critical and security fixes only.
-- At end of support, the `release/*` branch is deleted and the retirement is announced in the release notes. If a maintenance branch starts feeling like active development again, that's the signal to revisit the EOL clock — not to keep growing the branch.
+- At end of support, the `release/*` branch is deleted and the retirement
+  is announced in the release notes. If a maintenance branch starts feeling
+  like active development again, that's the signal to revisit the EOL clock
+  — not to keep growing the branch.
 
 :::note[Status]
-The automation described here (backport label action, forward-port tracker, maintenance-line release job, branch protection) lands incrementally; until each piece exists, perform its step manually and say so in the PR description. Tracking issues live under the [`type: devops`](https://github.com/michaeldcanady/servicenow-sdk-go/issues?q=is%3Aopen+label%3A%22type%3A+devops%22) label.
+The automation described here (backport label action, forward-port tracker,
+maintenance-line release job, branch protection) lands incrementally; until
+each piece exists, perform its step manually and say so in the PR
+description. Tracking issues live under the
+[`type: devops`](https://github.com/michaeldcanady/servicenow-sdk-go/issues?q=is%3Aopen+label%3A%22type%3A+devops%22)
+label.
 :::

--- a/website/docs/contributing/release-branches.md
+++ b/website/docs/contributing/release-branches.md
@@ -22,12 +22,12 @@ this page is the day-to-day version.
 
 Four rules explain almost every decision on this page:
 
-| Rule | Meaning |
-| --- | --- |
-| `main` is next-major trunk | All new development lands on `main`, always. It's the tip of the next major version. |
-| Tags are cut points | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so branches are created **only when first needed**, never preemptively. |
-| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It's never a second development trunk. |
-| Drift must be tracked, never silent | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision. |
+| Rule                                 | Meaning                                                                                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main` is next-major trunk           | All new development lands on `main`, always. It's the tip of the next major version.                                                                                                                    |
+| Tags are cut points                  | Releases are tagged; branches merely give tags a place to grow from. You can branch from a tag at any time — even years later — so create branches **only when first needed**, never preemptively. |
+| Maintenance branches flow downstream | A `release/vX.Y` branch only ever receives changes that came from (or are accounted to) `main`. It's never a second development trunk.                                                                  |
+| Drift must be tracked, never silent  | Every change that reaches a maintenance branch without coming from `main` automatically opens a tracking issue demanding an explicit port-or-won't-port decision.                                       |
 
 ```mermaid
 gitGraph
@@ -61,20 +61,20 @@ Naming rules:
 - One branch per actively-patched minor line — in practice, the latest
   minor of each supported major. If a feature release ships `v2.5.0` from a
   `release/v2.4` branch, later `v2.5.*` patches get a fresh
-  `release/v2.5` cut at `v2.5.0`; the older branch is retired unless it
-  still has patch work in flight.
+  `release/v2.5` cut at `v2.5.0`; retire the older branch unless it still
+  has patch work in flight.
 - Never create a branch "for symmetry" or ahead of need. An idle long-lived
   branch is how silent drift starts.
 
 ## Where does my change land?
 
-| Your change | Lands on |
-| --- | --- |
-| Bug fix, dependency bump, doc fix affecting both majors | `main`, then backport (next section) |
-| New ServiceNow feature useful for both majors, small/portable | `main`, then port down to `release/vX.Y` |
+| Your change                                                                                            | Lands on                                                                                      |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Bug fix, dependency bump, doc fix affecting both majors                                                | `main`, then backport (next section)                                                          |
+| New ServiceNow feature useful for both majors, small/portable                                          | `main`, then port down to `release/vX.Y`                                                      |
 | New ServiceNow feature useful for both majors, but touching core code that has diverged between majors | `main` only, unless consumer demand justifies the port cost — document the decision in the PR |
-| Feature that only makes sense on the old major (depends on prior-major model shapes) | `release/vX.Y` directly — see [old-major-only features](#landing-an-old-major-only-feature) |
-| Anything else speculative | Don't. Ask in an issue first. |
+| Feature that only makes sense on the old major (depends on prior-major model shapes)                   | `release/vX.Y` directly — see [old-major-only features](#landing-an-old-major-only-feature)   |
+| Anything else speculative                                                                              | Don't. Ask in an issue first.                                                                 |
 
 ## Backporting fixes (`main` → `release/vX.Y`)
 
@@ -93,7 +93,8 @@ remainder by hand, and keep backport PRs small enough that this stays
 tractable. A fix too tangled to port cheaply is a signal to discuss whether
 it should be ported at all, not a reason to force it.
 
-Direct pushes to `release/*` are blocked. Everything arrives by PR.
+Branch protection blocks direct pushes to `release/*`. Everything arrives
+by PR.
 
 ## Landing an old-major-only feature
 
@@ -127,7 +128,7 @@ safe: divergence can happen, but it can never happen invisibly.
 
 ## Worked example: A new ServiceNow API ships today
 
-`main` is mid-v3-development. ServiceNow publishes a new endpoint, and v2
+`main` is mid-v3 development. ServiceNow publishes a new endpoint, and v2
 users are asking for it now.
 
 **Path A — both majors want it (the usual case):**
@@ -173,8 +174,8 @@ tagged major below it.
   Until that tag exists, the latest released major stays feature-eligible —
   that window is what makes [old-major-only features](#landing-an-old-major-only-feature)
   possible while the next major is still in development.
-- At end of support, the `release/*` branch is deleted and the retirement
-  is announced in the release notes. If a maintenance branch starts feeling
+- At end of support, maintainers delete the `release/*` branch and announce
+  the retirement in the release notes. If a maintenance branch starts feeling
   like active development again, that's the signal to revisit the EOL clock
   — not to keep growing the branch.
 

--- a/website/docs/user-guide/batch.mdx
+++ b/website/docs/user-guide/batch.mdx
@@ -41,7 +41,7 @@ func main() {
 
 ## Tips
 
-- ServiceNow executes the sub-requests independently — a batch is **not** a
+- ServiceNow executes the sub-requests independently — a batch isn't a
   transaction. Check `GetUnservicedRequests()` for the ones that didn't run.
 - Each serviced request carries its own status code and body; a `200` on the
   batch only means the batch itself was processed.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -300,7 +300,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Conventions & playbooks',
       collapsed: false,
-      items: ['contributing/conventions', 'contributing/add-api-module'],
+      items: ['contributing/conventions', 'contributing/add-api-module', 'contributing/release-branches'],
     },
     {
       type: 'category',


### PR DESCRIPTION
## What & why

The first live `E2E Nightly` dispatch ([run](https://github.com/michaeldcanady/servicenow-sdk-go/actions/runs/32616276677)) reported **success despite a failing scenario**: `go test … | tee` returns tee's exit code, so the step passed, the `if: failure()` summary step was skipped, and 18/19 scenarios showed green overall.

Adds `set -o pipefail`, matching the existing pattern in `.github/scripts/report-tests.sh`.

Note for reviewers: the failing scenario itself (`Client credentials token acquisition against live instance`) is expected to fail on any live instance today — its step hardcodes `mock-client-id`/`mock-client-secret` (`auth_steps.go:75`). Fixing that is a test-fixture decision tracked separately.

## Type of change

- [x] `chore` — CI, tooling, dependencies, or other non-release work

## Checklist

- [x] `gofmt -s -w .` and `golangci-lint run ./...` pass (no Go changes)
- [x] `go test ./...` passes (no Go changes)
- [x] New or changed exported surface has unit tests (none — workflows only)
- [x] `website/` N/A
- [x] Code samples N/A
- [x] `VERSION` and `CHANGELOG.md` untouched