### PR TITLE
chore: rewrite design-decisions skill as decision rules

### DIFF
--- a/.opencode/agents/principal-qa-engineer.md
+++ b/.opencode/agents/principal-qa-engineer.md
@@ -58,6 +58,15 @@ Read `CLAUDE.md` (Testing conventions) and map the actual test layout:
   coverage gap as an issue. Run it; it discovers the repo's actual GitHub
   issue templates and gets explicit go-ahead before anything visible is
   filed.
+- **design-decisions** — before triaging or asserting on behavior shaped by
+  an ADR — nil-receiver guards returning a sentinel instead of `(nil, nil)`
+  (ADR 006), error-sentinel identity (`errors.Is`, ADR 001), pagination via
+  the generic `core.PageIterator` and per-endpoint `Link`-header support
+  (ADR 005) — or before auditing the conventions that QA exists to protect.
+  Read the covering ADR in `website/docs/contributing/adrs/` first; a test
+  that encodes the wrong contract trains the whole suite on drift. You never
+  modify production code, but your tests must assert the repo's actual
+  decisions, not an invented alternative.
 
 ## Stay strictly inside the task's scope
 

--- a/.opencode/skills/design-decisions/SKILL.md
+++ b/.opencode/skills/design-decisions/SKILL.md
@@ -187,5 +187,5 @@ deserves an ADR:
    `CLAUDE.md`, update it too — ADR and CLAUDE.md must never describe two
    different realities.
 
-Routine bug fixes, formatting, and behavior fully explained by the diff don't
+need an ADR.
 need an ADR.

--- a/.opencode/skills/design-decisions/SKILL.md
+++ b/.opencode/skills/design-decisions/SKILL.md
@@ -1,170 +1,191 @@
 ---
 name: design-decisions
