### PR TITLE
chore(ci): add stale bot to auto-close issues waiting on reporter info

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,20 +1,26 @@
 # Auto-close issues that are waiting on reporter information (#643).
 #
-# Once a day, issues with no activity for 14 days get a warning comment plus
-# a `stale` label; 7 days later they are closed as not planned. Any comment,
-# commit reference, or edit removes the `stale` label and resets the clock,
-# so a reporter who returns keeps their issue open.
+# Two tiers, because untriaged and triaged issues rot on different clocks:
+#
+# Active tier (everything except the triaged backlog): no activity for 14
+# days draws a warning comment plus a `stale` label; 7 days later the issue
+# is closed as not planned. Any comment, commit reference, or edit removes
+# the `stale` label and resets the clock, so a reporter who returns keeps
+# their issue open. In practice this tier sweeps quiet `status: new` issues.
+#
+# Backlog tier (`status: reviewed` only): maintainer-triaged issues wait on
+# a contributor, not the reporter, so they get a much longer leash — warned
+# at 90 days idle, closed 7 days after that. Implemented as a second
+# actions/stale pass scoped with only-issue-labels because one invocation
+# cannot carry two thresholds.
 #
 # Scope is issues only — PRs go stale through review pressure, not this bot.
 #
-# Exemptions:
+# Exemptions (both tiers):
 # - `pinned` and good-first-issue labels never go stale. Both spellings of
 #   good-first-issue are listed because the repo's existing label is
 #   "good first issue" (GitHub's default), while callers often write it
 #   hyphenated; GitHub treats those as distinct labels.
-# - `status: reviewed` is the maintainer-triaged backlog — those issues are
-#   waiting on a contributor, not on the reporter, so they never go stale.
-#   In practice the bot only sweeps `status: new` issues that went quiet.
 # - Issues with any assignee never go stale — an assignee means someone owns
 #   the work, which is the opposite of waiting on the reporter.
 #
@@ -74,7 +80,7 @@ jobs:
             fi
           fi
 
-      - name: Mark and close stale issues
+      - name: Mark and close stale issues (active tier)
         uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           # Issues only: negative PR windows disable PR processing entirely.
@@ -106,3 +112,36 @@ jobs:
             This issue was closed automatically because it had no activity for 21 days and appeared to be waiting on reporter information.
 
             If this is still a problem, comment below or reopen it. Include your SDK version, Go version, and a minimal reproduction so we can pick it up quickly.
