### PR TITLE
chore: add related-issue check to PR flow

### DIFF
--- a/.opencode/skills/check-related-issue/SKILL.md
+++ b/.opencode/skills/check-related-issue/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: check-related-issue
+description: >-
+  Checks whether an already-open GitHub issue relates to a unit of work about to be shipped: it
+  searches the repo's open issues with keywords pulled from a branch name, commit subject, stash
+  message, or work description, scores the candidates, and declares a verdict (a strong related
+  issue, ambiguous candidates, or none — plus a flag when the work is already in flight on an
+  open PR). Use before opening a PR (the commit-push-pr skill runs it automatically), before
+  starting a branch for work, or whenever the user asks "is there an issue that already tracks
+  this?", "check for a related open issue", or "does an issue exist for X". Do not use it to file
+  issues (that is write-issue) or to dedupe newly-filed report issues (that is the CI
+  issue-similarity-check workflow — this skill looks backwards from work about to ship, not
+  forwards from a fresh report).
+---
+
+# check-related-issue
+
+## Why this exists
+
+A PR carries one of two signals about issue tracking: a link to an issue
+it closes (`Closes #n`), or the `no-issue-required` label. The second
+signal is only honest if no open issue actually tracks the work —
+otherwise the ship path silently duplicates a tracked item, the issue is
+never closed by the PR, and `branch-policy`'s "issue or
+no-issue-required" rule is satisfied by accident while triage loses the
+link. This skill closes that gap: given the work about to ship, it finds
+out whether an open issue already describes it, so the caller can link it
+instead of defaulting to `no-issue-required`. It is deliberately
+conservative — a false positive (linking an unrelated issue)
+is worse than a miss, because linking claims the PR resolves that issue.
+
+## When to use
+
+- Automatically, from the **commit-push-pr** skill, just before the PR is
+  opened (it hands this skill the work description and reads the verdict).
+- Directly, when the user wants to know whether an issue already covers
+  work they're about to branch or PR.
+- As a lighter confirmation when the user did provide an issue reference
+  but you want to make sure the work isn't *also* tracked elsewhere and
+  isn't already in flight on another PR.
+
+## Inputs
+
+You need something that describes the work. The caller passes as much of
+this as it has, best first:
+
+- The user's request phrasing (what they asked to ship).
+- The branch name (a `fix/123-add-sysparm-view` branch encodes both an
+  issue number and a description).
+- The commit subject of the last commit on the branch (most concrete when
+  it exists).
+- The stash/work-summary message (the commit-push-pr flow writes one).
+
+If you have literally nothing (no branch name, no commit, no description),
+**stop and ask the user** what the work is — a search seeded with empty
+terms finds nothing and proves nothing.
+
+## Step 1 — Resolve the repository
+
+```bash
+git remote get-url origin   # parse owner/repo from SSH or HTTPS form
+gh auth status              # gh must be authenticated to search issues
+```
+
+- No origin remote, or the remote isn't a `github.com` URL → **stop** and
+  ask. Don't search the wrong repo.
+- `gh` not authenticated → **stop** and tell the user to authenticate.
+  An unauthenticated search returning no rows is indistinguishable from
+  "no related issue", so it must not be treated as a negative.
+
+## Step 2 — Extract search keywords
+
+Turn the inputs into query terms: lowercase, keep tokens of **4+ chars**,
+drop English stopwords and repo-noise (e.g. `servicenow`, `sdk`, `pr`,
+`issue`, `add`, `support`, `error` — words that appear in most titles and
+add no discriminative signal). Keep order for longest-first queries.
+
+```bash
+# quick shell tokenizer
+printf '%s' "$WORK_DESC" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '\n' \
+  | awk 'length($0) >= 4'
+```
+
+If the branch/context encodes an issue number (`123-` or `#123`), record
+it — that is a *known* reference, which you should validate in step 3
+rather than treat as an open question.
+
+## Step 3 — Search open issues
+
+GitHub search **ANDs every term**, so a long query returns zero rows even
+when related issues exist. Walk a prefix ladder — all keywords first, then
+progressively shorter prefixes (8, 4, then 3 of the highest-signal terms) —
+and accumulate hits across every rung:
+
+```bash
+gh search issues --repo <owner>/<repo> --state open "<terms>" --limit 20
+# or, for more control:
+gh api search/issues -f q="repo:<owner>/<repo> is:issue is:open <terms>" \
+  -f per_page=15 --jq '.items[] | [.number, .title, .state, .created_at] | @tsv'
+```
+
+- Exclude the obvious negatives: closed issues (work already done), PRs
+  (`is:issue` filters those out), and any issue that is literally the one
+  you already know about from a provided reference.
+- If every rung returns nothing, that is a real negative — record
+  `NO_RELATED_ISSUE` and stop.
+
+## Step 4 — Score and rank candidates
+
+Mirror the repo's own `issue-similarity-check` heuristic so this skill
+agrees with how the maintainers judge "related":
+
+- Lowercase each candidate's title and body.
+- Score: **3 points per shared title keyword**, **1 per shared body
+  keyword**, word-boundary matches only (so `test` cannot match
+  `latest`).
+- A candidate **qualifies** only if it shares **≥1 title keyword** and
+  scores **≥ 5** — title overlap is what separates genuinely related
+  issues from coincidental body overlap.
+
+Then classify:
+
+- **Strong match** — shares **≥ 2 title keywords** or scores **≥ 8**:
+  `RELATED_ISSUE=<n>`.
+- **Qualified but uncertain** — meets the qualify bar but not the strong
+  bar, or there are several qualified candidates that could point at
+  different work: `CANDIDATES=<n1,n2,...>`.
+- **Nothing qualifies** — `NO_RELATED_ISSUE`.
+
+Read the top candidates' actual titles/bodies before finalizing — a
+handful of human reads beats scoring alone, and catches things like an
+issue that is about a *different* verb of the same noun (a "docs" issue
+named the same as a "feat" request). Don't let one fuzzy keyword carry a
+link.
+
+## Step 5 — Check whether the work is already in flight
+
+For a strong (or user-selected) related issue, before declaring it safe
+to link, check whether an **open PR already references it** — the work
+may be in progress by someone else:
+
+```bash
+gh pr list --repo <owner>/<repo> --state open --search "<issue number or title>" --json number,title,headRefName
+# or inspect linked PRs directly:
+gh api repos/<owner>/<repo>/issues/<n>/timeline --jq '.[] | select(.event=="cross-referenced" and .source.issue.pull_request) | .source.issue.number'
+```
+
+If an open PR already closes the issue, include
+`ALREADY_IN_PR=<m>` in the verdict. A fresh PR for the same issue is a
+duplicate, not a fix — the caller should **stop** rather than ship.
+
+## Step 6 — Declare the verdict
+
+End the skill by stating exactly one of these, with the issue number(s)
+and titles, so the caller can act without re-deriving anything:
+
+- `RELATED_ISSUE=<n>` — strong match; caller links the PR (`Closes #<n>`,
+  names the branch from it, and omits `no-issue-required`). Append
+  `ALREADY_IN_PR=<m>` when an open PR already covers it.
+- `CANDIDATES=<n1,n2,...>` — qualified but uncertain; caller asks the
+  user which, if any, applies before proceeding.
+- `NO_RELATED_ISSUE` — nothing open tracks the work; `no-issue-required`
+  is an honest label.
+
+## Notes on judgment calls
+
+- **A false positive is worse than a miss.** Linking means the PR claims
+  to resolve the issue. When in doubt, report candidates and let the user
+  decide rather than declaring a strong link.
+- **Same noun, different verb.** "Add license headers" and "Remove
+  license headers" share keywords; only overlap in the *action* the PR
+  performs counts as related.
+- **`ALREADY_IN_PR` is a stop, not a prompt.** If the work is in flight,
+  the useful outcome is joining that PR or closing the issue, not creating
+  a parallel one.
+- **Never fabricate a negative.** A failed `gh` call (rate limit,
+  transient error) is not a "no related issue" result — surface the error
+  and stop so the caller knows the check didn't run.

