### PR TITLE
chore(ci): clear active-work status labels when issues close

### DIFF
--- a/.github/workflows/issue-status-sync.yml
+++ b/.github/workflows/issue-status-sync.yml
@@ -1,29 +1,36 @@
-# Sync issue status labels when PRs open/close.
+# Sync issue status labels when PRs open/close and when issues close.
 #
 # - PR opened/reopened → linked issues get "status: in progress"
 # - PR closed (not merged) → linked issues revert to "status: reviewed"
-# - PR merged → GitHub auto-closes issues natively via "Closes #N"
+# - PR merged → GitHub auto-closes issues natively via "Closes #N";
+#   issue closure then strips active-work status labels
+# - Issue closed (any path) → "status: in progress" / "status: in review" removed
 #
 # Uses mondeja/pr-linked-issues-action for finding linked issues (well-maintained,
 # 1k+ stars), with minimal bash for the label updates.
 #
-# Security: Runs on pull_request_target with author association check.
+# Security: Runs on pull_request_target with author association check;
+# the issues.closed cleanup is self-scoped to the closing issue.
 
 name: Issue Status Sync
 
 on:
   pull_request_target:
     types: [opened, reopened, closed]
+  issues:
+    types: [closed]
 
 permissions: {}
 
+# Event-aware: PR runs serialize per-PR, issue-close runs serialize per-issue.
 concurrency:
-  group: issue-status-sync-${{ github.event.pull_request.number }}
+  group: ${{ github.event_name == 'pull_request_target' && format('issue-status-sync-pr-{0}', github.event.pull_request.number) || format('issue-status-sync-issue-{0}', github.event.issue.number) }}
   cancel-in-progress: false
 
 jobs:
   sync:
     name: Sync Issue Status
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -74,4 +81,24 @@ jobs:
             echo "Reverting issue #$n to reviewed"
             gh issue edit "$n" --repo "$REPO" --remove-label "status: in progress" 2>/dev/null || true
             gh issue edit "$n" --repo "$REPO" --add-label "status: reviewed" 2>/dev/null || true
+          done
+
+  cleanup-closed:
+    name: Clear Active Status on Close
+    if: github.event_name == 'issues' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Remove active-work status labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          for label in "status: in progress" "status: in review"; do
+            echo "Removing '$label' from issue #$NUMBER"
+            gh issue edit "$NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
           done

--- a/.github/workflows/issue-status-sync.yml
+++ b/.github/workflows/issue-status-sync.yml
@@ -4,7 +4,8 @@
 # - PR closed (not merged) → linked issues revert to "status: reviewed"
 # - PR merged → GitHub auto-closes issues natively via "Closes #N";
 #   issue closure then strips active-work status labels
-# - Issue closed (any path) → "status: in progress" / "status: in review" removed
+# - Issue closed (any path) → pipeline status labels removed
+#   ("status: new" / "status: reviewed" / "status: in progress" / "status: in review")
 #
 # Uses mondeja/pr-linked-issues-action for finding linked issues (well-maintained,
 # 1k+ stars), with minimal bash for the label updates.
@@ -91,14 +92,14 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Remove active-work status labels
+      - name: Remove pipeline status labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          for label in "status: in progress" "status: in review"; do
+          for label in "status: new" "status: reviewed" "status: in progress" "status: in review"; do
             echo "Removing '$label' from issue #$NUMBER"
             gh issue edit "$NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
           done


### PR DESCRIPTION
## Problem

`issue-status-sync.yml` moved linked issues from `status: reviewed` to `status: in progress` when a PR opened, but nothing removed status labels when the issue closed — including the merge path, where GitHub auto-closes issues natively via `Closes #N`. Closed issues kept stale workflow-position labels indefinitely ([#661](https://github.com/michaeldcanady/servicenow-sdk-go/issues/661) is an example). The stale bot compounds this systematically: its two tiers close quiet `status: new` and aged `status: reviewed` issues, leaving those labels behind.

The merge path cannot be fixed inside the existing PR-closed job: it discovers linked issues via `mondeja/pr-linked-issues-action` with `include-closed-issues: false`, so by merge time the auto-closed issue is invisible to it.

## Fix

- Add an `issues: [closed]` trigger and a `cleanup-closed` job that strips all pipeline status labels (`status: new`, `status: reviewed`, `status: in progress`, `status: in review`) from the closing issue. This covers every closure path: merged-PR auto-close, manual close, and bot closes.
- Gate the existing `sync` job on `github.event_name == 'pull_request_target'` so the new trigger can't run it without PR context.
- Make the workflow-level concurrency group event-aware (`issue-status-sync-pr-<n>` / `issue-status-sync-issue-<n>`). The previous key read `github.event.pull_request.number`, which is empty on issue events and would have collapsed all close-time runs into one serialized queue.

## Notes

- Forward-looking only; existing stale labels were cleaned up manually in this session (51 closed issues across all four pipeline labels, verified zero remaining).
- Terminal-state descriptors (`status: duplicate`, `status: invalid`, `status: wontfix`, `status: blocked`) are intentionally kept — they describe how an issue ended and align with native `state_reason`; no `status: done`/`merged` label added (native closed state + `state_reason` already encode terminal semantics).

Follow-up to #661.