### PR TITLE
chore(ci): fix sign-release asset upload content type

### DIFF
--- a/.github/workflows/sign-release.yml
+++ b/.github/workflows/sign-release.yml
@@ -143,6 +143,7 @@ jobs:
 
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
               -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Content-Type: application/octet-stream" \
               --data-binary "@${ASSET}" \
               "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${ASSET}")
             if [ "${HTTP_CODE}" != "201" ]; then


### PR DESCRIPTION
## What's changing

- `sign-release.yml`: set `Content-Type: application/octet-stream` on the release-asset upload POST.

## Why

The v2.0.3 signing backfill failed on the very last step with `HTTP 422` uploading `SHA256SUMS`. The upload `curl` uses `--data-binary` without a `Content-Type` header, so curl sends `application/x-www-form-urlencoded`; GitHub's releases uploads API rejects that and returns 422, and the job exits before attaching either the checksums or the sigstore bundle.

`sbom.yml` already sets its content type explicitly (`application/spdx+json`) and its upload succeeds against the same release. This mirrors that pattern.

## Verification

- Manual repro: uploading the same way without the header to the v2.0.3 release returns `HTTP/2 422`; with `Content-Type: application/octet-stream` the upload returns 201.
- The v2.0.3 SBOM backfill (`workflow_dispatch` on `sbom.yml`) attached `sbom.spdx.json` successfully.
- After this merges, re-dispatch `sign-release.yml` for `v2.0.3` to attach `SHA256SUMS` and `SHA256SUMS.sigstore.json`.

## Checklist

- [x] CI-only change, conventional commit type `chore:`