### PR TITLE
chore: add license headers to all source files with CI enforcement

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 # Codecov coverage gate. `fail_ci_if_error` in ci.yml only guards the upload
 # itself; these status checks fail the check when coverage regresses.
 # `target: auto` ratchets against the base commit — no hardcoded number to

--- a/.devcontainer/go-cache/install.sh
+++ b/.devcontainer/go-cache/install.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 set -e
 echo "Configuring Go cache persistence..."

--- a/.devcontainer/xdg-utils/install.sh
+++ b/.devcontainer/xdg-utils/install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 set -e
 
 # Use the option from devcontainer-feature.json

--- a/.github/scripts/report-tests.sh
+++ b/.github/scripts/report-tests.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 set -o pipefail
 
 go test -coverprofile=coverage.out -json -v ./... > test-output.json

--- a/.github/workflows/backfill-license.yml
+++ b/.github/workflows/backfill-license.yml
@@ -65,22 +65,49 @@ jobs:
 
       - name: Open license backfill PR
         if: steps.detect.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
+        env:
+          # Matches docs-version.yml: x-access-token injection + gh pr create,
+          # since checkout runs with persist-credentials: false.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
           # Matches branch-policy.yml's <type>/<kebab-description> convention.
-          branch: chore/license-backfill
+          BRANCH="chore/license-backfill"
+
+          # A re-run while a previous backfill PR is still open must degrade
+          # into a green no-op (same pattern as docs-version.yml).
+          open_prs="$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')"
+          if [[ "$open_prs" != "0" ]]; then
+            echo "::notice::A license backfill PR ($BRANCH) is already open; nothing to do."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
           # Conventional-Commits (chore:) so release-please never surfaces the
           # header churn in CHANGELOG.md; the PR title also passes pr.yml.
-          title: "chore: add license headers to source files"
-          commit-message: "chore: add license headers to source files"
-          body: |
-            Automated license-header backfill by `.github/workflows/backfill-license.yml`.
+          git commit -m "chore: add license headers to source files"
 
