### PR TITLE
chore(ci): scope vale runs to the docs trees and fix moved-page findings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -124,6 +124,10 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          # Newline-delimited so vale-action can split the list below — its
+          # default (a single space-joined string) isn't an existing path,
+          # which makes vale-action silently fall back to linting ".".
+          separator: "\n"
           files: |
             website/docs/**/*.md
             website/versioned_docs/**/*.md
@@ -136,6 +140,11 @@ jobs:
           files: |
             website/docs
             website/versioned_docs
+          # Multiline `files` needs this: without a separator vale-action
+          # treats the whole string as one path, doesn't find it, and falls
+          # back to linting "." — which is how a main push once failed on
+          # hundreds of pre-existing violations outside website/.
+          separator: "\n"
           level: error
           version: 3.18.0
 
@@ -147,6 +156,7 @@ jobs:
         with:
           fail_on_error: true
           files: ${{ steps.changed-md.outputs.all_changed_files }}
+          separator: "\n"
           level: error
           version: 3.18.0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -131,10 +131,14 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          # Newline-delimited so vale-action can split the list below — its
-          # default (a single space-joined string) isn't an existing path,
-          # which makes vale-action silently fall back to linting ".".
-          separator: "\n"
+          # Comma-delimited on purpose. vale-action only splits its `files`
+          # input when given a matching `separator`; with the default (a
+          # single space-joined string) it treats the whole thing as one
+          # nonexistent path and silently falls back to linting ".". The
+          # delimiter must survive the runner, which trims action inputs —
+          # so a newline ("\n" arrives as "" after trimming) is out; a comma
+          # is safe because no repo path contains one.
+          separator: ","
           files: |
             website/docs/**/*.md
             website/versioned_docs/**/*.md
@@ -144,14 +148,8 @@ jobs:
         uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # 3.0.0
         with:
           fail_on_error: true
-          files: |
-            website/docs
-            website/versioned_docs
-          # Multiline `files` needs this: without a separator vale-action
-          # treats the whole string as one path, doesn't find it, and falls
-          # back to linting "." — which is how a main push once failed on
-          # hundreds of pre-existing violations outside website/.
-          separator: "\n"
+          files: website/docs,website/versioned_docs
+          separator: ","
           level: error
           version: 3.18.0
 
@@ -163,7 +161,7 @@ jobs:
         with:
           fail_on_error: true
           files: ${{ steps.changed-md.outputs.all_changed_files }}
-          separator: "\n"
+          separator: ","
           level: error
           version: 3.18.0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,11 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    if: ${{ needs.changes-docs.outputs.docs == 'true' }}
+    # workflow_dispatch bypasses the changed-files gate so the push-only
+    # steps (full-site Vale scan, deploy gating) can be exercised by hand
+    # against a ref before relying on them; !cancelled() is what lets this
+    # job evaluate at all when changes-docs was skipped.
+    if: ${{ !cancelled() && (needs.changes-docs.outputs.docs == 'true' || github.event_name == 'workflow_dispatch') }}
     needs:
       - changes-docs
     steps:
@@ -98,7 +102,10 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-    if: ${{ needs.changes-docs.outputs.docs == 'true' }}
+    # Same dispatch bypass as build-site (see the comment there): this is
+    # what makes the full-site scan below — the push-only step — runnable
+    # by hand against a ref.
+    if: ${{ !cancelled() && (needs.changes-docs.outputs.docs == 'true' || github.event_name == 'workflow_dispatch') }}
     needs:
       - changes-docs
     steps:

--- a/website/docs/contributing/adrs/011-release-branches-and-cross-major-flow.md
+++ b/website/docs/contributing/adrs/011-release-branches-and-cross-major-flow.md
@@ -19,7 +19,7 @@ semantic-import-versioning module paths make this especially expensive to
 recover from: every touched file carries `/v1` vs `/v2` import suffixes, so
 cross-line merges conflict in nearly every file and effectively become
 rewrites rather than merges. Drift between major lines therefore compounds
-fast and does not heal on its own.
+fast and doesn't heal on its own.
 
 Tooling reinforces the problem today: release-please fires only on `main`
 (`.github/workflows/stable-release.yml`), so there is no supported path for
@@ -104,9 +104,9 @@ backport label action, the forward-port tracker workflow, and
   two release-please configs and several new workflows add maintenance
   surface; rules 4–5 depend on reviewer discipline that automation only
   partially enforces.
-- **Rule for future release questions:** do not create preemptive
+- **Rule for future release questions:** don't create preemptive
   `release/*` branches, never land feature work on a maintenance branch
-  without completing the forward-port assessment, and do not treat a
+  without completing the forward-port assessment, and don't treat a
   maintenance branch as a development trunk — if v2-era work starts feeling
-  like active development again, that is the signal to re-evaluate the EOL
+  like active development again, that's the signal to re-evaluate the EOL
   clock, not to grow the branch.

--- a/website/docs/contributing/release-branch-protection.md
+++ b/website/docs/contributing/release-branch-protection.md
@@ -25,8 +25,8 @@ schema:
 | trunk | `main` | PR + 1 CODEOWNERS approval, stale-review dismissal, conversation resolution, no deletion/force-push |
 | maintenance lines | `release/v*` | same as trunk **plus required linear history** |
 
-Both require only universally reporting status checks ("Check Branch Name",
-"Check Linked Issue", "Validate PR Title", "CodeQL") — path-filtered jobs
+Both require only universally reporting status checks (`Check Branch Name`,
+`Check Linked Issue`, `Validate PR Title`, `CodeQL`) — path-filtered jobs
 would sit pending forever on PRs whose paths they skip.
 
 The table below is the human-readable spec the declaration encodes; consult

--- a/website/docs/contributing/triage.md
+++ b/website/docs/contributing/triage.md
@@ -62,7 +62,7 @@ stateDiagram-v2
 | `status: blocked`     | Blocked on another issue, decision, or external dependency |
 | `status: duplicate`   | Already exists                                             |
 | `status: invalid`     | Doesn't seem right                                         |
-| `status: wontfix`     | Will not be worked on                                      |
+| `status: wontfix`     | Won't be worked on                                         |
 
 ### Type labels
 


### PR DESCRIPTION
## What

Fixes the red main-push docs lint (run 32676490654).

**Root cause — scoping, not content.** vale-action only splits its `files` input when given a `separator`. With the default (empty) it treated the multiline `website/docs\nwebsite/versioned_docs` string as a single nonexistent path and silently fell back to linting `.` — the whole repo, including `CLAUDE.md`, `specs/`, `.claude/`, and `CHANGELOG.md`, which have never been held to house style. The PR-path step had the same latent bug (tj-actions joins with spaces by default), masked until now because reviewdog's added-lines filter can diff PRs; push events have no diff, so every pre-existing violation surfaced at once.

- Both Vale steps and the changed-files step now pass `separator: "\n"`.
- Fixed the 8 real findings the correctly-scoped scan reports in pages moved by #678: contractions in ADR 011, punctuation-in-quotes in release-branch-protection.md (quoted check names are now backticks, which also reads better), and "Won't be worked on" in triage.md.

## Verification

- Local Vale 3.18.0 (pinned CI version, repo config): `docs versioned_docs` → **0 findings**
- actionlint on docs.yml: clean
- Whole-repo violations outside `website/` remain untouched — they were never meant to be linted here