--- a/.opencode/skills/commit-push-pr/SKILL.md
+++ b/.opencode/skills/commit-push-pr/SKILL.md
@@ -6,8 +6,10 @@ description: >-
   branch, commits them via the commit skill, pushes the branch, and opens the PR against
   the default branch. Accepts an optional issue reference; when no issue is provided the PR is
   labeled no-issue-required. Use whenever the user asks to "commit, push, and open a PR", "ship
-  these changes", "commit and PR this", or similar — never use on a clean tree with nothing to
-  ship, and never push to the default branch directly.
+  these changes", "commit and PR this", or similar. Before opening the PR it checks whether an
+  already-open issue relates to the work (via the check-related-issue skill) and links the PR to
+  that issue instead of the no-issue-required label when one is found — never use on a clean tree
+  with nothing to ship, and never push to the default branch directly.
 ---
 
 # Commit → Push → PR
@@ -15,8 +17,8 @@ description: >-
 This skill runs the working-tree change set through the full ship path:
 stash → sync trunk → restore on a feature branch → commit → push → open a
 PR. It is the outer loop that hands the actual branch creation to the
-**branch** skill (step 5) and the commit-writing to the **commit**
-skill (step 6) — both own their conventions and safety rails, so don't
+**branch** skill (step 6) and the commit-writing to the **commit**
+skill (step 7) — both own their conventions and safety rails, so don't
 duplicate their rules here.
 
 The gating rule before anything else: **never ship nothing**. Step 1
