### PR TITLE
chore(ci): Failed to create the 'stale' label.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -67,6 +67,10 @@ jobs:
       # dry-run promise is that nothing is touched at all. The stale passes
       # below are safe to dry-run because debug-only suppresses all writes.
       - name: Ensure stale label exists
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -67,10 +67,6 @@ jobs:
       # dry-run promise is that nothing is touched at all. The stale passes
       # below are safe to dry-run because debug-only suppresses all writes.
       - name: Ensure stale label exists
-        if: inputs.dry_run != true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -80,7 +76,7 @@ jobs:
               --repo "$REPO" \
               --color "EDEDED" \
               --description "No recent activity; closes in 7 days without an update" ; then
-            if gh label view "stale" --repo "$REPO" >/dev/null 2>&1; then
+            if gh api "repos/$REPO/labels/stale" >/dev/null 2>&1; then
               echo "Label 'stale' already exists; continuing."
             else
               echo "::error::Failed to create the 'stale' label."


### PR DESCRIPTION
<!--
  PR title MUST be a Conventional Commit line — CI lints it and it becomes the squash commit.
  Examples:
    feat(tableapi): add display-value support
    fix(credentials): handle expired refresh token
    chore(ci): update golangci-lint version
    docs: fix broken link in tableapi README
-->

## What & why

<!-- Short description of the change and the problem it solves. Link related issues with "Closes #123". -->

## Type of change

<!-- Check one. This determines which checklist items apply. -->

- [ ] `feat` — new or changed exported API surface
- [X] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [ ] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

<!-- Only check items relevant to your change type. -->

- [ ] `gofmt -s -w .` and `golangci-lint run ./...` pass
- [ ] `go test ./...` passes
- [ ] New or changed exported surface has unit tests
- [ ] `website/` is updated (or explain why not below)
- [ ] Code samples use `website/snippets/*.go` region markers, not inline in pages
- [ ] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

<!-- If docs or tests are intentionally untouched, say why: -->
