### PR TITLE
docs: link issue templates to the lifecycle guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -88,3 +88,8 @@ body:
       description: Related issues, ServiceNow version/plugin config, etc.
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Once you submit, maintainers triage your issue through a standard lifecycle — see the [issue lifecycle guide](https://michaeldcanady.github.io/servicenow-sdk-go/contributing/triage) to learn what happens next.

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -62,3 +62,8 @@ body:
       description: Related issues/PRs, ServiceNow docs links, etc.
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Once you submit, maintainers triage your issue through a standard lifecycle — see the [issue lifecycle guide](https://michaeldcanady.github.io/servicenow-sdk-go/contributing/triage) to learn what happens next.


### PR DESCRIPTION
## Summary
- Appends an identical footer `markdown` element to both public issue templates (bug + feature request) linking to the issue lifecycle guide, so submitters know what happens after filing.
- Completes the last open acceptance criterion of #467 (lifecycle doc itself already lives at `contributing/triage`).

Fixes #467

## Test plan
- Both YAML files parse cleanly and retain required issue-form keys (`name`/`description`/`body`).
- Footer verified identical across templates and placed as the final body element.