@@ -30,11 +32,14 @@ request was phrased — `$ARGUMENTS` on the command line, an issue number like
 `#123`, a GitHub issue URL, or a referenced issue title. Parse the number (or
 URL) out of the request.
 
-- **Issue provided** → link the PR to it: `Closes #<n>` in the PR body, and
-  name the branch from it (see step 5).
-- **No issue provided** → the PR **must** be labeled `no-issue-required`
-  (step 8). This is the explicit fallback the repo wants when work ships
-  without an issue on file.
+- **Issue provided** → link the PR to it: `Closes #<n>` in the PR body,
+  and name the branch from it (see step 6).
+- **No issue provided** → run the related-issue check (step 5) before
+  defaulting to the `no-issue-required` label. The PR is only labeled
+  `no-issue-required` when the check finds no genuinely related open
+  issue. If it finds one, this flow treats that issue as the reference
+  (branch name in step 6, `Closes #<n>` in step 9, no
+  `no-issue-required` label).
 
 ## Step 0 — Preflight
 
@@ -68,14 +73,14 @@ git status --porcelain
 ## Step 2 — Stash the changes
 
 ```bash
-git branch --show-current     # record the branch you're on for step 5
+git branch --show-current     # record the branch you're on for step 6
 git stash push -u -m "commit-push-pr: <one-line summary of the work>"
 ```
 
 - Use `-u` so untracked new files ride along with the stash — a plain stash
   would leave them loose and they could collide when the tree is restored.
 - Guard the stash until the end: **never `git stash drop` before the PR is
-  confirmed open** (step 9), so a mid-flow failure never destroys the work.
+  confirmed open** (step 10), so a mid-flow failure never destroys the work.
 - After stashing, the working tree is clean, which is what makes steps 3–5
   safe.
 
@@ -101,7 +106,38 @@ remote doesn't), **stop and ask** — the local default branch has diverged and
 rewriting or force-flagging it is not this skill's call to make. Never create
 a merge commit just to reconcile the trunk.
 
-## Step 5 — Restore the stashed changes on a PR branch
+## Step 5 — Check for a related open issue
+
+Before committing the work to a branch and PR, make sure it isn't already
+tracked by an open issue — otherwise the PR silently duplicates a tracked
+item and the issue never gets closed. Run the **check-related-issue**
+skill, handing it the best description of the work you have: the user's
+request phrasing, the stash message written in step 2, and the pre-stash
+branch name (if any).
+
+Skip this step only when the user has already handed you an explicit
+issue reference — their choice is the source of truth and there is
+nothing to discover. (Run it anyway if you also want the duplicate-PR
+signal; the skill degrades gracefully when the explicit issue is the only
+match.)
+
+Read the skill's verdict and act as follows:
+
+- **`RELATED_ISSUE=<n>`** → the work maps to an open issue. Treat `#<n>`
+  as this flow's issue reference: seed the branch name with it (step 6),
+  reference `Closes #<n>` in the commit body (step 7) and the PR body
+  (step 9), and **do not** apply the `no-issue-required` label.
+  - If the verdict also reports **`ALREADY_IN_PR=<m>`** (an open PR
+    already closes that issue), **stop** — the work is already in flight.
+    Do not create a duplicate PR; tell the user which PR covers the issue
+    and let them decide.
+- **`CANDIDATES=<n1,n2,...>`** → genuinely uncertain. **Stop and ask the
+  user** which issue, if any, this work belongs to before continuing.
+  Never pick silently.
+- **`NO_RELATED_ISSUE`** → no open issue tracks the work. Continue; the
+  PR will carry the `no-issue-required` label (step 9).
+
+## Step 6 — Restore the stashed changes on a PR branch
 
 You can't open a PR with head == base; the changes cannot be committed on the
 default branch itself. Decide where they land:
@@ -117,7 +153,7 @@ default branch itself. Decide where they land:
   ```bash
   git ls-remote --heads origin <pre-stash-branch> | grep -q .
   ```
-  Rebasing a pushed branch rewrites every commit hash on it, which step 7's
+  Rebasing a pushed branch rewrites every commit hash on it, which step 8's
   never-force-push rule can't ship — a normal push would be rejected as
   non-fast-forward and force is forbidden, dead-ending the flow. If the
   branch exists on origin, **stop and ask** the user to choose: rebase with a
@@ -131,9 +167,10 @@ default branch itself. Decide where they land:
 - **Fresh branch**: if you were on the default branch, detached HEAD, or no
   branch at all, run the **branch** skill to cut a branch off the
   freshly synced trunk. Hand it the base (`<default>`) and the naming seed —