+
+      - name: Mark and close stale issues (backlog tier)
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
+        with:
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-stale: 90
+          days-before-issue-close: 7
+
+          # Touch only triaged backlog issues; the active tier above handles
+          # everything else, so the two passes never process the same issue.
+          only-issue-labels: "status: reviewed"
+
+          stale-issue-label: stale
+
+          exempt-issue-labels: "good first issue,good-first-issue,pinned"
+          exempt-all-issue-assignees: true
+
+          close-issue-reason: not_planned
+
+          operations-per-run: 30
+
+          debug-only: ${{ inputs.dry_run == true }}
+
+          stale-issue-message: |
+            This issue was triaged some time ago and has now had no activity for 90 days.
+
+            If it still matters, comment below or remove the `stale` label. If we hear nothing, it closes automatically in 7 days.
+
+          close-issue-message: |
+            This issue was closed automatically because it stayed inactive for 97 days after triage.
+
+            If this is still relevant, comment below or reopen it — ideally with your current SDK version, Go version, and a minimal reproduction.

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,108 @@
+# Auto-close issues that are waiting on reporter information (#643).
+#
+# Once a day, issues with no activity for 14 days get a warning comment plus
+# a `stale` label; 7 days later they are closed as not planned. Any comment,
+# commit reference, or edit removes the `stale` label and resets the clock,
+# so a reporter who returns keeps their issue open.
+#
+# Scope is issues only — PRs go stale through review pressure, not this bot.
+#
+# Exemptions:
+# - `pinned` and good-first-issue labels never go stale. Both spellings of
+#   good-first-issue are listed because the repo's existing label is
+#   "good first issue" (GitHub's default), while callers often write it
+#   hyphenated; GitHub treats those as distinct labels.
+# - `status: reviewed` is the maintainer-triaged backlog — those issues are
+#   waiting on a contributor, not on the reporter, so they never go stale.
+#   In practice the bot only sweeps `status: new` issues that went quiet.
+# - Issues with any assignee never go stale — an assignee means someone owns
+#   the work, which is the opposite of waiting on the reporter.
+#
+# Labels are mutable repo settings with no declarative file form, so the
+# `stale` label is provisioned idempotently here each run (same approach as
+# maintenance-label.yml); actions/stale cannot create labels itself and
+# silently fails to mark issues when its label is missing.
+#
+# Rollout/dry runs: trigger via workflow_dispatch with dry_run checked —
+# the bot logs everything it would do but touches nothing live.
+
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: "30 5 * * *" # daily, off-peak; distinct from Scorecard's Monday slot
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log intended actions without touching live issues
+        type: boolean
+        required: false
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: stale-issues
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    name: Mark and close stale issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write # labels, comments, and closes all live under the Issues API
+    steps:
+      - name: Ensure stale label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent create: "already exists" is success here; any other
+          # failure aborts loudly rather than leaving the bot unable to mark.
+          if ! gh label create "stale" \
+              --repo "$REPO" \
+              --color "EDEDED" \
+              --description "No recent activity; closes in 7 days without an update" ; then
+            if gh label view "stale" --repo "$REPO" >/dev/null 2>&1; then
+              echo "Label 'stale' already exists; continuing."
+            else
+              echo "::error::Failed to create the 'stale' label."
+              exit 1
+            fi
+          fi
+
+      - name: Mark and close stale issues
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
+        with:
+          # Issues only: negative PR windows disable PR processing entirely.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+
+          stale-issue-label: stale
+
+          exempt-issue-labels: "good first issue,good-first-issue,pinned,status: reviewed"
+          exempt-all-issue-assignees: true
+
+          close-issue-reason: not_planned
+
+          # Each mark/close costs ~2 API operations, so this caps a first-run
+          # backlog sweep at roughly half the open issues per day instead of
+          # firing every warning at once.
+          operations-per-run: 30
+
+          debug-only: ${{ inputs.dry_run == true }}
+
+          stale-issue-message: |
+            This issue has had no activity for 14 days, so it may be waiting on information from the reporter.
+
+            If this still affects you, comment with current details — your SDK version, Go version, and a minimal reproduction. If we hear nothing, this issue closes automatically in 7 days.
+
+          close-issue-message: |
+            This issue was closed automatically because it had no activity for 21 days and appeared to be waiting on reporter information.
+
+            If this is still a problem, comment below or reopen it. Include your SDK version, Go version, and a minimal reproduction so we can pick it up quickly.


### PR DESCRIPTION
## What & why

Adds a daily `actions/stale` workflow (`.github/workflows/stale-issues.yml`) that auto-closes issues waiting on reporter information. Closes #643. Part of #472.

**Behavior**
- Warns after **14 days** of inactivity (comment + `stale` label), closes as *not planned* after a further **7-day** grace period
- Close comment includes reopen instructions (comment or reopen, with SDK/Go version and repro)
- Any activity removes the `stale` label and resets the clock

**Exemptions**
- `pinned`, `good first issue`, `good-first-issue` — both spellings exempted because the repo's live label is GitHub's default `good first issue`, while the issue text says `good-first-issue`; GitHub treats them as distinct
- `status: reviewed` — maintainer-triaged backlog waits on a contributor, not the reporter, so the bot effectively only sweeps quiet `status: new` issues
- Any assignee — assigned issues are owned work

**Design notes**
- Issues only: PR stale windows set to `-1`
- The `stale` label is provisioned idempotently each run (`maintenance-label.yml` pattern) because actions/stale cannot create labels and silently no-ops when its label is missing
- `workflow_dispatch` with a `dry_run` input wires into `debug-only` for log-only rollout; `operations-per-run: 30` throttles the first backlog sweep
- Action SHA-pinned to `actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629` (# v10); least privilege (`issues: write` only)

## Type of change

- [ ] `feat` — new or changed exported API surface
- [ ] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [x] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

<!-- Only check items relevant to your change type. -->

- [ ] `gofmt -s -w .` and `golangci-lint run ./...` pass
- [ ] `go test ./...` passes
- [ ] New or changed exported surface has unit tests
- [ ] `website/` is updated (or explain why not below)
- [ ] Code samples use `website/snippets/*.go` region markers, not inline in pages
- [x] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

Go checks are unaffected (no Go changes); `actionlint` passes on all workflows. `website/` is untouched: this repo has no workflow-catalog docs page to update.