### PR TITLE
docs: document Epic->Story->Task planning hierarchy

### DIFF
--- a/.github/styles/config/vocabularies/Vale/accept.txt
+++ b/.github/styles/config/vocabularies/Vale/accept.txt
@@ -214,3 +214,4 @@ Godog
 (?i)runtimes?('s)?
 (?i)rulesets?
 (?i)codeowners
+(?i)deliverable(s)?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ full contributor documentation lives on the docs site:
   unit, integration, and e2e suites.
 - **[Conventions reference](https://michaeldcanady.github.io/servicenow-sdk-go/contributing/conventions)** —
   the dense field guide reviewers hold PRs to.
+- **[Issue triage](https://michaeldcanady.github.io/servicenow-sdk-go/contributing/triage)** —
+  labels, priority scoring, and the Epic → Story → Task planning hierarchy
+  (maintainers file epics, stories, and tasks from `.github/templates/`).
 
 The two rules most worth knowing before your first PR:
 

--- a/website/docs/contributing/triage.md
+++ b/website/docs/contributing/triage.md
@@ -194,6 +194,42 @@ Revisit an issue's priority when:
 - It's reopened after being closed.
 - A milestone's scope changes.
 
+## Planning hierarchy
+
+Large bodies of work are planned through an Epic → Story → Task hierarchy.
+Each level is a GitHub issue:
+
+- An **epic** tracks a large body of work via its linked stories. It carries
+  the [`type: epic`](#type-labels) label.
+- A **story** delivers one slice of user-visible value toward an epic.
+- A **task** is a single unit of implementable work inside a story.
+
+### Templates
+
+Epics, stories, and tasks are maintainer-only planning artifacts. Maintainers
+file them from the templates in `.github/templates/` — one template per level:
+
+| Template                 | Contents                                                          |
+| ------------------------ | ----------------------------------------------------------------- |
+| `EPIC_TEMPLATE.md`       | Overview, user personas, success criteria, linked stories         |
+| `USER_STORY_TEMPLATE.md` | As-a/I-want/so-that statement, acceptance criteria, linked tasks  |
+| `TASK_TEMPLATE.md`       | Description, task type, sub-tasks, deliverables, parent story     |
+
+You won't find these levels in the public issue chooser. It exposes only two
+forms: **Bug report** and **Feature request** — a feature request becomes a
+story once planning starts. Blank issues are disabled, and questions go to
+[Discussions](https://github.com/michaeldcanady/servicenow-sdk-go/discussions),
+not issues.
+
+### Backlog hygiene
+
+A hierarchy is only useful while it reflects reality:
+
+- Keep `status:` labels current as work moves — see
+  [status labels](#status-labels-workflow-state).
+- Review epics during triage. Close epics whose success criteria are met,
+  and split stale ones into smaller, actionable stories.
+
 ## Quick reference
 
 ### Worked examples


### PR DESCRIPTION
## Summary
- Adds a "Planning hierarchy" section to the triage doc covering the Epic → Story → Task levels, the maintainer-only templates in `.github/templates/`, the two-form public chooser, Discussions routing, and backlog hygiene rules.
- Links that page from root `CONTRIBUTING.md`, resolving the dangling reference in `.github/ISSUE_TEMPLATE/config.yml` ("see /.github/templates/ and CONTRIBUTING.md").

Completes the remaining criterion of #461's process restructure.

Fixes #461

## Test plan
- Anchor targets (`#type-labels`, `#status-labels-workflow-state`) verified against actual headings.
- File references checked to exist; Discussions URL matches config.yml.
- Docs-site routing pattern matches the six existing CONTRIBUTING.md links.
