### PR TITLE
chore(website): track code copies and per-page docs feedback via Plausible

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -39,6 +39,8 @@ const config: Config = {
 
   themes: ['@docusaurus/theme-mermaid'],
 
+  clientModules: ['./src/clientModules/trackCodeCopy.ts'],
+
   scripts:
     process.env.NODE_ENV === 'production' && !process.env.DOCS_BASE_URL
       ? [

--- a/website/src/clientModules/trackCodeCopy.ts
+++ b/website/src/clientModules/trackCodeCopy.ts
@@ -1,0 +1,14 @@
+// Tracks clicks on any code-block copy button as a Plausible "Copy Code"
+// event. The button has no stable class (its styling comes from a CSS
+// module), so this keys off its aria-label, which is stable English —
+// the site is single-locale.
+import {trackEvent} from '../utils/analytics';
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('click', (event) => {
+    const target = event.target as Element | null;
+    if (target?.closest?.('button[aria-label="Copy code to clipboard"]')) {
+      trackEvent('Copy Code', {page: window.location.pathname});
+    }
+  });
+}

--- a/website/src/components/DocsFeedback/index.tsx
+++ b/website/src/components/DocsFeedback/index.tsx
@@ -1,0 +1,50 @@
+import React, {useEffect, useState} from 'react';
+import {useLocation} from '@docusaurus/router';
+import {trackEvent} from '../../utils/analytics';
+import styles from './styles.module.css';
+
+type Vote = 'yes' | 'no';
+
+// Per-page feedback widget. Votes go to Plausible as a "Docs Feedback"
+// event with the page path and vote as props — Plausible itself is the
+// backend, so no server-side component is needed.
+export default function DocsFeedback(): React.ReactElement {
+  const {pathname} = useLocation();
+  const [vote, setVote] = useState<Vote | null>(null);
+
+  // Reset when navigating between docs pages.
+  useEffect(() => {
+    setVote(null);
+  }, [pathname]);
+
+  const send = (value: Vote) => {
+    if (vote === null) {
+      trackEvent('Docs Feedback', {page: pathname, vote: value});
+    }
+    setVote(value);
+  };
+
+  return (
+    <div className={styles.container}>
+      {vote === null ? (
+        <>
+          <span className={styles.prompt}>Was this page helpful?</span>
+          <button
+            type="button"
+            className="button button--sm button--outline button--secondary"
+            onClick={() => send('yes')}>
+            Yes
+          </button>
+          <button
+            type="button"
+            className="button button--sm button--outline button--secondary"
+            onClick={() => send('no')}>
+            No
+          </button>
+        </>
+      ) : (
+        <span className={styles.thanks}>Thanks for your feedback!</span>
+      )}
+    </div>
+  );
+}

--- a/website/src/components/DocsFeedback/styles.module.css
+++ b/website/src/components/DocsFeedback/styles.module.css
@@ -1,0 +1,17 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.prompt {
+  font-weight: 600;
+  margin-right: 0.25rem;
+}
+
+.thanks {
+  color: var(--ifm-color-emphasis-600);
+}

--- a/website/src/theme/DocItem/index.tsx
+++ b/website/src/theme/DocItem/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import DocItem from '@theme-original/DocItem';
+import type {ComponentProps} from 'react';
+import DocsFeedback from '@site/src/components/DocsFeedback';
+
+// Appends the per-page feedback widget to every docs page.
+export default function DocItemWrapper(
+  props: ComponentProps<typeof DocItem>,
+): React.ReactElement {
+  return (
+    <>
+      <DocItem {...props} />
+      <DocsFeedback />
+    </>
+  );
+}

--- a/website/src/utils/analytics.ts
+++ b/website/src/utils/analytics.ts
@@ -1,0 +1,32 @@
+// Minimal Plausible custom-event client. Safe to call from anywhere: when
+// the Plausible script is absent (local dev, PR previews) events queue
+// in-memory and are dropped on page unload, so nothing is ever sent.
+
+type PlausibleOptions = {props?: Record<string, string>};
+
+type PlausibleFn = ((event: string, options?: PlausibleOptions) => void) & {
+  q?: unknown[];
+};
+
+declare global {
+  interface Window {
+    plausible?: PlausibleFn;
+  }
+}
+
+export function trackEvent(name: string, props?: Record<string, string>): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (!window.plausible) {
+    // Queue shim per https://plausible.io/docs/custom-events — the real
+    // script drains the queue once it loads, then replaces window.plausible.
+    const queue: unknown[] = [];
+    const shim = ((event: string, options?: PlausibleOptions) => {
+      queue.push([event, options]);
+    }) as PlausibleFn;
+    shim.q = queue;
+    window.plausible = shim;
+  }
+  window.plausible(name, props ? {props} : undefined);
+}


### PR DESCRIPTION
## What

Adds interaction tracking on top of the pageview analytics from #679:

1. **Copy Code events** — a client module (`src/clientModules/trackCodeCopy.ts`) fires `Copy Code` (prop: `page`) whenever a code-block copy button is clicked. It delegates on the button's stable `aria-label` because Docusaurus styles it with a hashed CSS-module class.
2. **Was this page helpful? widget** — `src/components/DocsFeedback` appends a Yes/No widget to every docs page via a `DocItem` wrapper (`src/theme/DocItem/index.tsx`). Votes fire a `Docs Feedback` event with `page` + `vote` props — Plausible is the backend, so there is no server-side component and no data leaves Plausible.
3. **Shared helper** — `src/utils/analytics.ts` wraps `window.plausible` with the documented queue shim, so calls are safe in dev/preview builds where the script is never injected.

## After merge — dashboard setup (2 min)

In Plausible, add **Goals** for the custom event names `Copy Code` and `Docs Feedback` (Settings → Goals → Custom event). Until a goal exists, the events are collected but not shown in the dashboard. Prop breakdowns (per-page votes, top-copied pages) are available inside each goal's drilldown.

## Verification

- `npm run typecheck`: pass; `NODE_ENV=production npm run build`: pass
- Widget markup present exactly once per docs page in emitted HTML
- `Copy Code` tracking present in the production JS bundle
- Plausible script still gated to production deploys only (unchanged from #679)

## Deliberate choices

- `chore` not `feat`: release-please has no path exclusions, so a `feat:` here would bump the Go SDK version for a docs-site change
- No dedup beyond per-pageview UI state: repeat votes are rare and the signal is directional