### PR TITLE
fix(ci): propagate go test exit code through tee in e2e-nightly

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -71,7 +71,11 @@ jobs:
 
       - name: Run E2E suites
         working-directory: tests/integration/v2
-        run: go test -tags e2e ./... -timeout "$GO_TEST_TIMEOUT" -v 2>&1 | tee e2e-output.txt
+        # pipefail is mandatory: without it the pipeline's exit code comes from
+        # tee, and go test failures silently produce a green job.
+        run: |
+          set -o pipefail
+          go test -tags e2e ./... -timeout "$GO_TEST_TIMEOUT" -v 2>&1 | tee e2e-output.txt
 
       - name: Summarize failures
         if: failure()


### PR DESCRIPTION
## What & why

The first live `E2E Nightly` dispatch ([run](https://github.com/michaeldcanady/servicenow-sdk-go/actions/runs/32616276677)) reported **success despite a failing scenario**: `go test … | tee` returns tee's exit code, so the step passed, the `if: failure()` summary step was skipped, and the run went green at 18/19 scenarios.

Adds `set -o pipefail`, matching the existing pattern in `.github/scripts/report-tests.sh`.

Note: the failing scenario itself is fixed separately (client credentials sourced from env).

## Type of change

- [x] `chore` — CI, tooling, dependencies, or other non-release work

## Checklist

- [x] No Go changes · [x] website N/A · [x] VERSION/CHANGELOG untouched