### PR TITLE
test(e2e): capture real Bearer token and hermetic credential tests

### DIFF
--- a/tests/integration/v2/support/client.go
+++ b/tests/integration/v2/support/client.go
@@ -3,6 +3,9 @@ package support
 import (
 	"fmt"
 	"net/http"
+	"strings"
+	"sync"
+	"time"
 
 	sdk "github.com/michaeldcanady/servicenow-sdk-go/v2"
 	"github.com/michaeldcanady/servicenow-sdk-go/v2/credentials"
@@ -12,11 +15,51 @@ import (
 	"github.com/jarcoal/httpmock"
 )
 
+// tokenCaptureRT records the most recent Bearer token on outgoing requests so
+// scenarios can assert a real token was used. It must sit BELOW the Kiota
+// middleware pipeline (as the parent transport) — that is where the
+// authentication provider has already injected the Authorization header.
+type tokenCaptureRT struct {
+	w    *World
+	base http.RoundTripper
+
+	mu sync.Mutex
+}
+
+func (t *tokenCaptureRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	if authz := req.Header.Get("Authorization"); strings.HasPrefix(authz, "Bearer ") {
+		t.mu.Lock()
+		t.w.CachedToken = strings.TrimPrefix(authz, "Bearer ")
+		t.mu.Unlock()
+	}
+	rt := t.base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	return rt.RoundTrip(req)
+}
+
+// newTokenCapturingClient builds an http.Client equivalent to the SDK default,
+// with token capture enabled. Only used for live (e2e) runs; offline runs keep
+// their httpmock transport untouched.
+func newTokenCapturingClient(w *World) *http.Client {
+	parent := &tokenCaptureRT{w: w}
+	return &http.Client{
+		Transport: nethttplibrary.NewCustomTransportWithParentTransport(
+			parent, nethttplibrary.GetDefaultMiddlewares()...,
+		),
+		Timeout: 60 * time.Second,
+	}
+}
+
 // NewSDKClient creates a ServiceNowServiceClient with the given options.
 // It automatically injects the HTTP client (httpmock when offline) and instance.
 func NewSDKClient(w *World, opts ...sdk.ServiceNowServiceClientOption) error {
 	instance := IntegrationInstance()
 	httpClient := GetHTTPClient()
+	if httpClient == nil && IsE2E() {
+		httpClient = newTokenCapturingClient(w)
+	}
 
 	baseOpts := []sdk.ServiceNowServiceClientOption{
 		sdk.WithInstance(instance),

--- a/tests/integration/v2/support/env_test.go
+++ b/tests/integration/v2/support/env_test.go
@@ -6,6 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// credentialEnvKeys are pinned in every case so ambient SN_*/SNOW_* variables
+// (e.g. real secrets set in the e2e-nightly job) cannot leak into assertions.
+var credentialEnvKeys = []string{
+	"SN_CLIENT_ID", "SN_CLIENT_SECRET",
+	"SNOW_CLIENT_ID", "SNOW_CLIENT_SECRET",
+}
+
 func TestClientCredentials(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -54,8 +61,8 @@ func TestClientCredentials(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range tt.env {
-				t.Setenv(k, v)
+			for _, k := range credentialEnvKeys {
+				t.Setenv(k, tt.env[k]) // empty string == unset for FirstEnv
 			}
 			gotID, gotSecret := ClientCredentials()
 			assert.Equal(t, tt.wantID, gotID)


### PR DESCRIPTION
## What & why

Two distinct failures in [e2e nightly run 32617736971](https://github.com/michaeldcanady/servicenow-sdk-go/actions/runs/32617736971) — the good news is the live OAuth flow now works end-to-end (client init ✓, token acquisition ✓, real API request ✓ against the tenant).

**Failure 1 — live scenario assertion:** `Client credentials token acquisition` failed only on its final step: `World.CachedToken` was empty. Root cause: no capture path ever existed — the sole writer sets the literal `"acquired"` (`auth_steps.go:154`), which the assertion deliberately rejects (`auth_steps.go:667`). Basic-auth never hits this because its scenario has no token assertion.

Fix: `NewSDKClient` now injects a token-capturing `http.Client` on **live runs only**. A `RoundTripper` sits as parent transport of the Kiota middleware pipeline so it observes the `Authorization` header *after* the auth provider adds it; Bearer-only (Basic credentials are not captured); mutex-guarded; offline/httpmock transport untouched.

**Failure 2 — my unit tests weren't hermetic:** `TestClientCredentials/defaults_when_nothing_set` failed in CI because ambient `SN_CLIENT_ID`/`SN_CLIENT_SECRET` secrets from the `e2e-tests` environment leaked into the process (GitHub masked them as `***` in logs). Every case now pins all four env keys via `t.Setenv`; verified locally with ambient secrets set.

## Type of change

- [x] `test` — test coverage or infrastructure

## Checklist

- [x] `gofmt -s -w .` passes · [x] `go vet` clean (untagged, integration, e2e) · [x] mocked integration suite still passes · [x] website N/A · [x] VERSION/CHANGELOG untouched