### PR TITLE
chore(ci): fix ref-version-mismatch findings from online audits

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -79,7 +79,8 @@ jobs:
       pull-requests: write # open backport PRs, comment on the source PR
     steps:
       - name: Checkout repository history
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- backport job must push cherry-pick branches; credential persistence is required and no artifact is uploaded
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # zizmor: ignore[artipacked] -- backport job must push cherry-pick branches; credential persistence is required and no artifact is uploaded
         with:
           # Full history so cherry-picks across main and release branches
           # always find their parent commits.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- check-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- check-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -124,7 +125,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- build-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- build-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -150,7 +152,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- lint-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- lint-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
         with:
           go-version: ${{ matrix.go-version }}
       - name: Run golangci-lint
@@ -183,7 +186,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- test-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- test-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install tparse
@@ -235,7 +239,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- integration-test-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- integration-test-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
         with:
           go-version: "stable"
           cache: true
@@ -262,7 +267,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- tag-gated-test-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- tag-gated-test-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
         with:
           go-version: "stable"
           cache: true

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Vale Linter (full site)
         if: github.event_name != 'pull_request'
-        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # 3.0.0
+        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # v3.0.0
         with:
           fail_on_error: true
           files: website/docs,website/versioned_docs
@@ -127,7 +127,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           steps.changed-md.outputs.any_changed == 'true'
-        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # 3.0.0
+        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # v3.0.0
         with:
           fail_on_error: true
           files: ${{ steps.changed-md.outputs.all_changed_files }}

--- a/.github/workflows/docs-stable.yml
+++ b/.github/workflows/docs-stable.yml
@@ -94,7 +94,7 @@ jobs:
       # vale-action only splits its files input when given one, and the
       # delimiter must survive the runner's input trimming.
       - name: Vale Linter (full site)
-        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # 3.0.0
+        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # v3.0.0
         with:
           fail_on_error: true
           files: website/docs,website/versioned_docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
           requireScope: false
           postErrorComment: false
 
-      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v2
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: always() && steps.lint_title.outputs.error_message != ''
         with:
           header: pr-title-lint-error
@@ -58,7 +58,7 @@ jobs:
             ${{ steps.lint_title.outputs.error_message }}
             ```
 
-      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v2
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: ${{ !cancelled() && steps.lint_title.outputs.error_message == '' }}
         with:
           header: pr-title-lint-error


### PR DESCRIPTION
Prep work for making the zizmor CI gate (#748) a required check: the gate runs with `online-audits` enabled, which resolves pinned SHAs to tags via the GitHub API. That surfaces 12 stale/malformed pin version comments on `main` that offline auditing cannot see — and once the gate becomes a required check on `main`, the branch itself would fail it.

1. **setup-go ×6 (ci.yml) + checkout ×1 (backport.yml)** — the combined `@sha # vX.Y.Z # zizmor: ignore[...] -- reason` comment broke zizmor's whole-string version parse (it wants the entire inline comment to be `vX.Y.Z`). The ignore comment moves to the line below the `uses:` step; the version comment stays on the pin. Both rules are satisfied (the suppression is still honored — verified).
2. **vale-action ×3 (docs-preview ×2, docs-stable ×1)** — `# 3.0.0` → `# v3.0.0`, matching the actual `v3.0.0` tag.
3. **sticky-pull-request-comment ×2 (pr.yml)** — `# v2` → `# v3.0.5`, the tag the pinned SHA (5770ad5e…) actually points to.

**Verification**
- Audited with the gate's exact configuration (auditor persona, `collect: all`, `min-severity: informational`, `min-confidence: low`, `online-audits: true`): **0 findings, 10 ignored** — suppressions unchanged from #749, no new ones.
- `actionlint` clean on all workflows.
- This branch is the same 5-file delta at #748's `1999b449`, *without* the gate workflow (which stays in #748).

**Type of change**
- [ ] `chore` — CI, tooling

**Checklist**
- [x] `VERSION`/`CHANGELOG.md` untouched
- [x] branch name `chore/zizmor-fix-online-version-comments` matches Branch Policy