-  the issue reference (`#123`) when there is one, otherwise a short work
-  description. It owns name derivation, git-ref validation, and the
-  existing-branch check, so don't duplicate that logic here.
+  the issue reference (`#123` — given by the user or discovered by the
+  step-5 check) when there is one, otherwise a short work description. It
+  owns name derivation, git-ref validation, and the existing-branch check,
+  so don't duplicate that logic here.
 
 Then restore the work, **on that branch**:
 
@@ -145,7 +182,7 @@ git stash pop
   the stash. Surface the conflict markers and the current state to the user.
   The stash stays intact until they decide.
 
-## Step 6 — Commit via the commit skill
+## Step 7 — Commit via the commit skill
 
 Run the **commit** skill and follow its process end-to-end (inspect →
 atomic → type from the diff → write subject/body → stage explicitly →
@@ -153,11 +190,11 @@ commit → verify). That skill owns subject length, type selection (including
 the always-`chore:` CI rule), the `Co-Authored-By` trailer, and the
 no-force/no-hook-skip rails.
 
-If an issue was provided, reference it in the commit body (`Closes #123`) —
-the release process and the PR both benefit from the link living at the
-commit.
+If an issue reference is in play — given by the user or discovered by the
+step-5 check — reference it in the commit body (`Closes #123`), as the
+release process and the PR both benefit from the link living at the commit.
 
-## Step 7 — Push the changes
+## Step 8 — Push the changes
 
 ```bash
 git push -u origin <branch>
@@ -169,7 +206,7 @@ git push -u origin <branch>
   `git fetch origin` then `git rebase origin/<default>` (or `origin/<branch>`
   if that's what moved) and retry a normal push — never a forced one.
 
-## Step 8 — Open the pull request
+## Step 9 — Open the pull request
 
 ```bash
 gh pr create --base <default> --head <branch> \
@@ -177,8 +214,10 @@ gh pr create --base <default> --head <branch> \
   --body "<commit body from git log -1 --pretty=%b>"
 ```
 
-- **Issue provided**: append the `Closes #<n>` link to the body.
-- **No issue provided**: the PR **must** carry the `no-issue-required` label:
+- **Issue reference in play** (given by the user or found by the step-5
+  check): append the `Closes #<n>` link to the body.
+- **No issue reference** (the step-5 check found no related open issue):
+  the PR **must** carry the `no-issue-required` label:
   ```bash
   gh pr create ... --label no-issue-required
   ```
@@ -191,7 +230,7 @@ gh pr create --base <default> --head <branch> \
 Let `gh` also fill in the default body template when the commit body is
 empty — an empty-handed `--body ""` forfeits the repo's template fields.
 
-## Step 9 — Verify and clean up
+## Step 10 — Verify and clean up
 
 ```bash
 gh pr view <number> --json url,title,baseRefName,headRefName,labels
@@ -202,7 +241,8 @@ git stash list
 Confirm, before reporting success:
 
 - The PR exists with the right base/head and correct title.
-- The `no-issue-required` label is attached **when no issue was given**.
+- The `no-issue-required` label is attached **when no issue was given or
+  found by the step-5 check** — and absent when an issue is linked.
 - The working tree is clean and the branch is pushed (`git status` should
   show "up to date with origin/<branch>").
 - No stash remains: if `git stash list` still shows one, the pop didn't fully
@@ -217,9 +257,12 @@ Stop and surface state — never work around it silently:
 
 - Step 1: clean tree → nothing to ship.
 - Step 4: local default branch diverged from origin → ask, don't rewrite.
-- Step 5: `git stash pop` conflicts → stop, keep the stash, show the
+- Step 5: verdict is `ALREADY_IN_PR=<m>` for the related issue → stop;
+  don't create a duplicate PR. Verdict is `CANDIDATES=...` → ask the user
+  which issue applies; never pick silently.
+- Step 6: `git stash pop` conflicts → stop, keep the stash, show the
   conflicts.
-- Step 7: push rejected → rebase then retry; never force.
-- Step 8: missing `no-issue-required` label → report; don't fake the label.
+- Step 8: push rejected → rebase then retry; never force.
+- Step 9: missing `no-issue-required` label → report; don't fake the label.
 - Any failure before the PR is open → the work is still safe in the stash;
   say so explicitly in your report.


### PR DESCRIPTION
The commit-push-pr skill defaulted to the no-issue-required label when the user gave no issue, without checking whether an open issue already tracked the work - silently duplicating a tracked item and leaving the issue never closed by the PR.

Add a dedicated check-related-issue skill (mirroring the issue-similarity-check scoring heuristic) and run it from commit-push-pr before opening a PR: link Closes when a strong match is found, stop when the work is already in flight on another PR, and only fall back to no-issue-required when nothing open tracks the work.