### PR TITLE
chore(ci): run full CI weekly on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
   workflow_dispatch:
+  # Run the full matrix weekly, independent of PR activity. Tuesdays 03:00 UTC
+  # avoids Scorecard (Mon 01:30), the weekly release (Mon 03:00), e2e-nightly
+  # (daily 04:00), the stale bot (daily 05:30), and CodeQL (Fri 03:00).
+  schedule:
+    - cron: "0 3 * * 2"
   push:
     branches:
       - main
@@ -37,14 +42,18 @@ jobs:
       contents: read
     # Release-please PRs are no longer exempt: they bump version.go (compiled
     # code) and must pass the same gates as any other change before a tag is cut.
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule'
     outputs:
-      code: ${{ steps.filter.outputs.any_changed }}
+      code: ${{ github.event_name == 'schedule' || steps.filter.outputs.any_changed == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Changed Files
+        if: github.event_name != 'schedule'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         id: filter
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ on:
       - ".golangci.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Scheduled runs carry no head_ref or ref, so without the run_id fallback
+  # every weekly run shares one bare group key and cancel-in-progress drops
+  # whichever started first. run_id gives each its own slot; push, PR, and
+  # dispatch grouping are unchanged.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary
- Schedules the whole CI workflow weekly, Tuesdays 03:00 UTC — clear of Scorecard (Mon 01:30), the weekly release (Mon 03:00), e2e-nightly (daily 04:00), the stale bot (daily 05:30), and CodeQL (Fri 03:00).
- Forces the `changes` gate open on `schedule` events: scheduled runs have no diff range, so without this every gated job skips and the run silently looks green.

Closes the missing criteria on #624 (integration tests run weekly, not just per-PR) and #626 (govulncheck runs weekly + per-PR).

Fixes #624
Fixes #626

## Test plan
- YAML parse of `.github/workflows/ci.yml` passes.
- `actionlint .github/workflows/ci.yml` clean.
- `schedule` triggers ignore `paths:` filters, confirming weekly runs fire regardless of activity; path filtering for push/PR untouched.
