### PR TITLE
chore(ci): enforce license headers in CI and document template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       github.event_name == 'schedule'
     outputs:
       code: ${{ github.event_name == 'schedule' || steps.filter.outputs.any_changed == 'true' }}
+      headers: ${{ github.event_name == 'schedule' || steps.header_filter.outputs.any_changed == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -69,6 +70,22 @@ jobs:
             !docs/snippets/**
             tests/integration/**
             **/*.feature
+            .github/workflows/ci.yml
+
+      # Files in scope for the license-header check (matches scripts/add-license.sh:
+      # all .go/.sh plus root-level .yml/.yaml). A separate output keeps shell-only
+      # and config-only changes from unnecessarily re-running the Go build/test
+      # matrix while still gating the header check on the files it inspects.
+      - name: License Files Changed
+        if: github.event_name != 'schedule'
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        id: header_filter
+        with:
+          files: |
+            **.go
+            **/*.sh
+            *.yml
+            *.yaml
             .github/workflows/ci.yml
 
   check-go:
@@ -163,6 +180,26 @@ jobs:
           version: v2.13.0
           skip-cache: false
           args: --timeout=5m
+
+  check-license:
+    name: License Headers
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.headers == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # checkout and verify license headers
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- check-license: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+        with:
+          go-version: "stable"
+      - name: Verify license headers
+        run: ./scripts/add-license.sh --check-only
 
   test-go:
     name: Test Go Code

--- a/website/docs/contributing/conventions.md
+++ b/website/docs/contributing/conventions.md
@@ -89,6 +89,35 @@ Models are backing-store-backed, not plain structs
 - `Serialize()` / `GetFieldDeserializers()` are built from the
   `internal/serialization` generators — no hand-rolled property plumbing.
 
+## License headers
+
+Every in-scope source file carries an SPDX license header. CI enforces this:
+a PR that adds or edits a file without the header fails the **License
+Headers** check.
+
+In scope are all `*.go` and `*.sh` files, plus root-level `*.yml`/`*.yaml`
+configuration files. Workflow files under `.github/` are out of scope.
+
+The header template is:
+
+```text
+Copyright (c) {{.Year}} {{.Holder}}
+SPDX-License-Identifier: MIT
+```
+
+For this repository, that renders as a year plus the project holder, for
+example:
+
+```go
+// Copyright (c) 2026 Michael Canady
+// SPDX-License-Identifier: MIT
+```
+
+- Existing files keep their original creation year. Add or verify headers
+  with `./scripts/add-license.sh` — `--check-only` verifies without editing,
+  and a bare run applies the current year to new files.
+- New files receive the current year automatically.
+
 ## Compose `internal/`, don't reinvent
 
 If you're writing a nil check, a header string, an accessor, or serializer

--- a/website/docs/contributing/first-pr.mdx
+++ b/website/docs/contributing/first-pr.mdx
@@ -75,6 +75,9 @@ the surrounding file is the style guide.
 
 - Changing Go code? If you're unsure what something should look like,
   `tableapi/` is the canonical example of nearly everything.
+- Adding a new file? Give it an SPDX license header (see the
+  [conventions reference](conventions.md)); `./scripts/add-license.sh`
+  applies it, and CI fails without one.
 - Changing docs? Go samples live in `website/snippets/*.go` behind
   `// [START x]` / `// [END x]` markers — never inline in the page — so CI
   can compile them. Preview locally with `just serve-docs`.


### PR DESCRIPTION
Wires the existing add-license.sh --check-only guard into ci.yml as a
dedicated License Headers job, gated on a new changes output that detects
in-scope files (.go/.sh/root yml), so a PR that adds or edits a file without
an SPDX header fails CI. Documents the SPDX template and the script in the
conventions reference and the first-PR walkthrough.

Closes #726
Co-authored-by: opencode <opencode@local>