### PR TITLE
chore(website): add Plausible analytics gated to production deploys

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -39,6 +39,20 @@ const config: Config = {
 
   themes: ['@docusaurus/theme-mermaid'],
 
+  scripts:
+    process.env.NODE_ENV === 'production' && !process.env.DOCS_BASE_URL
+      ? [
+          // Plausible analytics. Only loaded on production deploys: local
+          // dev runs with NODE_ENV=development, and PR previews inject
+          // DOCS_BASE_URL, so neither pollutes the stats.
+          {
+            src: 'https://plausible.io/js/script.js',
+            defer: true,
+            'data-domain': 'michaeldcanady.github.io',
+          },
+        ]
+      : [],
+
   plugins: [
     // Allow importing Go snippet files as raw source (single source of truth
     // for all code examples; see src/components/GoSnippet and GoExample).


### PR DESCRIPTION
## What

Adds the Plausible analytics script to `website/docusaurus.config.ts` via Docusaurus's `scripts` option.

The script is only injected when **both** hold:
- `NODE_ENV === 'production'` (excludes local `docusaurus start` dev servers)
- `DOCS_BASE_URL` is unset (excludes CI PR-preview deploys, which set it per docusaurus.config.ts:19)

## Why

We want docs-usage signal (traffic sources, popular pages, outbound clicks) without Google Analytics' ad-tech baggage: no consent banner required (cookieless), lightweight beacon, and far less ad-blocker distortion for a developer audience. Starting with Plausible's 30-day cloud trial; self-hosted CE or another vendor can replace it later by changing this one script tag.

## Required manual step before merge (or right after)

Register the site in the Plausible dashboard with domain `michaeldcanady.github.io` — events are matched by hostname, and the subdirectory path (`/servicenow-sdk-go/`) shows up in page URLs automatically. Until registered, the beacon 404s silently and nothing breaks.

## Verification

- `npm run typecheck`: pass
- Production build (`NODE_ENV=production npm run build`, no override): plausible.io `<script>` present in emitted HTML
- Preview-mode build (`DOCS_BASE_URL=/servicenow-sdk-go/pr-preview/pr-N/`): no plausible.io reference anywhere in `build/`
- Local dev server path excluded via the same `NODE_ENV` gate