-description: >
-  Points to this repo's (servicenow-sdk-go) Architecture Decision Records,
-  published on the docs site at website/docs/contributing/adrs/ -- the
-  deliberate trade-offs behind hand-writing the client on top of Kiota's
-  runtime abstractions instead of generating it from OpenAPI or writing it
-  fully from scratch (ADR 003), storing model properties in a Kiota
-  BackingStore instead of plain struct fields so "absent" and "zero" stay
-  distinguishable (ADR 002), and standardizing error sentinels/messaging
-  across the three separate error-sentinel locations (ADR 001). Also covers
-  the v2.0-era conventions: pointer-typed query parameters wired through
-  vanilla Kiota request-configuration (ADR 004), one generic core.PageIterator
-  instead of per-module wrappers (ADR 005), nil-receiver guards returning a
-  shared sentinel error instead of (nil, nil) (ADR 006), never scaffolding a
-  builder chain ahead of an implemented operation (ADR 007), package/
-  symbol/URL names as independent naming axes (ADR 008), keeping the
-  RequestBuilder/RequestInformation names despite their imprecise roles, for
-  Kiota/msgraph parity (ADR 009), and staying at the michaeldcanady GitHub
-  org/module path for the v2 lifecycle instead of migrating to a NerdIT-Tech
-  org (ADR 010) -- plus release branches that are lazily cut, downstream-only,
-  and never silently diverge, with tracked forward-ports across majors (ADR
-  011). Consult this BEFORE proposing or making changes to the
-  request-builder/model architecture, error handling conventions, pagination,
-  nil-guard behavior, module naming, branching/release flow, or anything that
-  would make this SDK diverge from Kiota-generated SDK conventions (e.g.
-  msgraph-sdk-go) -- these are not accidents or defaults, they were chosen
-  over real alternatives for stated reasons, and changing them without knowing
-  why risks silently undoing a considered trade-off. Also consult it before
-  answering any "why does this repo do X" / "why not just do Y instead"
-  question. Use it proactively even when not asked explicitly -- e.g. before
-  suggesting plain-struct models, a generated-from-OpenAPI client, a
-  per-module page-iterator wrapper, a bare (nil, nil) nil-guard return, a
-  preemptive release/* branch, or a bespoke error type instead of the shared
-  sentinels.
+description: >-
+  Carries this repo's load-bearing architecture decisions (servicenow-sdk-go) as
+  ready-to-apply rules, so design work and review don't accidentally undo a
+  considered trade-off. Hand-written-on-Kiota client that mirrors Kiota-generated
+  SDK conventions (msgraph-sdk-go); backing-store models not plain structs;
+  shared error sentinels; nil-receiver guards returning sentinels not (nil, nil);
+  pointer-typed query parameters; one generic page iterator; no speculative
+  builder chains; three independent naming axes; trunk-first with lazily-cut
+  release/vX.Y branches. USE when the user asks "why does this repo do X"/"why
+  not Y instead", wants a design review/RFC, or proposes anything touching the
+  request-builder/model architecture, error handling, pagination, nil-guard
+  behavior, naming, module path, or branch/release flow. USE proactively when
+  you're about to suggest a plain-struct model, a generated-from-OpenAPI
+  client, a per-module page-iterator wrapper, a fresh errors.New where a shared
+  sentinel exists, a bare (nil, nil) nil-guard return, a speculative builder
+  chain, a rename of RequestBuilder/RequestInformation, or a preemptive
+  release/* branch. Full records: website/docs/contributing/adrs/. Not for
+  routine bug fixes or formatting, which don't need ADR backing.
 ---
 
 # Design decisions
 
-This repo records its architectural trade-offs as ADRs, published on the
-docs site at
+This repo's simplest-looking code is its most deliberately chosen. Nearly
+every "why is this odd?" has an Architecture Decision Record (ADR) behind it,
+and the ADRs weren't accidents — they were chosen over real alternatives. This
+skill distills those decisions into rules you can apply *to the code you're
+touching right now*. Where a rule needs the full reasoning — alternatives
+considered, rejected options, consequences — the linked ADR has it.
+
+The rulebook is grouped by **situation**, not by document. Find your situation,
+apply the rule. Deep dives live at
 [`website/docs/contributing/adrs/`](../../../website/docs/contributing/adrs/)
-(index page: [`index.md`](../../../website/docs/contributing/adrs/index.md)) —
-**not** in `Readme.md` or `CLAUDE.md`. `Readme.md`/`CLAUDE.md` cover what the
-SDK does and how it's structured; the ADRs cover why, what was rejected, and
-what a change here has to respect. Keeping them separate is deliberate:
-cramming rationale into the top-level docs turns them into a decision log
-nobody can navigate, and duplicating the same reasoning in two places means
-it drifts out of sync the first time only one copy gets updated.
+(index: [`index.md`](../../../website/docs/contributing/adrs/index.md)),
+with plain-language summaries in
+`website/docs/contributing/design-decisions.md`.
 
-The catalog is eleven files numbered `001-` through `011-` (three digits, not
-four), each with Docusaurus frontmatter and an entry in the index table:
+## First principles
 
-1. [`001-error-standardization.md`](../../../website/docs/contributing/adrs/001-error-standardization.md)
-   — centralizes sentinel errors and message phrasing in the `/errors`
-   package. Note this interacts with the "three separate error-sentinel
-   locations" gotcha documented in the root `CLAUDE.md` (root `errors.go`,
-   `errors/errors.go`, and a few package-local `errors.go` files) — always
-   reuse an existing sentinel by identity, don't create a fresh
-   `errors.New(...)` with matching text, or `errors.Is` breaks for callers.
-2. [`002-backing-store-models.md`](../../../website/docs/contributing/adrs/002-backing-store-models.md)
-   — every model embeds `core.BaseModel` and stores properties in a Kiota
-   `BackingStore` instead of plain struct fields, specifically so "the field
-   was never sent" and "the field was sent as zero/empty" stay distinguishable,
-   and so writes only serialize what the caller actually touched.
-3. [`003-hand-written-on-kiota.md`](../../../website/docs/contributing/adrs/003-hand-written-on-kiota.md)
-   — the founding decision. ServiceNow doesn't publish usable OpenAPI specs,
-   so generating from Kiota's CLI was rejected; writing everything from
-   scratch was rejected as reinventing undifferentiated plumbing (URI
-   templates, auth, serialization, retries). Instead the SDK hand-writes
-   request builders/models on Kiota's runtime libraries
-   (`kiota-abstractions-go`, `kiota-http-go`, `kiota-serialization-*-go`),
-   deliberately mirroring the conventions of Kiota-*generated* SDKs like
-   msgraph-sdk-go: request-builder chaining, `RequestConfiguration` shapes,
-   parsable factories, backed models. This is why "just match the
-   Kiota-generated pattern exactly" is usually the right call when a piece of
-   this SDK looks hand-rolled and slightly different from upstream Kiota
-   conventions — the divergence is either a considered ADR-003 trade-off or
-   drift worth fixing, not a free design choice.
-4. [`004-vanilla-kiota-request-configuration.md`](../../../website/docs/contributing/adrs/004-vanilla-kiota-request-configuration.md)
-   — every `*QueryParameters` struct uses pointer fields with
-   `uriparametername` tags through `abstractions.ConfigureRequestInformation`,
-   replacing a bespoke go-querystring wrapper, to match msgraph-sdk-go and let
-   "unset" and "zero" stay distinguishable. Sharp edge: new integer query
-   params must be `*int32`, not `*int` — the native encoder silently drops a
-   bare `*int`.
-5. [`005-generic-page-iterator-only.md`](../../../website/docs/contributing/adrs/005-generic-page-iterator-only.md)
-   — `core.NewPageIterator[T]` is the one documented pagination pattern;
-   per-module wrapper constructors (the old `tableapi`/`attachmentapi` ones)
-   were removed and shouldn't be re-added for new modules, even for symmetry.
-6. [`006-nil-receiver-sentinel-error.md`](../../../website/docs/contributing/adrs/006-nil-receiver-sentinel-error.md)
-   — nil-receiver guards on verb methods return `snerrors.ErrNilRequestBuilder`,
-   never a bare `(nil, nil)`/`nil`, so a nil builder fails loud at the call
-   site instead of silently succeeding. Enforced by the
-   `principal-software-engineer` agent via new-module design reviews.
-7. [`007-no-speculative-builder-chains.md`](../../../website/docs/contributing/adrs/007-no-speculative-builder-chains.md)
-   — don't add a request-builder accessor for a URL segment until the
-   operation(s) behind it are actually implemented; a navigable chain with no
-   working verb method is worse than not having the chain at all.
-8. [`008-package-symbol-url-naming-independence.md`](../../../website/docs/contributing/adrs/008-package-symbol-url-naming-independence.md)
-   — package names, exported symbol names, and accessor/URL-segment names are
-   independent naming axes (see `aggregationapi` package vs. `Stats*` types vs.
-   `Now().Stats()`); an inconsistency in one doesn't mean the other two need to
-   change too.
-9. [`009-requestbuilder-requestinformation-naming.md`](../../../website/docs/contributing/adrs/009-requestbuilder-requestinformation-naming.md)
-   — keeps `RequestBuilder`/`RequestInformation` named as-is despite the
-   names being technically imprecise (`RequestBuilder` is really a facade,
-   `RequestInformation` is the actual builder), because they mirror
-   `kiota-abstractions-go`/msgraph-sdk-go conventions. Settled through v3 —
-   don't revisit without a new major-version boundary and a concrete
-   consumer-facing reason.
-10. [`010-no-nerdit-tech-migration.md`](../../../website/docs/contributing/adrs/010-no-nerdit-tech-migration.md)
-    — declines a proposed GitHub org migration to NerdIT-Tech at v2; the
-    module path stays `github.com/michaeldcanady/servicenow-sdk-go` (only
-    the `/v2` semver suffix changes). Settled through v3 — don't revisit
-    without a new major-version boundary and a concrete, non-speculative
-    reason to move.
-11. [`011-release-branches-and-cross-major-flow.md`](../../../website/docs/contributing/adrs/011-release-branches-and-cross-major-flow.md)
-    — trunk-first development with lazily-cut `release/vX.Y` maintenance
-    branches: fixes land on `main` first and backport down via label;
-    anything landing on a maintenance branch without backport provenance
-    triggers a `needs-forward-port` issue so divergence is tracked debt, never
-    silent. Never create preemptive `release/*` branches or treat a
-    maintenance branch as a development trunk.
+1. **Mirror Kiota-generated conventions.** This SDK is hand-written on
+   Microsoft's Kiota runtime (`kiota-abstractions-go`, `kiota-http-go`,
+   `kiota-serialization-*-go`) and deliberately conforms to what a
+   *generated* Kiota SDK would produce (msgraph-sdk-go is the reference
+   shape): request-builder chaining, `RequestConfiguration` types,
+   parsable factories, backed models. ServiceNow publishes no usable OpenAPI
+   specs, so generating was rejected; writing from scratch was rejected as
+   reinventing Kiota's plumbing. **Rule:** when a piece of this SDK looks
+   hand-rolled and differs from the Kiota-generated shape, decide whether the
+   divergence is a considered ADR trade-off or drift to fix — don't accept it
+   as a free design choice, and don't "improve" it away from Kiota parity.
+   ([ADR 003](../../../website/docs/contributing/adrs/003-hand-written-on-kiota.md))
+2. **Distinguish absent from zero.** Backing stores exist so "the caller never
+   set this" and "the caller set zero/empty" stay distinguishable, and so
+   `Patch` bodies only serialize what was actually set. **Rule:** models embed
+   `core.BaseModel`, properties go through `internal/store` accessor/mutator
+   pairs (`GetX() (T, error)` / `setX(T) error`), getters return pointers
+   (`nil` = not sent). Never reach for a plain struct while writing a model.
+   ([ADR 002](../../../website/docs/contributing/adrs/002-backing-store-models.md))
 
-Plain-language contributor summaries of ADRs 001–003 live alongside them on
-the site under [Why it's built this way](https://michaeldcanady.github.io/servicenow-sdk-go/contributing/design-decisions)
-(`design-decisions.md`, `design-backed-models.md`, `design-hand-written-kiota.md`,
-`design-error-handling.mdx`) — those link into these primary sources.
+## Rules by situation
 
-Before touching an area covered by an ADR, or answering a "why"/"should we
-change this" question:
+### Error handling — adding or triaging an error path
 
-1. Read the specific ADR(s) that cover the area you're about to touch.
-2. If what you're about to do would contradict an ADR, say so explicitly and
-   confirm with the user first — don't just quietly change course. A few of
-   these look like the "wrong" choice in isolation (hand-writing instead of
-   generating; pointer-returning getters instead of plain fields) and are
-   only correct in the context of the trade-off the ADR records.
+- **Reuse sentinels by identity, never by text.** Shared sentinels live in
+  `errors/errors.go` (`snerrors.ErrNilRequestBuilder`, `ErrNilRequestAdapter`,
+  `ErrNilResponse`, `ErrNilConfig`, `ErrNilBody`, ...). A fresh
+  `errors.New("... cannot be nil")` with matching text breaks `errors.Is` for
+  every caller — the exact bug v2 reworked away. Message phrasing is
+  standardized: `"[param] cannot be nil"`, `"[param] is required"`, no
+  contractions.
+- **Route HTTP errors through the shared mapping.** Request builders pass
+  `core.DefaultErrorMapping()` to every `Send`/`SendPrimitive` call, never a
+  bespoke error struct. There are *three* error-sentinel locations that look
+  alike (root `errors.go`, `errors/errors.go`, package-local ones) — check
+  `errors/errors.go` first for an identity to reuse.
+- ([ADR 001](../../../website/docs/contributing/adrs/001-error-standardization.md))
 
-## Keeping the catalog current
+### Nil-guard behavior — writing a verb method
 
-This is a living document, not a one-time snapshot. When a **real
-architectural trade-off** gets decided in conversation — something with a
-rejected alternative and a reason, the kind of thing a new contributor would
-otherwise have to reverse-engineer from git blame — add a new ADR:
+- **A nil receiver returns a sentinel, never `(nil, nil)`.** Every verb method
+  opens with:
+  ```go
+  if conversion.IsNil(rB) || conversion.IsNil(rB.RequestBuilder) {
+      return nil, snerrors.ErrNilRequestBuilder
+  }
+  if conversion.IsNil(rB.GetRequestAdapter()) {
+      return nil, snerrors.ErrNilRequestAdapter
+  }
+  ```
+  (single-error-return verbs return the sentinel alone). A bare `(nil, nil)` /
+  `nil` is a silent-failure trap the ADR explicitly rejects — it's a
+  consistency-review finding, not a style nit. Navigation methods returning a
+  bare `*Builder` and other nil-response semantics are out of scope.
+- ([ADR 006](../../../website/docs/contributing/adrs/006-nil-receiver-sentinel-error.md))
 
-1. Check the highest existing number in
-   `website/docs/contributing/adrs/`; yours is **that plus one**, full stop.
-   Create `NNN-<short-title>.md` there (three-digit prefix, matching the
-   existing files — don't switch to four digits).
-2. Follow the shape already used by `001`–`003`: `Status`, `Context`,
-   `Decision`, `Consequences` (`002`/`003` also include an `Alternatives
-   considered`-style discussion inside Context — keep that). Add Docusaurus
-   frontmatter (`title` matching the H1, one-line `description`) like the
-   existing pages.
-3. Register it: add a row to the table in
-   `website/docs/contributing/adrs/index.md` and an entry to the
-   "Architecture decision records" category in `website/sidebars.ts`. An
-   unregistered ADR is invisible on the site.
-4. If the new ADR changes or replaces an earlier one, don't edit the old
-   file's decision — mark it `Superseded by ADR-00N` in its Status line and
-   note the supersession in the new file, so the history of *why it changed*
-   is kept rather than overwritten.
+### Query parameters — adding a param to a request
 
-Routine bug fixes, formatting, or anything already fully explained by the
-diff/commit message don't need an ADR. And if a change you're about to make
-would only be correctly understood by *also* updating `CLAUDE.md`'s factual
-"what/how" description (not its reasoning), update that too — ADRs and
-`CLAUDE.md` should never describe two different realities.
+- **Pointer fields, `uriparametername` tags, wired through
+  `abstractions.ConfigureRequestInformation`.** Unset ≠ zero is the whole
+  point, exactly like msgraph-sdk-go. **Sharp edge:** integer params must be
+  `*int32`, not `*int` — the native encoder silently drops a bare `*int` with
+  no error. Also: request builders that carry a body skip the generic
+  `ConfigureRequestInformation` path for content and set it manually via
+  `SetContentFromParsable` in `ToXRequestInformation`.
+- ([ADR 004](../../../website/docs/contributing/adrs/004-vanilla-kiota-request-configuration.md))
+
+### Pagination — adding a collection endpoint
+
+- **One pattern: `core.NewPageIterator[T]`.** Per-module wrappers were removed
+  deliberately (three near-identical constructors, and they implied `Link`-
+  header pagination endpoints may not support). Don't add a
+  `New<X>PageIterator` for a new module, "even for symmetry." Document
+  per-endpoint whether it actually emits `Link` headers.
+- ([ADR 005](../../../website/docs/contributing/adrs/005-generic-page-iterator-only.md))
+
+### Builder chains — adding an accessor
+
+- **No speculative chains.** A request-builder accessor exists only when the
+  operations it leads to are implemented. A navigable chain with no working
+  verb method is worse than no chain at all.
+- ([ADR 007](../../../website/docs/contributing/adrs/007-no-speculative-builder-chains.md))
+
+### Naming — package, symbol, accessor
+
+- **Three independent axes.** Package names follow ServiceNow's API-surface
+  name; exported symbols follow the wire format; accessor methods follow the
+  URL segment. They don't have to agree (`aggregationapi` / `Stats*` /
+  `Now().Stats()`). An inconsistency in one axis doesn't make the others
+  wrong.
+- **`RequestBuilder` / `RequestInformation` keep their names.** Technically
+  imprecise (`RequestBuilder` is a facade, `RequestInformation` is the real
+  builder), but they mirror kiota-abstractions-go/msgraph-sdk-go. Settled
+  through v3 — don't propose a rename.
+- ([ADR 008](../../../website/docs/contributing/adrs/008-package-symbol-url-naming-independence.md),
+  [ADR 009](../../../website/docs/contributing/adrs/009-requestbuilder-requestinformation-naming.md))
+
+### Module path / org — versioning or org questions
+
+- **Stays `github.com/michaeldcanady/servicenow-sdk-go`.** Only the `/vN`
+  semantic-version suffix changes across majors (a release-day runbook item).
+  No GitHub org transfer is planned through v3 — don't propose one.
+- ([ADR 010](../../../website/docs/contributing/adrs/010-no-nerdit-tech-migration.md))
+
+### Branch & release flow — where work should land
+
+- **Trunk-first.** `main` is always the tip of the next major's development.
+  All changes arrive by PR; no in-place commits to `main` or `release/*`.
+- **Maintenance branches are `release/vX.Y`** (no patch segment), **created
+  lazily** at first need, never preemptively. Never cut a `release/*` branch
+  ahead of need, and never treat one as a development trunk.
+- **Downstream-only within a major.** Fixes land on `main` first, then move
+  down via a label-triggered backport (`backport release/vX.Y`). Direct pushes
+  to `release/*` are blocked.
+- **Drift is tracked debt, never silent.** A merge into `release/*` without
+  backport provenance opens a `needs-forward-port` issue — it closes by
+  porting up or recording an explicit "won't port."
+- ([ADR 011](../../../website/docs/contributing/adrs/011-release-branches-and-cross-major-flow.md))
+
+## Handling a conflict with a rule
+
+If what you're about to do would contradict one of these decisions, **say so
+explicitly and confirm with the user before changing course** — don't quietly
+diverge. Several of these look like the "wrong" choice in isolation
+(hand-writing instead of generating; backed models instead of plain structs)
+and are only correct in light of the trade-off the ADR records. When a real
+new trade-off gets decided in conversation (a rejected alternative plus a
+reason), note it as an ADR candidate for the product-manager agent rather than
+silently codifying it in code.
+
+## When a new ADR is warranted
+
+A real architectural trade-off — rejected alternative, stated reason, the kind
+of thing a new contributor would otherwise reverse-engineer from `git blame` —
+deserves an ADR:
+
+1. **Number:** highest existing number in
+   `website/docs/contributing/adrs/` plus one (`NNN-<short-title>.md`,
+   three-digit prefix).
+2. **Shape:** `Status`, `Context` (incl. alternatives considered), `Decision`,
+   `Consequences`, with Docusaurus frontmatter — match `001`–`003`.
+3. **Register:** add a row to `index.md` and an entry in `website/sidebars.ts`
+   — an unregistered ADR is invisible on the site.
+4. **Supersession:** if it replaces an earlier decision, mark the old file
+   `Superseded by ADR-00N` in its Status; keep the history, don't overwrite.
+5. **Keep CLAUDE.md honest:** if the change alters a "what/how" fact in
+   `CLAUDE.md`, update it too — ADR and CLAUDE.md must never describe two
+   different realities.
+
+Routine bug fixes, formatting, and behavior fully explained by the diff don't
+need an ADR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,22 @@ fluent, typed client. It is built directly on Microsoft's Kiota abstractions
 Kiota client — the request-builder/parsable/backing-store pattern is hand-written to match Kiota's
 conventions so the SDK "feels" like other Kiota-generated SDKs (e.g. msgraph-sdk-go).
 
+## Consult the ADRs before you act
+
+The repo's load-bearing design trade-offs are recorded as Architecture Decision Records (ADRs) in
+`website/docs/contributing/adrs/` (index: `index.md`; plain-language overview: `design-decisions.md`).
+They cover the request-builder/model architecture, error handling, pagination, nil-guard behavior,
+naming, module path, and the branch/release flow. **Before proposing or changing anything in that
+scope — and before answering "why does this repo do X" — read the covering ADR first**, and run the
+`design-decisions` skill (`.opencode/skills/design-decisions`) to get the rules applied to your
+situation. These trade-offs (hand-writing on Kiota over generating from OpenAPI — ADR 003; backing
+stores over plain fields — ADR 002; shared error sentinels — ADR 001; generic `core.PageIterator`
+over per-module wrappers — ADR 005; trunk-first lazily-cut `release/vX.Y` branches — ADR 011) were
+chosen over real alternatives; a change that contradicts one without saying so is the most common
+way good work goes wrong in this repo. If you hit a genuinely new trade-off (a rejected alternative
+plus a reason), flag it as an ADR candidate to the `product-manager` agent rather than silently
+codifying it — routine bug fixes and formatting don't need ADR backing.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Rewrites `.opencode/skills/design-decisions/SKILL.md` from an ADR catalog into a
decision rulebook, and makes ADR consultation a hard floor for every agent.

### Problem
- **Under-triggering.** The skill description listed *documents* (an index of 11 ADRs),
  not the *situations* that need the skill, so it wasn't picked up when design decisions
  were being made.
- **Catalog, not guidance.** The body pointed at the ADR records rather than carrying the
  decisions themselves, so an agent had to go read the ADRs to apply them — and had no
  ready-made "don't do X, do Y" answer while writing code.
- **Patchy agent awareness.** Only the software-engineer and devops-engineer agents
  consulted the ADRs; the QA agent had no ADR references, and nothing universal forced an
  "read the ADR first" floor before anyone acted.

### Change
- Description rewritten as trigger-oriented: concrete situations (design review/RFC,
  request-builder/model architecture, error handling, pagination, nil guards, naming,
  module path, branch/release flow) plus the specific anti-patterns that should fire it
  (plain-struct models, generated-from-OpenAPI client, per-module page-iterator wrapper,
  fresh `errors.New`, bare `(nil, nil)` guard, speculative chains, renames, preemptive
  `release/*` branches).
- Body restructured by **situation**, not by document: error handling → nil guards →
  query params → pagination → builder chains → naming → module path → release flow.
  Each rule states the required behavior, the rejected alternative, and links the ADR for
  the full reasoning.
- ADRs remain the source of truth for *why*; the skill now carries *what to do*.
- **`CLAUDE.md`** gains a top-level "Consult the ADRs before you act" floor, read by every
  agent and subagent (including built-ins): read the covering ADR before proposing or
  changing anything in ADR scope, or before answering "why does this repo do X".
- **`principal-qa-engineer`** now lists design-decisions among its skills and consults the
  ADRs whose contracts its tests assert (ADR 001 error-sentinel identity, ADR 005 generic
  page iterator, ADR 006 nil-guard sentinels).

No behavior change to any shipped SDK surface.

No related open issue (`no-issue-required`).