-            Runs `scripts/add-license.sh` (google/addlicense) over the in-scope
-            source files (`**/*.go`, `**/*.sh`, root `*.yml`/`*.yaml`) and
-            opens this PR whenever the diff is non-empty. Existing headers are
-            never rewritten (addlicense skips files that already carry one);
-            new files receive the current year. No SDK behavior is affected.
+          # A stale remote branch left by a partial failure (push landed, PR
+          # create didn't) would reject the push as non-fast-forward; replace
+          # it since no PR references it anymore.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "--delete" "$BRANCH" 2>/dev/null || true
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH}"
+
+          # The PR body is assembled with printf because a physically
+          # multi-line quoted string here would put an unindented line inside
+          # the run block, which terminates the YAML literal scalar and breaks
+          # the workflow file itself.
+          pr_body="$(printf '%s\n\n%s' \
+            "Automated license-header backfill by \`.github/workflows/backfill-license.yml\`." \
+            "Runs \`scripts/add-license.sh\` (google/addlicense) over the in-scope source files (\`**/*.go\`, \`**/*.sh\`, root \`*.yml\`/\`*.yaml\`) and opens this PR whenever the diff is non-empty. Existing headers are never rewritten (addlicense skips files that already carry one); new files receive the current year. No SDK behavior is affected.")"
           # branch-policy.yml requires either an issue reference or this label.
-          labels: no-issue-required
-          delete-branch: true
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --label "no-issue-required" \
+            --title "chore: add license headers to source files" \
+            --body "$pr_body"

--- a/.github/workflows/backfill-license.yml
+++ b/.github/workflows/backfill-license.yml
@@ -1,0 +1,86 @@
+name: License Header Backfill
+
+# Runs addlicense in apply mode over the in-scope source files (**/*.go,
+# **/*.sh, root *.yml/*.yaml) on the default branch, and opens a PR whenever
+# the diff is non-empty. Never commits in place: ADR 011 requires all
+# main/release changes to arrive by PR (an in-place commit would race
+# release-please and bypass required CI). The bot PR self-validates via the
+# normal CI gates.
+#
+# addlicense skips files that already carry a header, so the one-time 2021
+# backfill is preserved; weekly runs only stamp NEW files with the current
+# year (and catch anything added without a header, e.g. an untracked file
+# pushed directly to a path-filtered CI run).
+#
+# Default branch only: release/vX.Y maintenance lines are excluded — new files
+# there receive headers through their own PR flow, and automation must not
+# push to protected branches.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly Tuesday 06:00 UTC — clear of CI weekly (Tue 03:00), the weekly
+    # release (Mon 03:00), Scorecard (Mon 01:30), zizmor (Mon 05:00),
+    # e2e-nightly (daily 04:00), the stale bot (daily 05:30), and
+    # CodeQL (Fri 03:00).
+    - cron: "0 6 * * 2"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backfill:
+    name: Apply License Headers
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/')
+    permissions:
+      contents: write # push the license-backfill branch
+      pull-requests: write # open the license-backfill PR
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # cache disabled per zizmor cache-poisoning audit (mirrors release-verify.yml)
+        with:
+          go-version: "stable"
+          cache: false
+
+      - name: Apply license headers
+        run: ./scripts/add-license.sh
+
+      - name: Detect changes
+        id: detect
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open license backfill PR
+        if: steps.detect.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          # Matches branch-policy.yml's <type>/<kebab-description> convention.
+          branch: chore/license-backfill
+          # Conventional-Commits (chore:) so release-please never surfaces the
+          # header churn in CHANGELOG.md; the PR title also passes pr.yml.
+          title: "chore: add license headers to source files"
+          commit-message: "chore: add license headers to source files"
+          body: |
+            Automated license-header backfill by `.github/workflows/backfill-license.yml`.
+
+            Runs `scripts/add-license.sh` (google/addlicense) over the in-scope
+            source files (`**/*.go`, `**/*.sh`, root `*.yml`/`*.yaml`) and
+            opens this PR whenever the diff is non-empty. Existing headers are
+            never rewritten (addlicense skips files that already carry one);
+            new files receive the current year. No SDK behavior is affected.
+          # branch-policy.yml requires either an issue reference or this label.
+          labels: no-issue-required
+          delete-branch: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 version: "2"
 run:
   build-tags:
@@ -22,6 +25,7 @@ linters:
     - bodyclose
     - noctx
     - importas
+    - goheader
   settings:
     dupl:
       threshold: 200
@@ -45,7 +49,22 @@ linters:
           alias: internalSerialization
         - pkg: github.com/michaeldcanady/servicenow-sdk-go/internal/store
           alias: internalStore
+    goheader:
+      values:
+        regexp:
+          # Deliberately NOT the builtin {{ YEAR }} (which pins to the current
+          # year and would fail every file annually). A custom regexp means
+          # each file keeps its own static creation year (2021 for the
+          # backfill, current year for new files) with zero annual churn.
+          YEAR: '20\d{2}'
+      # Must match scripts/license-header.tmpl (addlicense output) byte-for-byte:
+      # holder, year, SPDX line order — matched line-for-line against the
+      # leading comment block of each .go file.
+      template: |-
+        Copyright (c) {{ YEAR }} Michael Canady
+        SPDX-License-Identifier: MIT
   exclusions:
+    generated: lax # exclude "// Code generated ... DO NOT EDIT." files (default, stated explicitly)
     rules:
       - linters:
           - dupl
@@ -76,6 +95,12 @@ linters:
       - builtin$
       - examples$
       - docs/assets/snippets/.*\.go$
+      # Defensive: never force a header onto generated files via the path
+      # convention either (the `generated: lax` exclusion already covers
+      # "// Code generated ... DO NOT EDIT." markers).
+      - .*\.gen\.go$
+      - .*_generated\.go$
+      - .*/generated/.*\.go$
 formatters:
   enable:
     - gofmt

--- a/.project-label-sync.yml
+++ b/.project-label-sync.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 project-url: https://github.com/users/michaeldcanady/projects/7
 field: Status
 mapping:

--- a/accountapi/account.go
+++ b/accountapi/account.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_item_request_builder.go
+++ b/accountapi/account_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_item_request_builder_get_request_configuration.go
+++ b/accountapi/account_item_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/accountapi/account_item_request_builder_test.go
+++ b/accountapi/account_item_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_request_builder.go
+++ b/accountapi/account_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_request_builder_get_query_parameters.go
+++ b/accountapi/account_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 // AccountRequestBuilderGetQueryParameters represents the query parameters for a GET request.

--- a/accountapi/account_request_builder_get_request_configuration.go
+++ b/accountapi/account_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/accountapi/account_request_builder_new_test.go
+++ b/accountapi/account_request_builder_new_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_request_builder_test.go
+++ b/accountapi/account_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_response.go
+++ b/accountapi/account_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_response_test.go
+++ b/accountapi/account_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/account_test.go
+++ b/accountapi/account_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/rank_tier.go
+++ b/accountapi/rank_tier.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/accountapi/rank_tier_test.go
+++ b/accountapi/rank_tier_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package accountapi
 
 import (

--- a/activitysubscriptionsapi/act_sub_gaps_test.go
+++ b/activitysubscriptionsapi/act_sub_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/act_sub_models.go
+++ b/activitysubscriptionsapi/act_sub_models.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/act_sub_models_test.go
+++ b/activitysubscriptionsapi/act_sub_models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/act_sub_request_builder.go
+++ b/activitysubscriptionsapi/act_sub_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/act_sub_request_builder_test.go
+++ b/activitysubscriptionsapi/act_sub_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/activities_request_builder.go
+++ b/activitysubscriptionsapi/activities_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/activities_request_builder_get_query_parameters.go
+++ b/activitysubscriptionsapi/activities_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 // ActivitiesRequestBuilderGetQueryParameters defines query parameters for retrieving activity subscriptions.

--- a/activitysubscriptionsapi/activities_request_builder_get_request_configuration.go
+++ b/activitysubscriptionsapi/activities_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/activitysubscriptionsapi/activities_request_builder_test.go
+++ b/activitysubscriptionsapi/activities_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/activity.go
+++ b/activitysubscriptionsapi/activity.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/activity_test.go
+++ b/activitysubscriptionsapi/activity_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/errors.go
+++ b/activitysubscriptionsapi/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import "errors"

--- a/activitysubscriptionsapi/facets_context_request_builder.go
+++ b/activitysubscriptionsapi/facets_context_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/facets_instance_request_builder.go
+++ b/activitysubscriptionsapi/facets_instance_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/facets_instance_request_builder_get_request_configuration.go
+++ b/activitysubscriptionsapi/facets_instance_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/activitysubscriptionsapi/facets_request_builder.go
+++ b/activitysubscriptionsapi/facets_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/facets_request_builder_get_query_parameters.go
+++ b/activitysubscriptionsapi/facets_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 // FacetsRequestBuilderGetQueryParameters defines query parameters for retrieving activity facets.

--- a/activitysubscriptionsapi/field.go
+++ b/activitysubscriptionsapi/field.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/field_test.go
+++ b/activitysubscriptionsapi/field_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/helper.go
+++ b/activitysubscriptionsapi/helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/activitysubscriptionsapi/helper_test.go
+++ b/activitysubscriptionsapi/helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package activitysubscriptionsapi
 
 import (

--- a/aggregationapi/display_value.go
+++ b/aggregationapi/display_value.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/aggregationapi/display_value_test.go
+++ b/aggregationapi/display_value_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/aggregationapi/stats.go
+++ b/aggregationapi/stats.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/aggregationapi/stats_request_builder.go
+++ b/aggregationapi/stats_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/aggregationapi/stats_request_builder_get_query_parameters.go
+++ b/aggregationapi/stats_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 // StatsRequestBuilderGetQueryParameters represents the query parameters for a Stats API GET request.

--- a/aggregationapi/stats_request_builder_get_query_parameters_test.go
+++ b/aggregationapi/stats_request_builder_get_query_parameters_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/aggregationapi/stats_request_builder_get_request_configuration.go
+++ b/aggregationapi/stats_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/aggregationapi/stats_request_builder_test.go
+++ b/aggregationapi/stats_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/aggregationapi/stats_result.go
+++ b/aggregationapi/stats_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/aggregationapi/stats_result_test.go
+++ b/aggregationapi/stats_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/aggregationapi/stats_test.go
+++ b/aggregationapi/stats_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package aggregationapi
 
 import (

--- a/appointmentbookingapi/appointment_booking_request_builder.go
+++ b/appointmentbookingapi/appointment_booking_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/appointment_booking_request_builder_test.go
+++ b/appointmentbookingapi/appointment_booking_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/appointment_request.go
+++ b/appointmentbookingapi/appointment_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/appointment_request_builder.go
+++ b/appointmentbookingapi/appointment_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/appointment_request_test.go
+++ b/appointmentbookingapi/appointment_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/appointment_response.go
+++ b/appointmentbookingapi/appointment_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/appointment_response_test.go
+++ b/appointmentbookingapi/appointment_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/availability_request.go
+++ b/appointmentbookingapi/availability_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/availability_request_builder.go
+++ b/appointmentbookingapi/availability_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/availability_request_builder_post_request_configuration.go
+++ b/appointmentbookingapi/availability_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appointmentbookingapi/availability_request_test.go
+++ b/appointmentbookingapi/availability_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/availability_response.go
+++ b/appointmentbookingapi/availability_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/availability_response_test.go
+++ b/appointmentbookingapi/availability_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/availability_slot.go
+++ b/appointmentbookingapi/availability_slot.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/calendar_request_builder.go
+++ b/appointmentbookingapi/calendar_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/calendar_request_builder_get_query_parameters.go
+++ b/appointmentbookingapi/calendar_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 // CalendarRequestBuilderGetQueryParameters represents the query parameters for GET /calendar.

--- a/appointmentbookingapi/calendar_request_builder_get_request_configuration.go
+++ b/appointmentbookingapi/calendar_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appointmentbookingapi/calendar_response.go
+++ b/appointmentbookingapi/calendar_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi // nolint:dupl // shares field-count shape with UserTimeFormatModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (

--- a/appointmentbookingapi/calendar_response_test.go
+++ b/appointmentbookingapi/calendar_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/configuration_request_builder.go
+++ b/appointmentbookingapi/configuration_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/configuration_request_builder_get_query_parameters.go
+++ b/appointmentbookingapi/configuration_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 // ConfigurationRequestBuilderGetQueryParameters represents the query parameters for GET /configuration.

--- a/appointmentbookingapi/configuration_request_builder_get_request_configuration.go
+++ b/appointmentbookingapi/configuration_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appointmentbookingapi/configuration_response.go
+++ b/appointmentbookingapi/configuration_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/configuration_response_test.go
+++ b/appointmentbookingapi/configuration_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/constants.go
+++ b/appointmentbookingapi/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 const (

--- a/appointmentbookingapi/default_timezone.go
+++ b/appointmentbookingapi/default_timezone.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/enum.go
+++ b/appointmentbookingapi/enum.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/enum_test.go
+++ b/appointmentbookingapi/enum_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/execute_rule_conditions.go
+++ b/appointmentbookingapi/execute_rule_conditions.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/execute_rule_conditions_request_builder.go
+++ b/appointmentbookingapi/execute_rule_conditions_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/execute_rule_conditions_request_builder_post_request_configuration.go
+++ b/appointmentbookingapi/execute_rule_conditions_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appointmentbookingapi/execute_rule_conditions_response.go
+++ b/appointmentbookingapi/execute_rule_conditions_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/execute_rule_conditions_result.go
+++ b/appointmentbookingapi/execute_rule_conditions_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/execute_rule_conditions_test.go
+++ b/appointmentbookingapi/execute_rule_conditions_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/field_mapping.go
+++ b/appointmentbookingapi/field_mapping.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/field_mapping_test.go
+++ b/appointmentbookingapi/field_mapping_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/models_extra_test.go
+++ b/appointmentbookingapi/models_extra_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/nil_guard_extra_test.go
+++ b/appointmentbookingapi/nil_guard_extra_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/rp_variable.go
+++ b/appointmentbookingapi/rp_variable.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi // nolint:dupl // shares field-count shape with UserTimeFormatOptionsModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (

--- a/appointmentbookingapi/rp_variable_test.go
+++ b/appointmentbookingapi/rp_variable_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/service_config.go
+++ b/appointmentbookingapi/service_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/service_config_test.go
+++ b/appointmentbookingapi/service_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/short_month.go
+++ b/appointmentbookingapi/short_month.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/sub_request_builders_post_test.go
+++ b/appointmentbookingapi/sub_request_builders_post_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/sub_request_builders_test.go
+++ b/appointmentbookingapi/sub_request_builders_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/time_format.go
+++ b/appointmentbookingapi/time_format.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/user_date_format_options.go
+++ b/appointmentbookingapi/user_date_format_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/user_time_format.go
+++ b/appointmentbookingapi/user_time_format.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi // nolint:dupl // shares field-count shape with CalendarResponseModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (

--- a/appointmentbookingapi/user_time_format_options.go
+++ b/appointmentbookingapi/user_time_format_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi // nolint:dupl // shares field-count shape with RpVariableModel by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (

--- a/appointmentbookingapi/user_time_format_options_test.go
+++ b/appointmentbookingapi/user_time_format_options_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/user_time_format_test.go
+++ b/appointmentbookingapi/user_time_format_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/user_window_request.go
+++ b/appointmentbookingapi/user_window_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/user_window_request_builder.go
+++ b/appointmentbookingapi/user_window_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/user_window_request_builder_post_request_configuration.go
+++ b/appointmentbookingapi/user_window_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/user_window_response.go
+++ b/appointmentbookingapi/user_window_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/view.go
+++ b/appointmentbookingapi/view.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/view_scale.go
+++ b/appointmentbookingapi/view_scale.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appointmentbookingapi/week_day_short.go
+++ b/appointmentbookingapi/week_day_short.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appointmentbookingapi
 
 import (

--- a/appserviceapi/app_service_action_response.go
+++ b/appserviceapi/app_service_action_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/app_service_action_response_test.go
+++ b/appserviceapi/app_service_action_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/app_service_action_result.go
+++ b/appserviceapi/app_service_action_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/app_service_action_result_test.go
+++ b/appserviceapi/app_service_action_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/app_service_item_request_builder.go
+++ b/appserviceapi/app_service_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/app_service_item_request_builder_test.go
+++ b/appserviceapi/app_service_item_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/app_service_request_builder.go
+++ b/appserviceapi/app_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/app_service_request_builder_test.go
+++ b/appserviceapi/app_service_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/basic_details.go
+++ b/appserviceapi/basic_details.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/basic_details_test.go
+++ b/appserviceapi/basic_details_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/cmdb_group_based_population_method.go
+++ b/appserviceapi/cmdb_group_based_population_method.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/cmdb_group_based_population_method_test.go
+++ b/appserviceapi/cmdb_group_based_population_method_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/constants.go
+++ b/appserviceapi/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 const (

--- a/appserviceapi/convert_to_dynamic_service_request_builder.go
+++ b/appserviceapi/convert_to_dynamic_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/convert_to_dynamic_service_request_builder_test.go
+++ b/appserviceapi/convert_to_dynamic_service_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/convert_to_dynamic_service_request_configuration.go
+++ b/appserviceapi/convert_to_dynamic_service_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/convert_to_manual_service_request_builder.go
+++ b/appserviceapi/convert_to_manual_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/convert_to_manual_service_request_builder_test.go
+++ b/appserviceapi/convert_to_manual_service_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/convert_to_manual_service_request_configuration.go
+++ b/appserviceapi/convert_to_manual_service_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/create_dynamic_service_request_builder.go
+++ b/appserviceapi/create_dynamic_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_dynamic_service_request_builder_test.go
+++ b/appserviceapi/create_dynamic_service_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_dynamic_service_request_configuration.go
+++ b/appserviceapi/create_dynamic_service_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/create_request_builder.go
+++ b/appserviceapi/create_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_request_builder_test.go
+++ b/appserviceapi/create_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_request_configuration.go
+++ b/appserviceapi/create_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_service_response.go
+++ b/appserviceapi/create_service_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_service_response_test.go
+++ b/appserviceapi/create_service_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_service_result.go
+++ b/appserviceapi/create_service_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/create_service_result_test.go
+++ b/appserviceapi/create_service_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/csdm_app_service_item_request_builder.go
+++ b/appserviceapi/csdm_app_service_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/csdm_app_service_item_request_builder_test.go
+++ b/appserviceapi/csdm_app_service_item_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/csdm_request_builder.go
+++ b/appserviceapi/csdm_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/csdm_request_builder_test.go
+++ b/appserviceapi/csdm_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/discovery_population_method.go
+++ b/appserviceapi/discovery_population_method.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/discovery_population_method_attribute.go
+++ b/appserviceapi/discovery_population_method_attribute.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/discovery_population_method_attribute_test.go
+++ b/appserviceapi/discovery_population_method_attribute_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/discovery_population_method_test.go
+++ b/appserviceapi/discovery_population_method_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/find_service_query_parameters.go
+++ b/appserviceapi/find_service_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 // FindServiceQueryParameters represents the query parameters for a find_service request.

--- a/appserviceapi/find_service_request_builder.go
+++ b/appserviceapi/find_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/find_service_request_builder_test.go
+++ b/appserviceapi/find_service_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/find_service_request_configuration.go
+++ b/appserviceapi/find_service_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/find_service_response.go
+++ b/appserviceapi/find_service_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/find_service_response_test.go
+++ b/appserviceapi/find_service_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/find_service_result.go
+++ b/appserviceapi/find_service_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/find_service_result_test.go
+++ b/appserviceapi/find_service_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/get_content_request_builder.go
+++ b/appserviceapi/get_content_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/get_content_request_builder_get_query_parameters.go
+++ b/appserviceapi/get_content_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 // GetContentRequestBuilderGetQueryParameters represents the query parameters for a getContent request.

--- a/appserviceapi/get_content_request_builder_get_request_configuration.go
+++ b/appserviceapi/get_content_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/get_content_request_builder_test.go
+++ b/appserviceapi/get_content_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/get_content_response.go
+++ b/appserviceapi/get_content_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/get_content_response_test.go
+++ b/appserviceapi/get_content_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/get_content_result.go
+++ b/appserviceapi/get_content_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/get_content_result_test.go
+++ b/appserviceapi/get_content_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/helpers_test.go
+++ b/appserviceapi/helpers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import "errors"

--- a/appserviceapi/nil_guard_extra_test.go
+++ b/appserviceapi/nil_guard_extra_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/populate_service_request.go
+++ b/appserviceapi/populate_service_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/populate_service_request_builder.go
+++ b/appserviceapi/populate_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/populate_service_request_builder_test.go
+++ b/appserviceapi/populate_service_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/populate_service_request_configuration.go
+++ b/appserviceapi/populate_service_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/populate_service_request_test.go
+++ b/appserviceapi/populate_service_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/populate_service_response.go
+++ b/appserviceapi/populate_service_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/populate_service_response_test.go
+++ b/appserviceapi/populate_service_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/populate_service_result.go
+++ b/appserviceapi/populate_service_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/population_method.go
+++ b/appserviceapi/population_method.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/population_method_test.go
+++ b/appserviceapi/population_method_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_request.go
+++ b/appserviceapi/register_service_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_request_builder.go
+++ b/appserviceapi/register_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_request_builder_test.go
+++ b/appserviceapi/register_service_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_request_configuration.go
+++ b/appserviceapi/register_service_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/register_service_request_test.go
+++ b/appserviceapi/register_service_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_response.go
+++ b/appserviceapi/register_service_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_response_test.go
+++ b/appserviceapi/register_service_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_result.go
+++ b/appserviceapi/register_service_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/register_service_result_test.go
+++ b/appserviceapi/register_service_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service.go
+++ b/appserviceapi/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_request.go
+++ b/appserviceapi/service_details_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_request_builder.go
+++ b/appserviceapi/service_details_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_request_builder_test.go
+++ b/appserviceapi/service_details_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_request_configuration.go
+++ b/appserviceapi/service_details_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/appserviceapi/service_details_request_test.go
+++ b/appserviceapi/service_details_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_response.go
+++ b/appserviceapi/service_details_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_response_test.go
+++ b/appserviceapi/service_details_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_result.go
+++ b/appserviceapi/service_details_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_details_result_test.go
+++ b/appserviceapi/service_details_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_post_request_builder.go
+++ b/appserviceapi/service_post_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_post_request_builder_test.go
+++ b/appserviceapi/service_post_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_relation.go
+++ b/appserviceapi/service_relation.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_relation_test.go
+++ b/appserviceapi/service_relation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_relationships.go
+++ b/appserviceapi/service_relationships.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_relationships_test.go
+++ b/appserviceapi/service_relationships_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/service_test.go
+++ b/appserviceapi/service_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/tag_list_population_method.go
+++ b/appserviceapi/tag_list_population_method.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/tag_list_population_method_tag.go
+++ b/appserviceapi/tag_list_population_method_tag.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/tag_list_population_method_tag_test.go
+++ b/appserviceapi/tag_list_population_method_tag_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/tag_list_population_method_test.go
+++ b/appserviceapi/tag_list_population_method_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/update_dynamic_number_of_levels_request_builder.go
+++ b/appserviceapi/update_dynamic_number_of_levels_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/update_dynamic_number_of_levels_request_builder_test.go
+++ b/appserviceapi/update_dynamic_number_of_levels_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import (

--- a/appserviceapi/update_dynamic_number_of_levels_request_configuration.go
+++ b/appserviceapi/update_dynamic_number_of_levels_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package appserviceapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/attachmentapi/attachment.go
+++ b/attachmentapi/attachment.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_collection_response.go
+++ b/attachmentapi/attachment_collection_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_collection_response_test.go
+++ b/attachmentapi/attachment_collection_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_file_request_builder.go
+++ b/attachmentapi/attachment_file_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_file_request_builder_post_query_parameters.go
+++ b/attachmentapi/attachment_file_request_builder_post_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 // AttachmentFileRequestBuilderPostQueryParameters represents attachment file post request query parameters

--- a/attachmentapi/attachment_file_request_builder_post_query_parameters_test.go
+++ b/attachmentapi/attachment_file_request_builder_post_query_parameters_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_file_request_builder_post_request_configuration.go
+++ b/attachmentapi/attachment_file_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/attachmentapi/attachment_file_request_builder_test.go
+++ b/attachmentapi/attachment_file_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_item_file_request_builder.go
+++ b/attachmentapi/attachment_item_file_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_item_file_request_builder_get_request_configuration.go
+++ b/attachmentapi/attachment_item_file_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/attachmentapi/attachment_item_file_request_builder_test.go
+++ b/attachmentapi/attachment_item_file_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_item_request_builder.go
+++ b/attachmentapi/attachment_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_item_request_builder_delete_request_configuration.go
+++ b/attachmentapi/attachment_item_request_builder_delete_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/attachmentapi/attachment_item_request_builder_get_request_configuration.go
+++ b/attachmentapi/attachment_item_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/attachmentapi/attachment_item_request_builder_test.go
+++ b/attachmentapi/attachment_item_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_request_builder.go
+++ b/attachmentapi/attachment_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_request_builder_gaps_test.go
+++ b/attachmentapi/attachment_request_builder_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_request_builder_get_query_parameters.go
+++ b/attachmentapi/attachment_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 // AttachmentRequestBuilderGetQueryParameters represents attachment get request query parameters

--- a/attachmentapi/attachment_request_builder_get_request_configuration.go
+++ b/attachmentapi/attachment_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/attachmentapi/attachment_request_builder_test.go
+++ b/attachmentapi/attachment_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_test.go
+++ b/attachmentapi/attachment_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_upload_request_builder.go
+++ b/attachmentapi/attachment_upload_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_upload_request_builder_gaps_test.go
+++ b/attachmentapi/attachment_upload_request_builder_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/attachment_upload_request_builder_post_request_configuration.go
+++ b/attachmentapi/attachment_upload_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/attachmentapi/attachment_upload_request_builder_test.go
+++ b/attachmentapi/attachment_upload_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/file.go
+++ b/attachmentapi/file.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/file_test.go
+++ b/attachmentapi/file_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/file_with_content.go
+++ b/attachmentapi/file_with_content.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/file_with_content_test.go
+++ b/attachmentapi/file_with_content_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/attachmentapi/helper.go
+++ b/attachmentapi/helper.go
@@ -1,1 +1,4 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi

--- a/attachmentapi/media.go
+++ b/attachmentapi/media.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import "github.com/microsoft/kiota-abstractions-go/serialization"

--- a/attachmentapi/media_test.go
+++ b/attachmentapi/media_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package attachmentapi
 
 import (

--- a/batchapi/batch_models_gaps_test.go
+++ b/batchapi/batch_models_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/batch_request.go
+++ b/batchapi/batch_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/batch_request_builder.go
+++ b/batchapi/batch_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/batch_request_builder_get_request_configuration.go
+++ b/batchapi/batch_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/batchapi/batch_request_builder_post_request_configuration.go
+++ b/batchapi/batch_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/batchapi/batch_request_builder_test.go
+++ b/batchapi/batch_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/batch_request_test.go
+++ b/batchapi/batch_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/batch_response.go
+++ b/batchapi/batch_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/batch_response_test.go
+++ b/batchapi/batch_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/mocking_test.go
+++ b/batchapi/mocking_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/rest_request.go
+++ b/batchapi/rest_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/rest_request_gaps_test.go
+++ b/batchapi/rest_request_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/rest_request_header.go
+++ b/batchapi/rest_request_header.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/rest_request_header_test.go
+++ b/batchapi/rest_request_header_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/rest_request_test.go
+++ b/batchapi/rest_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/serviced_request.go
+++ b/batchapi/serviced_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/serviced_request_model.go
+++ b/batchapi/serviced_request_model.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/serviced_request_model_gaps_test.go
+++ b/batchapi/serviced_request_model_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/serviced_request_model_test.go
+++ b/batchapi/serviced_request_model_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/shared.go
+++ b/batchapi/shared.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/batchapi/shared_test.go
+++ b/batchapi/shared_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package batchapi
 
 import (

--- a/caseapi/activities_response.go
+++ b/caseapi/activities_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/core"

--- a/caseapi/activities_result.go
+++ b/caseapi/activities_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/activities_result_entry.go
+++ b/caseapi/activities_result_entry.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/activities_result_entry_attachment.go
+++ b/caseapi/activities_result_entry_attachment.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/activities_result_field.go
+++ b/caseapi/activities_result_field.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/approval.go
+++ b/caseapi/approval.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_activities_request_builder.go
+++ b/caseapi/case_activities_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_activities_request_builder_get_query_parameters.go
+++ b/caseapi/case_activities_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 // CaseActivitiesRequestBuilderGetQueryParameters defines query parameters for retrieving case activities.

--- a/caseapi/case_activities_request_builder_get_request_configuration.go
+++ b/caseapi/case_activities_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/caseapi/case_field_values_request_builder.go
+++ b/caseapi/case_field_values_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_field_values_request_builder_get_query_parameters.go
+++ b/caseapi/case_field_values_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 // CaseFieldValuesRequestBuilderGetQueryParameters represents query parameters for field_values.

--- a/caseapi/case_field_values_request_builder_get_request_configuration.go
+++ b/caseapi/case_field_values_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/caseapi/case_item_request_builder.go
+++ b/caseapi/case_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_item_request_builder_get_query_parameters.go
+++ b/caseapi/case_item_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 // CaseItemRequestBuilderGetQueryParameters defines query parameters for retrieving a single case item.

--- a/caseapi/case_item_request_builder_get_request_configuration.go
+++ b/caseapi/case_item_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/caseapi/case_item_request_builder_put_request_configuration.go
+++ b/caseapi/case_item_request_builder_put_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/caseapi/case_models_test.go
+++ b/caseapi/case_models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_request_builder.go
+++ b/caseapi/case_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_request_builder_get_query_parameters.go
+++ b/caseapi/case_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 // CaseRequestBuilderGetQueryParameters represents the query parameters for GET /case.

--- a/caseapi/case_request_builder_get_request_configuration.go
+++ b/caseapi/case_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/caseapi/case_request_builder_post_request_configuration.go
+++ b/caseapi/case_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/caseapi/case_request_builder_test.go
+++ b/caseapi/case_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_responses.go
+++ b/caseapi/case_responses.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/case_result.go
+++ b/caseapi/case_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/category.go
+++ b/caseapi/category.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/constants.go
+++ b/caseapi/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 const (

--- a/caseapi/customer_service_request_builder.go
+++ b/caseapi/customer_service_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/display_value.go
+++ b/caseapi/display_value.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/caseapi/enum.go
+++ b/caseapi/enum.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/field_values_result.go
+++ b/caseapi/field_values_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/reference.go
+++ b/caseapi/reference.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/caseapi/state.go
+++ b/caseapi/state.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package caseapi
 
 import (

--- a/cdm_request_builder.go
+++ b/cdm_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/cdm_request_builder_test.go
+++ b/cdm_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/cdmapplicationsapi/applications_models_test.go
+++ b/cdmapplicationsapi/applications_models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/applications_request_builder.go
+++ b/cdmapplicationsapi/applications_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/applications_request_builders_config_test.go
+++ b/cdmapplicationsapi/applications_request_builders_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/applications_request_builders_test.go
+++ b/cdmapplicationsapi/applications_request_builders_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/applications_request_builders_wrong_type_test.go
+++ b/cdmapplicationsapi/applications_request_builders_wrong_type_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/collection_upload_request.go
+++ b/cdmapplicationsapi/collection_upload_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi // nolint:dupl // shares field-count shape with ComponentUploadRequest/ExportStatusResult by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (

--- a/cdmapplicationsapi/component_upload_request.go
+++ b/cdmapplicationsapi/component_upload_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi // nolint:dupl // shares field-count shape with CollectionUploadRequest/ExportStatusResult by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (

--- a/cdmapplicationsapi/component_vars_upload_request.go
+++ b/cdmapplicationsapi/component_vars_upload_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/constants.go
+++ b/cdmapplicationsapi/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 const (

--- a/cdmapplicationsapi/deployable_update_response.go
+++ b/cdmapplicationsapi/deployable_update_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/deployables_request_builder.go
+++ b/cdmapplicationsapi/deployables_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/deployables_request_builder_delete_query_parameters.go
+++ b/cdmapplicationsapi/deployables_request_builder_delete_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // DeployablesRequestBuilderDeleteQueryParameters represents query parameters for DELETE /applications/deployables.

--- a/cdmapplicationsapi/deployables_request_builder_delete_request_configuration.go
+++ b/cdmapplicationsapi/deployables_request_builder_delete_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/deployables_request_builder_put_query_parameters.go
+++ b/cdmapplicationsapi/deployables_request_builder_put_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // DeployablesRequestBuilderPutQueryParameters defines query parameters for updating a CDM deployable.

--- a/cdmapplicationsapi/deployables_request_builder_put_request_configuration.go
+++ b/cdmapplicationsapi/deployables_request_builder_put_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_item_content_request_builder.go
+++ b/cdmapplicationsapi/export_item_content_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_item_content_request_builder_get_request_configuration.go
+++ b/cdmapplicationsapi/export_item_content_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_item_request_builder.go
+++ b/cdmapplicationsapi/export_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_item_status_request_builder.go
+++ b/cdmapplicationsapi/export_item_status_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_item_status_request_builder_get_request_configuration.go
+++ b/cdmapplicationsapi/export_item_status_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_result.go
+++ b/cdmapplicationsapi/export_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_status_response.go
+++ b/cdmapplicationsapi/export_status_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/export_status_result.go
+++ b/cdmapplicationsapi/export_status_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi // nolint:dupl // shares field-count shape with CollectionUploadRequest/ComponentUploadRequest by coincidence, not copy-paste; distinct API concept, not worth sacrificing named accessors for
 
 import (

--- a/cdmapplicationsapi/exports_request_builder.go
+++ b/cdmapplicationsapi/exports_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/exports_request_builder_get_query_parameters.go
+++ b/cdmapplicationsapi/exports_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // ExportsRequestBuilderGetQueryParameters represents the GET query parameters for the Exports resource.

--- a/cdmapplicationsapi/exports_request_builder_get_request_configuration.go
+++ b/cdmapplicationsapi/exports_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/exports_response.go
+++ b/cdmapplicationsapi/exports_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/media.go
+++ b/cdmapplicationsapi/media.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/reference.go
+++ b/cdmapplicationsapi/reference.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_component_update_request.go
+++ b/cdmapplicationsapi/shared_component_update_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_component_update_response.go
+++ b/cdmapplicationsapi/shared_component_update_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_components_request_builder.go
+++ b/cdmapplicationsapi/shared_components_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_components_request_builder_delete_query_parameters.go
+++ b/cdmapplicationsapi/shared_components_request_builder_delete_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // SharedComponentsRequestBuilderDeleteQueryParameters represents query parameters for DELETE /applications/shared_components.

--- a/cdmapplicationsapi/shared_components_request_builder_delete_request_configuration.go
+++ b/cdmapplicationsapi/shared_components_request_builder_delete_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_components_request_builder_put_query_parameters.go
+++ b/cdmapplicationsapi/shared_components_request_builder_put_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // SharedComponentsRequestBuilderPutQueryParameters defines query parameters for updating a CDM shared component.

--- a/cdmapplicationsapi/shared_components_request_builder_put_request_configuration.go
+++ b/cdmapplicationsapi/shared_components_request_builder_put_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_libraries_components_applications_request_builder.go
+++ b/cdmapplicationsapi/shared_libraries_components_applications_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_libraries_components_applications_request_builder_get_query_parameters.go
+++ b/cdmapplicationsapi/shared_libraries_components_applications_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // SharedLibrariesComponentsApplicationsRequestBuilderGetQueryParameters represents the GET query parameters for the Shared Libraries Components Applications resource.

--- a/cdmapplicationsapi/shared_libraries_components_applications_request_builder_get_request_configuration.go
+++ b/cdmapplicationsapi/shared_libraries_components_applications_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_libraries_components_applications_response.go
+++ b/cdmapplicationsapi/shared_libraries_components_applications_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_libraries_components_request_builder.go
+++ b/cdmapplicationsapi/shared_libraries_components_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_libraries_request_builder.go
+++ b/cdmapplicationsapi/shared_libraries_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/shared_library_component_application.go
+++ b/cdmapplicationsapi/shared_library_component_application.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/upload_status_item_request_builder.go
+++ b/cdmapplicationsapi/upload_status_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/upload_status_item_request_builder_get_request_configuration.go
+++ b/cdmapplicationsapi/upload_status_item_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/upload_status_output.go
+++ b/cdmapplicationsapi/upload_status_output.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/upload_status_request_builder.go
+++ b/cdmapplicationsapi/upload_status_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/upload_status_response.go
+++ b/cdmapplicationsapi/upload_status_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/upload_status_result.go
+++ b/cdmapplicationsapi/upload_status_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_collections_file_request_builder.go
+++ b/cdmapplicationsapi/uploads_collections_file_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //nolint:dupl // per-verb request-builder methods share the mandatory nil-guard/send boilerplate by convention; each depends on its own outer type, response type, and discriminator factory, so it can't be extracted into a shared helper
 package cdmapplicationsapi
 

--- a/cdmapplicationsapi/uploads_collections_file_request_builder_post_query_parameters.go
+++ b/cdmapplicationsapi/uploads_collections_file_request_builder_post_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // UploadsCollectionsFileRequestBuilderPostQueryParameters represents the POST query parameters for the Uploads Collections File resource.

--- a/cdmapplicationsapi/uploads_collections_file_request_builder_post_request_configuration.go
+++ b/cdmapplicationsapi/uploads_collections_file_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_collections_request_builder.go
+++ b/cdmapplicationsapi/uploads_collections_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //nolint:dupl // per-verb request-builder methods share the mandatory nil-guard/send boilerplate by convention; each depends on its own outer type, response type, and discriminator factory, so it can't be extracted into a shared helper
 package cdmapplicationsapi
 

--- a/cdmapplicationsapi/uploads_collections_request_builder_post_request_configuration.go
+++ b/cdmapplicationsapi/uploads_collections_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_components_request_builder.go
+++ b/cdmapplicationsapi/uploads_components_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //nolint:dupl // per-verb request-builder methods share the mandatory nil-guard/send boilerplate by convention; each depends on its own outer type, response type, and discriminator factory, so it can't be extracted into a shared helper
 package cdmapplicationsapi
 

--- a/cdmapplicationsapi/uploads_components_request_builder_post_request_configuration.go
+++ b/cdmapplicationsapi/uploads_components_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_components_vars_request_builder.go
+++ b/cdmapplicationsapi/uploads_components_vars_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_components_vars_request_builder_post_request_configuration.go
+++ b/cdmapplicationsapi/uploads_components_vars_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_deployables_file_request_builder.go
+++ b/cdmapplicationsapi/uploads_deployables_file_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //nolint:dupl // per-verb request-builder methods share the mandatory nil-guard/send boilerplate by convention; each depends on its own outer type, response type, and discriminator factory, so it can't be extracted into a shared helper
 package cdmapplicationsapi
 

--- a/cdmapplicationsapi/uploads_deployables_file_request_builder_post_query_parameters.go
+++ b/cdmapplicationsapi/uploads_deployables_file_request_builder_post_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 // UploadsDeployablesFileRequestBuilderPostQueryParameters represents the POST query parameters for the Uploads Deployables File resource.

--- a/cdmapplicationsapi/uploads_deployables_file_request_builder_post_request_configuration.go
+++ b/cdmapplicationsapi/uploads_deployables_file_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_deployables_request_builder.go
+++ b/cdmapplicationsapi/uploads_deployables_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmapplicationsapi/uploads_request_builder.go
+++ b/cdmapplicationsapi/uploads_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmapplicationsapi
 
 import (

--- a/cdmchangesetapi/change_set_activity_result.go
+++ b/cdmchangesetapi/change_set_activity_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/change_set_result.go
+++ b/cdmchangesetapi/change_set_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/changeset_models_test.go
+++ b/cdmchangesetapi/changeset_models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/changeset_request_builders.go
+++ b/cdmchangesetapi/changeset_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //nolint:dupl // per-verb request-builder methods share the mandatory nil-guard/send boilerplate by convention; each depends on its own outer type, response type, and discriminator factory, so it can't be extracted into a shared helper
 package cdmchangesetapi
 

--- a/cdmchangesetapi/changeset_request_builders_config_test.go
+++ b/cdmchangesetapi/changeset_request_builders_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/changeset_request_builders_test.go
+++ b/cdmchangesetapi/changeset_request_builders_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/changeset_request_builders_wrong_type_test.go
+++ b/cdmchangesetapi/changeset_request_builders_wrong_type_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/changeset_request_configurations.go
+++ b/cdmchangesetapi/changeset_request_configurations.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/changeset_responses.go
+++ b/cdmchangesetapi/changeset_responses.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/commit_status_result.go
+++ b/cdmchangesetapi/commit_status_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/constants.go
+++ b/cdmchangesetapi/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 const (

--- a/cdmchangesetapi/impacted_deployable_by_sys_id_result.go
+++ b/cdmchangesetapi/impacted_deployable_by_sys_id_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/impacted_deployable_result.go
+++ b/cdmchangesetapi/impacted_deployable_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/impacted_shared_component_result.go
+++ b/cdmchangesetapi/impacted_shared_component_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmchangesetapi/reference.go
+++ b/cdmchangesetapi/reference.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmchangesetapi
 
 import (

--- a/cdmeditorapi/constants.go
+++ b/cdmeditorapi/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 const (

--- a/cdmeditorapi/editor_models.go
+++ b/cdmeditorapi/editor_models.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/editor_models_test.go
+++ b/cdmeditorapi/editor_models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/editor_request_builders.go
+++ b/cdmeditorapi/editor_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //nolint:dupl // per-verb request-builder methods share the mandatory nil-guard/send boilerplate by convention; each depends on its own outer type, response type, and discriminator factory, so it can't be extracted into a shared helper
 package cdmeditorapi
 

--- a/cdmeditorapi/editor_request_builders_gaps_test.go
+++ b/cdmeditorapi/editor_request_builders_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/editor_request_builders_test.go
+++ b/cdmeditorapi/editor_request_builders_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/editor_request_builders_wrong_type_test.go
+++ b/cdmeditorapi/editor_request_builders_wrong_type_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/editor_request_configurations.go
+++ b/cdmeditorapi/editor_request_configurations.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/editor_responses.go
+++ b/cdmeditorapi/editor_responses.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/node_create_request.go
+++ b/cdmeditorapi/node_create_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/node_result.go
+++ b/cdmeditorapi/node_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/node_update_request_model.go
+++ b/cdmeditorapi/node_update_request_model.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cdmeditorapi/validate_result.go
+++ b/cdmeditorapi/validate_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cdmeditorapi
 
 import (

--- a/cmdbinstanceapi/cmdb_class_request_builder.go
+++ b/cmdbinstanceapi/cmdb_class_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_class_request_builder_configurations.go
+++ b/cmdbinstanceapi/cmdb_class_request_builder_configurations.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_class_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_class_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_instance.go
+++ b/cmdbinstanceapi/cmdb_instance.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_instance_request_builder.go
+++ b/cmdbinstanceapi/cmdb_instance_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_instance_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_instance_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_instance_test.go
+++ b/cmdbinstanceapi/cmdb_instance_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_item_request_builder.go
+++ b/cmdbinstanceapi/cmdb_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_item_request_builder_configurations.go
+++ b/cmdbinstanceapi/cmdb_item_request_builder_configurations.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_item_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_item_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_relation_item_request_builder.go
+++ b/cmdbinstanceapi/cmdb_relation_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_relation_item_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_relation_item_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_relation_request_builder.go
+++ b/cmdbinstanceapi/cmdb_relation_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_relation_request_builder_configurations.go
+++ b/cmdbinstanceapi/cmdb_relation_request_builder_configurations.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_relation_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_relation_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_request_builder.go
+++ b/cmdbinstanceapi/cmdb_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/cmdbinstanceapi/cmdb_request_builder_test.go
+++ b/cmdbinstanceapi/cmdb_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package cmdbinstanceapi
 
 import (

--- a/core/backed_model.go
+++ b/core/backed_model.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/base_model.go
+++ b/core/base_model.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/base_model_options.go
+++ b/core/base_model_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/base_model_options_test.go
+++ b/core/base_model_options_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/base_model_test.go
+++ b/core/base_model_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/base_request_builder.go
+++ b/core/base_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/base_request_builder_test.go
+++ b/core/base_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/doc.go
+++ b/core/doc.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 // Package core provides the fundamental abstractions and base types for the ServiceNow SDK.

--- a/core/main_error.go
+++ b/core/main_error.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/main_error_test.go
+++ b/core/main_error_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/model.go
+++ b/core/model.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/page_iterator.go
+++ b/core/page_iterator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/page_iterator_options.go
+++ b/core/page_iterator_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/page_iterator_test.go
+++ b/core/page_iterator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/page_result.go
+++ b/core/page_result.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/page_result_test.go
+++ b/core/page_result_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/paging.go
+++ b/core/paging.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/paging_test.go
+++ b/core/paging_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/request_builder_shapes.go
+++ b/core/request_builder_shapes.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_collection_response.go
+++ b/core/service_now_collection_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_collection_response_test.go
+++ b/core/service_now_collection_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_error.go
+++ b/core/service_now_error.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_error_test.go
+++ b/core/service_now_error_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_item_response.go
+++ b/core/service_now_item_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_item_response_test.go
+++ b/core/service_now_item_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_response.go
+++ b/core/service_now_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/service_now_response_test.go
+++ b/core/service_now_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/credentials/access_token.go
+++ b/credentials/access_token.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import "time"

--- a/credentials/access_token_test.go
+++ b/credentials/access_token_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/auth_options.go
+++ b/credentials/auth_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/auth_options_test.go
+++ b/credentials/auth_options_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/authentication_provider_test.go
+++ b/credentials/authentication_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/authority.go
+++ b/credentials/authority.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 // Authority represents the base URL for the ServiceNow instance.

--- a/credentials/authority_test.go
+++ b/credentials/authority_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/authorization_code_credential.go
+++ b/credentials/authorization_code_credential.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/authorization_code_credential_test.go
+++ b/credentials/authorization_code_credential_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/base_access_token_provider.go
+++ b/credentials/base_access_token_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/base_access_token_provider_test.go
+++ b/credentials/base_access_token_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/basic_authentication_provider.go
+++ b/credentials/basic_authentication_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/basic_authentication_provider_test.go
+++ b/credentials/basic_authentication_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/bearer_token_authentication_provider.go
+++ b/credentials/bearer_token_authentication_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/bearer_token_authentication_provider_test.go
+++ b/credentials/bearer_token_authentication_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/client.go
+++ b/credentials/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/client_credentials_credential.go
+++ b/credentials/client_credentials_credential.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/client_credentials_credential_test.go
+++ b/credentials/client_credentials_credential_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/client_options.go
+++ b/credentials/client_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/client_options_test.go
+++ b/credentials/client_options_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/client_test.go
+++ b/credentials/client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/confidential_client.go
+++ b/credentials/confidential_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/confidential_client_test.go
+++ b/credentials/confidential_client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/error.go
+++ b/credentials/error.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/credentials/error_test.go
+++ b/credentials/error_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/helper.go
+++ b/credentials/helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/helper_test.go
+++ b/credentials/helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/jwt_credential.go
+++ b/credentials/jwt_credential.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/jwt_credential_test.go
+++ b/credentials/jwt_credential_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/mocking_test.go
+++ b/credentials/mocking_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/preparable.go
+++ b/credentials/preparable.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 // Preparable is an interface for authentication providers or token providers

--- a/credentials/public_client.go
+++ b/credentials/public_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/public_client_test.go
+++ b/credentials/public_client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/redirect_server.go
+++ b/credentials/redirect_server.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/redirect_server_test.go
+++ b/credentials/redirect_server_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/ropc_credential.go
+++ b/credentials/ropc_credential.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/ropc_credential_adapter.go
+++ b/credentials/ropc_credential_adapter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import "context"

--- a/credentials/ropc_credential_adapter_test.go
+++ b/credentials/ropc_credential_adapter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/ropc_credential_test.go
+++ b/credentials/ropc_credential_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/credentials/token_store.go
+++ b/credentials/token_store.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import "context"

--- a/credentials/validator_test.go
+++ b/credentials/validator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package credentials
 
 import (

--- a/documentsapi/action_request_builder.go
+++ b/documentsapi/action_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/action_request_builder_test.go
+++ b/documentsapi/action_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/attach_request_builder.go
+++ b/documentsapi/attach_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/attach_request_builder_post_request_configuration.go
+++ b/documentsapi/attach_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/attach_request_builder_test.go
+++ b/documentsapi/attach_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/content_request_builder.go
+++ b/documentsapi/content_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/content_request_builder_get_request_configuration.go
+++ b/documentsapi/content_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/content_request_builder_test.go
+++ b/documentsapi/content_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/create_document_request_builder.go
+++ b/documentsapi/create_document_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/create_document_request_builder_post_request_configuration.go
+++ b/documentsapi/create_document_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/create_document_request_builder_test.go
+++ b/documentsapi/create_document_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/create_request_builder.go
+++ b/documentsapi/create_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/create_request_builder_post_request_configuration.go
+++ b/documentsapi/create_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/create_request_builder_test.go
+++ b/documentsapi/create_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/delete_request_builder.go
+++ b/documentsapi/delete_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/delete_request_builder_delete_request_configuration.go
+++ b/documentsapi/delete_request_builder_delete_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/delete_request_builder_test.go
+++ b/documentsapi/delete_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/document.go
+++ b/documentsapi/document.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/document_get_request_builder.go
+++ b/documentsapi/document_get_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/document_get_request_builder_test.go
+++ b/documentsapi/document_get_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/document_post_request_builder.go
+++ b/documentsapi/document_post_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/document_post_request_builder_test.go
+++ b/documentsapi/document_post_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/document_test.go
+++ b/documentsapi/document_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/documents_request_builder.go
+++ b/documentsapi/documents_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/documents_request_builder_test.go
+++ b/documentsapi/documents_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/explore_request_builder.go
+++ b/documentsapi/explore_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/explore_request_builder_get_request_configuration.go
+++ b/documentsapi/explore_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/explore_request_builder_test.go
+++ b/documentsapi/explore_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/sync_down_request_builder.go
+++ b/documentsapi/sync_down_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/sync_down_request_builder_post_request_configuration.go
+++ b/documentsapi/sync_down_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/sync_down_request_builder_test.go
+++ b/documentsapi/sync_down_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/version_action_request_builder_patch_request_configuration.go
+++ b/documentsapi/version_action_request_builder_patch_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/version_state_request_builder.go
+++ b/documentsapi/version_state_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/version_state_request_builder_get_request_configuration.go
+++ b/documentsapi/version_state_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/version_state_request_builder_test.go
+++ b/documentsapi/version_state_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/versions_request_builder.go
+++ b/documentsapi/versions_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/versions_request_builder_get_request_configuration.go
+++ b/documentsapi/versions_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/documentsapi/versions_request_builder_test.go
+++ b/documentsapi/versions_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package documentsapi
 
 import (

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package errors // nolint: revive // renaming this public package would be a breaking API change; see CLAUDE.md's error-sentinel layout
 
 import "errors"

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package errors_test
 
 import (

--- a/internal/Mutex.go
+++ b/internal/Mutex.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 type Mutex interface {

--- a/internal/ast/array_node.go
+++ b/internal/ast/array_node.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 // ArrayNode represents a list of values, typically used for IN/NOT IN.

--- a/internal/ast/array_node_test.go
+++ b/internal/ast/array_node_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/binary_node.go
+++ b/internal/ast/binary_node.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 // BinaryNode represents a binary operation (e.g., field=value, fieldLIKEvalue).

--- a/internal/ast/binary_node_test.go
+++ b/internal/ast/binary_node_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/literal_node.go
+++ b/internal/ast/literal_node.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/literal_node_test.go
+++ b/internal/ast/literal_node_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/node.go
+++ b/internal/ast/node.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 // Node represents a node in the ServiceNow encoded query AST.

--- a/internal/ast/operator.go
+++ b/internal/ast/operator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/internal/ast/operator_test.go
+++ b/internal/ast/operator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/pair_node.go
+++ b/internal/ast/pair_node.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 // PairNode represents a pair of values, typically used for BETWEEN.

--- a/internal/ast/pair_node_test.go
+++ b/internal/ast/pair_node_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/primitive.go
+++ b/internal/ast/primitive.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 // Primitive represents any base type.

--- a/internal/ast/stringer.go
+++ b/internal/ast/stringer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/stringer_test.go
+++ b/internal/ast/stringer_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/unary_node.go
+++ b/internal/ast/unary_node.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 // UnaryNode represents a unary operation (e.g., fieldISEMPTY).

--- a/internal/ast/unary_node_test.go
+++ b/internal/ast/unary_node_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 import (

--- a/internal/ast/visitor.go
+++ b/internal/ast/visitor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package ast
 
 // Visitor represents a visitor for the AST.

--- a/internal/concurrent_dictionary.go
+++ b/internal/concurrent_dictionary.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/concurrent_dictionary_test.go
+++ b/internal/concurrent_dictionary_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/const.go
+++ b/internal/const.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 const (

--- a/internal/conversion/collection.go
+++ b/internal/conversion/collection.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import "fmt"

--- a/internal/conversion/collection_test.go
+++ b/internal/conversion/collection_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/conversion.go
+++ b/internal/conversion/conversion.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/conversion_test.go
+++ b/internal/conversion/conversion_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/enum.go
+++ b/internal/conversion/enum.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 // EnumString looks up v in m and returns the matching string, or fallback if v has no entry.

--- a/internal/conversion/enum_test.go
+++ b/internal/conversion/enum_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/helper.go
+++ b/internal/conversion/helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/helper_test.go
+++ b/internal/conversion/helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/mutator.go
+++ b/internal/conversion/mutator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 type Mutator[T, S any] func(input T) (S, error)

--- a/internal/conversion/numeric_range.go
+++ b/internal/conversion/numeric_range.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/numeric_range_test.go
+++ b/internal/conversion/numeric_range_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/type_converter.go
+++ b/internal/conversion/type_converter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/conversion/type_converter_test.go
+++ b/internal/conversion/type_converter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package conversion
 
 import (

--- a/internal/deserializer.go
+++ b/internal/deserializer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import "github.com/microsoft/kiota-abstractions-go/serialization"

--- a/internal/dictionary.go
+++ b/internal/dictionary.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 // Dictionary interface definition

--- a/internal/enum.go
+++ b/internal/enum.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 // Enum represents a generic enumeration interface.

--- a/internal/error_registry.go
+++ b/internal/error_registry.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/error_registry_test.go
+++ b/internal/error_registry_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build preview.query
 
 package internal

--- a/internal/error_thrower.go
+++ b/internal/error_thrower.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 type ErrorThrower interface {

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/helper_test.go
+++ b/internal/helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/http/content_type.go
+++ b/internal/http/content_type.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/content_type_test.go
+++ b/internal/http/content_type_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/header_http.go
+++ b/internal/http/header_http.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 type HTTPHeader int64

--- a/internal/http/header_http_test.go
+++ b/internal/http/header_http_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/header_request.go
+++ b/internal/http/header_request.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 // RequestHeader A request header is an HTTP header that can be used in an HTTP request to provide information about

--- a/internal/http/header_request_test.go
+++ b/internal/http/header_request_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/mocking_test.go
+++ b/internal/http/mocking_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import "github.com/stretchr/testify/mock"

--- a/internal/http/servicenow_client_config.go
+++ b/internal/http/servicenow_client_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_client_config_test.go
+++ b/internal/http/servicenow_client_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_client_option.go
+++ b/internal/http/servicenow_client_option.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_client_option_test.go
+++ b/internal/http/servicenow_client_option_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_request_adapter.go
+++ b/internal/http/servicenow_request_adapter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_request_adapter_config.go
+++ b/internal/http/servicenow_request_adapter_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_request_adapter_config_test.go
+++ b/internal/http/servicenow_request_adapter_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_request_adapter_option.go
+++ b/internal/http/servicenow_request_adapter_option.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_request_adapter_option_test.go
+++ b/internal/http/servicenow_request_adapter_option_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/http/servicenow_request_adapter_test.go
+++ b/internal/http/servicenow_request_adapter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internalhttp
 
 import (

--- a/internal/kiota_deserializer.go
+++ b/internal/kiota_deserializer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import "github.com/microsoft/kiota-abstractions-go/serialization"

--- a/internal/mocking/mock_authentication_provider.go
+++ b/internal/mocking/mock_authentication_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_backing_store.go
+++ b/internal/mocking/mock_backing_store.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_backing_store_factory.go
+++ b/internal/mocking/mock_backing_store_factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_backing_store_setter.go
+++ b/internal/mocking/mock_backing_store_setter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_batch_header.go
+++ b/internal/mocking/mock_batch_header.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_context.go
+++ b/internal/mocking/mock_context.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_credential.go
+++ b/internal/mocking/mock_credential.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import "github.com/stretchr/testify/mock"

--- a/internal/mocking/mock_deserializer.go
+++ b/internal/mocking/mock_deserializer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_dictionary.go
+++ b/internal/mocking/mock_dictionary.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import "github.com/stretchr/testify/mock"

--- a/internal/mocking/mock_enum_factory.go
+++ b/internal/mocking/mock_enum_factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_file.go
+++ b/internal/mocking/mock_file.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_http_client.go
+++ b/internal/mocking/mock_http_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_main_error.go
+++ b/internal/mocking/mock_main_error.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import "github.com/microsoft/kiota-abstractions-go/store"

--- a/internal/mocking/mock_middleware.go
+++ b/internal/mocking/mock_middleware.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_model.go
+++ b/internal/mocking/mock_model.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_option.go
+++ b/internal/mocking/mock_option.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import "github.com/stretchr/testify/mock"

--- a/internal/mocking/mock_parsable.go
+++ b/internal/mocking/mock_parsable.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_parsable_error.go
+++ b/internal/mocking/mock_parsable_error.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_parsable_factory.go
+++ b/internal/mocking/mock_parsable_factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_parse_node.go
+++ b/internal/mocking/mock_parse_node.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_parse_node_factory.go
+++ b/internal/mocking/mock_parse_node_factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_request_adapter.go
+++ b/internal/mocking/mock_request_adapter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_request_builder.go
+++ b/internal/mocking/mock_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_request_option.go
+++ b/internal/mocking/mock_request_option.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_serialization_writer.go
+++ b/internal/mocking/mock_serialization_writer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_serialization_writer_factory.go
+++ b/internal/mocking/mock_serialization_writer_factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_service_now_collection_response.go
+++ b/internal/mocking/mock_service_now_collection_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/mock_service_now_item_response.go
+++ b/internal/mocking/mock_service_now_item_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/request_adapter_test.go
+++ b/internal/mocking/request_adapter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/mocking/response_handler.go
+++ b/internal/mocking/response_handler.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mocking
 
 import (

--- a/internal/model/service_now_item.go
+++ b/internal/model/service_now_item.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package model
 
 import (

--- a/internal/model_setter.go
+++ b/internal/model_setter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 type ModelSetter[T any] func(val T) error

--- a/internal/nil_pointer_error.go
+++ b/internal/nil_pointer_error.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/internal/nil_pointer_error_test.go
+++ b/internal/nil_pointer_error_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/oauth2/auth_method.go
+++ b/internal/oauth2/auth_method.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 // Package oauth2 provides a spec-compliant OAuth2 client for various grant types.
 package oauth2
 

--- a/internal/oauth2/auth_method_test.go
+++ b/internal/oauth2/auth_method_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/client.go
+++ b/internal/oauth2/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/client_credentials_exchanger.go
+++ b/internal/oauth2/client_credentials_exchanger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/client_test.go
+++ b/internal/oauth2/client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/code_exchanger.go
+++ b/internal/oauth2/code_exchanger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/constants.go
+++ b/internal/oauth2/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 // --------------------

--- a/internal/oauth2/device.go
+++ b/internal/oauth2/device.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 // DeviceAuthorizationResponse represents the response from the device authorization endpoint (RFC 8628).

--- a/internal/oauth2/device_authorization_requester.go
+++ b/internal/oauth2/device_authorization_requester.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/device_code_exchanger.go
+++ b/internal/oauth2/device_code_exchanger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/endpoints.go
+++ b/internal/oauth2/endpoints.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/endpoints_test.go
+++ b/internal/oauth2/endpoints_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/exchanger.go
+++ b/internal/oauth2/exchanger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/http_client.go
+++ b/internal/oauth2/http_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "net/http"

--- a/internal/oauth2/introspection.go
+++ b/internal/oauth2/introspection.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 // IntrospectionResponse represents the response from the token introspection endpoint (RFC 7662).

--- a/internal/oauth2/introspector.go
+++ b/internal/oauth2/introspector.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/jwt_exchanger.go
+++ b/internal/oauth2/jwt_exchanger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/password_exchanger.go
+++ b/internal/oauth2/password_exchanger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/pkce/challenger.go
+++ b/internal/oauth2/pkce/challenger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 import "errors"

--- a/internal/oauth2/pkce/challenger_test.go
+++ b/internal/oauth2/pkce/challenger_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 import (

--- a/internal/oauth2/pkce/method_test.go
+++ b/internal/oauth2/pkce/method_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 import (

--- a/internal/oauth2/pkce/pkce_method.go
+++ b/internal/oauth2/pkce/pkce_method.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 type Method int

--- a/internal/oauth2/pkce/plain_challenger.go
+++ b/internal/oauth2/pkce/plain_challenger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 type PlainChallenger struct{}

--- a/internal/oauth2/pkce/s256_challenger.go
+++ b/internal/oauth2/pkce/s256_challenger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 import (

--- a/internal/oauth2/pkce/verifier_generator.go
+++ b/internal/oauth2/pkce/verifier_generator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 import (

--- a/internal/oauth2/pkce/verifier_generator_test.go
+++ b/internal/oauth2/pkce/verifier_generator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package pkce
 
 import (

--- a/internal/oauth2/refresh_token_exchanger.go
+++ b/internal/oauth2/refresh_token_exchanger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/revoker.go
+++ b/internal/oauth2/revoker.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import "context"

--- a/internal/oauth2/server.go
+++ b/internal/oauth2/server.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/server_test.go
+++ b/internal/oauth2/server_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/token.go
+++ b/internal/oauth2/token.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 // Token represents an OAuth2 access token and its associated metadata.

--- a/internal/oauth2/token_error.go
+++ b/internal/oauth2/token_error.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/oauth2/token_error_test.go
+++ b/internal/oauth2/token_error_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package oauth2
 
 import (

--- a/internal/option.go
+++ b/internal/option.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/internal/option_test.go
+++ b/internal/option_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/serialization/deserializer_func.go
+++ b/internal/serialization/deserializer_func.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package serialization
 
 import (

--- a/internal/serialization/deserializer_func_test.go
+++ b/internal/serialization/deserializer_func_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package serialization
 
 import (

--- a/internal/serialization/model_setter.go
+++ b/internal/serialization/model_setter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package serialization
 
 import (

--- a/internal/serialization/model_setter_test.go
+++ b/internal/serialization/model_setter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package serialization
 
 import (

--- a/internal/serialization/serialization_gaps_test.go
+++ b/internal/serialization/serialization_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package serialization
 
 import (

--- a/internal/serialization/serializer_func.go
+++ b/internal/serialization/serializer_func.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package serialization
 
 import (

--- a/internal/serialization/serializer_func_test.go
+++ b/internal/serialization/serializer_func_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package serialization
 
 import (

--- a/internal/servicenow_error_thrower.go
+++ b/internal/servicenow_error_thrower.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/servicenow_error_thrower_test.go
+++ b/internal/servicenow_error_thrower_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package internal
 
 import (

--- a/internal/store/backed_model_accessor.go
+++ b/internal/store/backed_model_accessor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/store/backed_model_accessor_test.go
+++ b/internal/store/backed_model_accessor_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/store/backed_model_mutator.go
+++ b/internal/store/backed_model_mutator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/store/backed_model_mutator_test.go
+++ b/internal/store/backed_model_mutator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/store/store_accessor.go
+++ b/internal/store/store_accessor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/store/store_accessor_test.go
+++ b/internal/store/store_accessor_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/store/store_mutator.go
+++ b/internal/store/store_mutator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/store/store_mutator_test.go
+++ b/internal/store/store_mutator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package store
 
 import (

--- a/internal/testutils/json_helper.go
+++ b/internal/testutils/json_helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package testutils
 
 import (

--- a/internal/testutils/json_helper_test.go
+++ b/internal/testutils/json_helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package testutils
 
 import (

--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package testutils
 
 import (

--- a/justfile
+++ b/justfile
@@ -31,6 +31,14 @@ check-docs:
 	go vet -tags snippets ./website/snippets/
 	./scripts/check-snippet-regions.sh
 
+# Apply license headers to in-scope source files (new files get the current year)
+add-license:
+	./scripts/add-license.sh
+
+# Verify all in-scope source files carry license headers
+check-license:
+	./scripts/add-license.sh --check-only
+
 # Clean up local build artifacts
 clean-docs:
 	rm -rf website/build website/.docusaurus

--- a/mocking_test.go
+++ b/mocking_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import "github.com/stretchr/testify/mock"

--- a/now_request_builder.go
+++ b/now_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/now_request_builder_test.go
+++ b/now_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/policyapi/input_status.go
+++ b/policyapi/input_status.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/input_status_test.go
+++ b/policyapi/input_status_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/policies_mappings.go
+++ b/policyapi/policies_mappings.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/policies_mappings_request_builder.go
+++ b/policyapi/policies_mappings_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/policies_mappings_request_builder_delete_request_configuration.go
+++ b/policyapi/policies_mappings_request_builder_delete_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/policyapi/policies_mappings_request_builder_post_query_parameters.go
+++ b/policyapi/policies_mappings_request_builder_post_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 // PoliciesMappingsRequestBuilderPostQueryParameters are the query parameters for the Post method.

--- a/policyapi/policies_mappings_request_builder_post_request_configuration.go
+++ b/policyapi/policies_mappings_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/policyapi/policies_mappings_request_builder_test.go
+++ b/policyapi/policies_mappings_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/policies_mappings_test.go
+++ b/policyapi/policies_mappings_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/policies_request_builder.go
+++ b/policyapi/policies_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/policies_request_builder_test.go
+++ b/policyapi/policies_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/policy_mappings_request_builder_delete_query_parameters.go
+++ b/policyapi/policy_mappings_request_builder_delete_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 // PolicyMappingsRequestBuilderDeleteQueryParameters are the query parameters for the Delete method.

--- a/policyapi/ref.go
+++ b/policyapi/ref.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/ref_test.go
+++ b/policyapi/ref_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/state.go
+++ b/policyapi/state.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/policyapi/state_test.go
+++ b/policyapi/state_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package policyapi
 
 import (

--- a/project-label-sync.yml
+++ b/project-label-sync.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 project-url: https://github.com/users/michaeldcanady/projects/7
 field: Status
 mapping:

--- a/query/base_field.go
+++ b/query/base_field.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/base_field_test.go
+++ b/query/base_field_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/boolean_field.go
+++ b/query/boolean_field.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/boolean_field_test.go
+++ b/query/boolean_field_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/condition.go
+++ b/query/condition.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/condition_test.go
+++ b/query/condition_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/date_time_field.go
+++ b/query/date_time_field.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/date_time_field_test.go
+++ b/query/date_time_field_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/datetime_value.go
+++ b/query/datetime_value.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/datetime_value_test.go
+++ b/query/datetime_value_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/helper.go
+++ b/query/helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/helper_test.go
+++ b/query/helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/number_field.go
+++ b/query/number_field.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/number_field_test.go
+++ b/query/number_field_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/query.go
+++ b/query/query.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 // Package query provides a type-safe and fluent API for building ServiceNow encoded queries.
 // It is a redesign of the query package, focusing on usability and immutability.
 package query

--- a/query/query_main_test.go
+++ b/query/query_main_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/string_field.go
+++ b/query/string_field.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/query/string_field_test.go
+++ b/query/string_field_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package query
 
 import (

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright (c) 2026 Michael Canady
+# SPDX-License-Identifier: MIT
+
+#
+# Applies (or verifies) MIT license headers to this repo's in-scope source
+# files using google/addlicense, pinned via `go run ...@v1.2.0` so the tool
+# stays out of go.mod/go.sum (mirrors how tparse is pinned in ci.yml).
+#
+# Scope (locked decision):
+#   - **/*.go            incl. website/snippets
+#   - **/*.sh            repo-owned shell, incl. .github/scripts and .devcontainer
+#   - root *.yml/*.yaml  config files only (workflow yaml under .github/ is out)
+# The file list is derived from `git ls-files`, so .git/, untracked
+# node_modules/build/vendor dirs can never be swept into the header pass.
+#
+# Year policy:
+#   - Existing files keep their static creation year: the one-time backfill
+#     stamped 2021, and addlicense skips any file that already carries a
+#     header, so re-runs never rewrite it.
+#   - New files get the current year: the default is -y $(date +%Y).
+#
+# Usage:
+#   scripts/add-license.sh [--check-only] [-y <year>]
+#
+#   --check-only   addlicense -check: verify every in-scope file carries a
+#                  header; exit non-zero if any does not. No modifications.
+#   -y <year>      copyright year to stamp (default: current year).
+set -euo pipefail
+
+CHECK_ONLY=false
+YEAR="$(date +%Y)"
+
+usage() {
+    awk 'NR > 1 && /^#/ { sub(/^# ?/, ""); print } NR > 1 && !/^#/ { exit }' "${BASH_SOURCE[0]}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check-only) CHECK_ONLY=true ;;
+        -y) YEAR="$2"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown parameter passed: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# In-scope files: every tracked *.go / *.sh, plus root-level *.yml/*.yaml
+# config files (a root file has no '/' in its path).
+FILES=()
+while IFS= read -r f; do
+    case "$f" in
+        *.go|*.sh) FILES+=("$f") ;;
+        *.yml|*.yaml)
+            if [[ "$f" != */* ]]; then
+                FILES+=("$f")
+            fi
+            ;;
+    esac
+done < <(git ls-files -- '*.go' '*.sh' '*.yml' '*.yaml')
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+    echo "No in-scope files found; nothing to do." >&2
+    exit 0
+fi
+
+COMMON_ARGS=(
+    -c "Michael Canady"
+    -l mit
+    -f "$REPO_ROOT/scripts/license-header.tmpl"
+    -y "$YEAR"
+)
+
+if [ "$CHECK_ONLY" = true ]; then
+    echo "Checking license headers on ${#FILES[@]} in-scope files (year looks like: $YEAR)..."
+    go run github.com/google/addlicense@v1.2.0 -check "${COMMON_ARGS[@]}" -- "${FILES[@]}"
+    echo "OK: all in-scope files carry a license header."
+else
+    echo "Applying license headers (year $YEAR) to ${#FILES[@]} in-scope files..."
+    go run github.com/google/addlicense@v1.2.0 "${COMMON_ARGS[@]}" -- "${FILES[@]}"
+    echo "Done. Review with: git diff --stat"
+fi

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 #
 # Prints (or runs) the set of Go packages affected by the current diff, including
 # transitive dependents. E.g. a change under core/ pulls in every *api package that

--- a/scripts/check-snippet-regions.sh
+++ b/scripts/check-snippet-regions.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 # Verifies the doc-snippet contract between website/docs and website/snippets:
 #   1. every region referenced from a page exists in a snippet file,
 #   2. every region defined in a snippet file is referenced by some page

--- a/scripts/generate_test_report.go
+++ b/scripts/generate_test_report.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/scripts/license-header.tmpl
+++ b/scripts/license-header.tmpl
@@ -1,0 +1,2 @@
+Copyright (c) {{.Year}} {{.Holder}}
+SPDX-License-Identifier: MIT

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2021 Michael Canady
+# SPDX-License-Identifier: MIT
+
 
 # Unified test runner for ServiceNow SDK for Go
 

--- a/servicenow_service_client.go
+++ b/servicenow_service_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/servicenow_service_client_children_test.go
+++ b/servicenow_service_client_children_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/servicenow_service_client_config.go
+++ b/servicenow_service_client_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/servicenow_service_client_config_test.go
+++ b/servicenow_service_client_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/servicenow_service_client_option.go
+++ b/servicenow_service_client_option.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/servicenow_service_client_option_test.go
+++ b/servicenow_service_client_option_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/servicenow_service_client_test.go
+++ b/servicenow_service_client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 import (

--- a/tableapi/display_value.go
+++ b/tableapi/display_value.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/tableapi/display_value_test.go
+++ b/tableapi/display_value_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/element_value.go
+++ b/tableapi/element_value.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/element_value_test.go
+++ b/tableapi/element_value_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/element_visitor.go
+++ b/tableapi/element_visitor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/element_visitor_test.go
+++ b/tableapi/element_visitor_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/primitive.go
+++ b/tableapi/primitive.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/tableapi/primitive_test.go
+++ b/tableapi/primitive_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/record_element.go
+++ b/tableapi/record_element.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/record_element_test.go
+++ b/tableapi/record_element_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_item_request_builder.go
+++ b/tableapi/table_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_item_request_builder_delete_query_parameters.go
+++ b/tableapi/table_item_request_builder_delete_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 // TableItemRequestBuilderDeleteQueryParameters represents the query parameters for a Table item DELETE request.

--- a/tableapi/table_item_request_builder_delete_request_configuration.go
+++ b/tableapi/table_item_request_builder_delete_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/tableapi/table_item_request_builder_gaps_test.go
+++ b/tableapi/table_item_request_builder_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_item_request_builder_get_query_parameters.go
+++ b/tableapi/table_item_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 // TableItemRequestBuilderGetQueryParameters represents the query parameters for a Table item GET request.

--- a/tableapi/table_item_request_builder_get_request_configuration.go
+++ b/tableapi/table_item_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/tableapi/table_item_request_builder_patch_query_parameters.go
+++ b/tableapi/table_item_request_builder_patch_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 // TableItemRequestBuilderPatchQueryParameters represents the query parameters for a Table item PATCH request.

--- a/tableapi/table_item_request_builder_patch_request_configuration.go
+++ b/tableapi/table_item_request_builder_patch_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/tableapi/table_item_request_builder_put_query_parameters.go
+++ b/tableapi/table_item_request_builder_put_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 // TableItemRequestBuilderPutQueryParameters represents the query parameters for a Table item PUT request.

--- a/tableapi/table_item_request_builder_put_request_configuration.go
+++ b/tableapi/table_item_request_builder_put_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/tableapi/table_item_request_builder_test.go
+++ b/tableapi/table_item_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_record.go
+++ b/tableapi/table_record.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_record_gaps_test.go
+++ b/tableapi/table_record_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_record_test.go
+++ b/tableapi/table_record_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_request_builder.go
+++ b/tableapi/table_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_request_builder_gaps_test.go
+++ b/tableapi/table_request_builder_gaps_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_request_builder_get_query_parameters.go
+++ b/tableapi/table_request_builder_get_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 // TableRequestBuilderGetQueryParameters represents the query parameters for a Table collection GET request.

--- a/tableapi/table_request_builder_get_request_configuration.go
+++ b/tableapi/table_request_builder_get_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/tableapi/table_request_builder_head_test.go
+++ b/tableapi/table_request_builder_head_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/table_request_builder_post_query_parameters.go
+++ b/tableapi/table_request_builder_post_query_parameters.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 // TableRequestBuilderPostQueryParameters represents the query parameters for a Table collection POST request.

--- a/tableapi/table_request_builder_post_request_configuration.go
+++ b/tableapi/table_request_builder_post_request_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import abstractions "github.com/microsoft/kiota-abstractions-go"

--- a/tableapi/table_request_builder_test.go
+++ b/tableapi/table_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tableapi/view.go
+++ b/tableapi/view.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import "github.com/michaeldcanady/servicenow-sdk-go/v2/internal/conversion"

--- a/tableapi/view_test.go
+++ b/tableapi/view_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package tableapi
 
 import (

--- a/tests/doc.go
+++ b/tests/doc.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package tests

--- a/tests/integration/v2/account_test.go
+++ b/tests/integration/v2/account_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/activity_subscriptions_test.go
+++ b/tests/integration/v2/activity_subscriptions_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/aggregation_test.go
+++ b/tests/integration/v2/aggregation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/app_service_test.go
+++ b/tests/integration/v2/app_service_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/appointment_booking_test.go
+++ b/tests/integration/v2/appointment_booking_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/attachment_test.go
+++ b/tests/integration/v2/attachment_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/auth_test.go
+++ b/tests/integration/v2/auth_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/batch_test.go
+++ b/tests/integration/v2/batch_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/case_test.go
+++ b/tests/integration/v2/case_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/cmdb_test.go
+++ b/tests/integration/v2/cmdb_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/documents_test.go
+++ b/tests/integration/v2/documents_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/e2e_test.go
+++ b/tests/integration/v2/e2e_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build e2e
 
 package v2

--- a/tests/integration/v2/integration_test.go
+++ b/tests/integration/v2/integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/tests/integration/v2/mockdata/account.go
+++ b/tests/integration/v2/mockdata/account.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var AccountList = `{

--- a/tests/integration/v2/mockdata/activity_subscriptions.go
+++ b/tests/integration/v2/mockdata/activity_subscriptions.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var ActivitySubscriptionItemResponse = `{

--- a/tests/integration/v2/mockdata/aggregation.go
+++ b/tests/integration/v2/mockdata/aggregation.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var StatsCount = `{

--- a/tests/integration/v2/mockdata/app_service.go
+++ b/tests/integration/v2/mockdata/app_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var CreateServiceResponse = `{

--- a/tests/integration/v2/mockdata/appointment_booking.go
+++ b/tests/integration/v2/mockdata/appointment_booking.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var AvailabilityResponse = `{

--- a/tests/integration/v2/mockdata/attachments.go
+++ b/tests/integration/v2/mockdata/attachments.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var AttachmentList = `{

--- a/tests/integration/v2/mockdata/authentication.go
+++ b/tests/integration/v2/mockdata/authentication.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var TokenResponse = `{

--- a/tests/integration/v2/mockdata/batch.go
+++ b/tests/integration/v2/mockdata/batch.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var BatchResponse = `{

--- a/tests/integration/v2/mockdata/case.go
+++ b/tests/integration/v2/mockdata/case.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var CaseList = `{

--- a/tests/integration/v2/mockdata/cdm.go
+++ b/tests/integration/v2/mockdata/cdm.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var PolicyMappingItem = `{

--- a/tests/integration/v2/mockdata/cmdb.go
+++ b/tests/integration/v2/mockdata/cmdb.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var CmdbList = `{

--- a/tests/integration/v2/mockdata/documents.go
+++ b/tests/integration/v2/mockdata/documents.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var DocumentsExploreResponse = `{

--- a/tests/integration/v2/mockdata/errors.go
+++ b/tests/integration/v2/mockdata/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var SomeErrorJSON = `{

--- a/tests/integration/v2/mockdata/incidents.go
+++ b/tests/integration/v2/mockdata/incidents.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package mockdata
 
 var IncidentList = `{

--- a/tests/integration/v2/steps/account_steps.go
+++ b/tests/integration/v2/steps/account_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/activity_subscriptions_steps.go
+++ b/tests/integration/v2/steps/activity_subscriptions_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/aggregation_steps.go
+++ b/tests/integration/v2/steps/aggregation_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/app_service_steps.go
+++ b/tests/integration/v2/steps/app_service_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/appointment_booking_steps.go
+++ b/tests/integration/v2/steps/appointment_booking_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/attachment_steps.go
+++ b/tests/integration/v2/steps/attachment_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/auth_steps.go
+++ b/tests/integration/v2/steps/auth_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/batch_steps.go
+++ b/tests/integration/v2/steps/batch_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/case_steps.go
+++ b/tests/integration/v2/steps/case_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/cmdb_steps.go
+++ b/tests/integration/v2/steps/cmdb_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/documents_steps.go
+++ b/tests/integration/v2/steps/documents_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/hooks.go
+++ b/tests/integration/v2/steps/hooks.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/shared_steps.go
+++ b/tests/integration/v2/steps/shared_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/steps/table_steps.go
+++ b/tests/integration/v2/steps/table_steps.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package steps
 
 import (

--- a/tests/integration/v2/support/assertions.go
+++ b/tests/integration/v2/support/assertions.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/support/client.go
+++ b/tests/integration/v2/support/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/support/env.go
+++ b/tests/integration/v2/support/env.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/support/env_test.go
+++ b/tests/integration/v2/support/env_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/support/jwt.go
+++ b/tests/integration/v2/support/jwt.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/support/mock_registry.go
+++ b/tests/integration/v2/support/mock_registry.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/support/token_providers.go
+++ b/tests/integration/v2/support/token_providers.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/support/world.go
+++ b/tests/integration/v2/support/world.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package support
 
 import (

--- a/tests/integration/v2/table_test.go
+++ b/tests/integration/v2/table_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build integration
 
 package v2

--- a/version.go
+++ b/version.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 package servicenowsdkgo
 
 // Version is the current version of the SDK

--- a/website/snippets/account_guide.go
+++ b/website/snippets/account_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/appointment_guide.go
+++ b/website/snippets/appointment_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/appservice_guide.go
+++ b/website/snippets/appservice_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/attachments.go
+++ b/website/snippets/attachments.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/attachments_delete_aging.go
+++ b/website/snippets/attachments_delete_aging.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/attachments_download.go
+++ b/website/snippets/attachments_download.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/attachments_recent.go
+++ b/website/snippets/attachments_recent.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/attachments_upload.go
+++ b/website/snippets/attachments_upload.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/auth.go
+++ b/website/snippets/auth.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/batch.go
+++ b/website/snippets/batch.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/batch_guide.go
+++ b/website/snippets/batch_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/case_guide.go
+++ b/website/snippets/case_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/cdm_applications_guide.go
+++ b/website/snippets/cdm_applications_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/cdm_changesets_guide.go
+++ b/website/snippets/cdm_changesets_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/cdm_editor_guide.go
+++ b/website/snippets/cdm_editor_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/cmdb_guide.go
+++ b/website/snippets/cmdb_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/concepts.go
+++ b/website/snippets/concepts.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/config.go
+++ b/website/snippets/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/documents_guide.go
+++ b/website/snippets/documents_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/errors_guide.go
+++ b/website/snippets/errors_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/modules.go
+++ b/website/snippets/modules.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/pagination.go
+++ b/website/snippets/pagination.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/pagination_guide.go
+++ b/website/snippets/pagination_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/policy_guide.go
+++ b/website/snippets/policy_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/query.go
+++ b/website/snippets/query.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/query_guide.go
+++ b/website/snippets/query_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/quickstart.go
+++ b/website/snippets/quickstart.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/reference_actions.go
+++ b/website/snippets/reference_actions.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/stats_guide.go
+++ b/website/snippets/stats_guide.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/tables.go
+++ b/website/snippets/tables.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/tables_create.go
+++ b/website/snippets/tables_create.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/tables_delete.go
+++ b/website/snippets/tables_delete.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/tables_query.go
+++ b/website/snippets/tables_query.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets

--- a/website/snippets/tables_update.go
+++ b/website/snippets/tables_update.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Michael Canady
+// SPDX-License-Identifier: MIT
+
 //go:build snippets
 
 package snippets


### PR DESCRIPTION
Adds the MIT copyright header to all source files and enforces it in CI.

**Commits**
- `chore: add license header tooling and CI enforcement` — enables the `goheader` golangci-lint gate (custom `regexp YEAR: 20\d{2}` so per-file years never churn), adds `scripts/add-license.sh` + `scripts/license-header.tmpl`, `justfile` `add-license`/`check-license` targets, and a `backfill-license` workflow (weekly + dispatch, main-only, opens a PR via `peter-evans/create-pull-request` — ADR 011 compliant, never commits in place).
- `chore: add license headers to source files` — one-time `2021` backfill stamping 828 files (819 `.go` incl. `website/snippets`, 6 `.sh`, 3 root YAML). Comments only, no behavior change.

**Header**
```
// Copyright (c) 2021 Michael Canady
// SPDX-License-Identifier: MIT
```
Existing files carry the `LICENSE` origin year; new files get their creation year. The `goheader` regexp accepts any `20xx` so the check won't flake annually. `release-verify.yml` also runs goheader on the tagged ref, so shipped tags stay green.

**Verified:** golangci-lint v2.13.0 0 issues, `go build ./...`, `go test ./...`, `go vet` (incl. snippet/integration tags) pass.

Closes #497
Refs #726
