### PR TITLE
chore(ci): attach SBOM and signatures in-band on release

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,20 +1,33 @@
 name: Generate SBOM
 
-# Generates and attaches an SPDX SBOM to the GitHub release for the published
-# version tag. Runs on the release-published event (release-please creates the
-# tag and release via the GitHub API, which does not emit a git push event, so
-# a `push: tags` trigger never fires). The SBOM asset is uploaded (or replaced)
-# via the GitHub Releases API. Idempotent: if the asset already exists it is
-# deleted and re-uploaded with fresh scan output.
+# Generates and attaches an SPDX SBOM to the GitHub release for a published
+# version tag. Runs as a reusable workflow, called by Stable Release and
+# Weekly Preview Release after release-please has created the tag and release
+# in the same workflow run, and available as workflow_dispatch for backfilling
+# older releases (for example v2.0.3, which predates this flow).
+#
+# Why this is not a `release: published` trigger: release-please creates
+# releases as GitHub Actions using the default token, and GitHub deliberately
+# does not start new workflow runs from events created by GITHUB_TOKEN (the
+# anti-recursion rule). A release-event trigger therefore never fires for
+# release-please-created releases, which is exactly what happened to v2.0.3.
+# Calling the workflow from the releasing workflow is deterministic.
+#
+# The SBOM asset is uploaded (or replaced) via the GitHub Releases API.
+# Idempotent: if the asset already exists it is deleted and re-uploaded with
+# fresh scan output.
 
 on:
-  release:
-    types:
-      - published
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag name to generate and attach an SBOM for (for example v2.0.3)
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
-        description: Tag name to generate and attach an SBOM for (for example v2.0.2)
+        description: Tag name to generate and attach an SBOM for (for example v2.0.3)
         required: true
 
 permissions: {}
@@ -60,7 +73,7 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           TAG_NAME="${RELEASE_TAG}"
           RELEASE_ID=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
@@ -109,6 +122,6 @@ jobs:
       - name: Notify if no release found for tag
         if: steps.release.outputs.release_id == '' || steps.release.outputs.release_id == 'null'
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           echo "::notice::No GitHub Release found for tag $RELEASE_TAG. The SBOM was generated at ./sbom.spdx.json but was not attached to a release. Ensure the release was published by the release-please process or manually create a release draft."

--- a/.github/workflows/sign-release.yml
+++ b/.github/workflows/sign-release.yml
@@ -1,12 +1,19 @@
 name: Sign Release
 
 # Signs release artifacts and tags for supply-chain trust (issue #713).
-# release-please creates the tag and release asynchronously when the release
-# PR merges, so at the time stable-release.yml runs the release does not exist
-# yet and its assets are not uploadable. Signing therefore runs on the
-# release-published event instead, the same trigger sbom.yml uses. This one
-# workflow covers both stable releases and weekly preview releases, because
-# release-please publishes both through the GitHub Releases API.
+# Runs as a reusable workflow, called by Stable Release and Weekly Preview
+# Release after release-please has created the tag and release in the same
+# workflow run, and available as workflow_dispatch for backfilling older
+# releases (for example v2.0.3, which predates this flow).
+#
+# Why this is not a `release: published` trigger: release-please creates
+# releases as GitHub Actions using the default token, and GitHub deliberately
+# does not start new workflow runs from events created by GITHUB_TOKEN (the
+# anti-recursion rule). A release-event trigger therefore never fires for
+# release-please-created releases, which is exactly what happened to v2.0.3.
+# Calling the workflow from the releasing workflow is deterministic, and the
+# caller runs it only after the SBOM workflow has attached the SBOM, so the
+# checksums always cover it.
 #
 # Artifacts are signed keylessly with cosign (sigstore): the GitHub Actions
 # OIDC identity is the signing principal, so no secrets are required. The
@@ -36,21 +43,20 @@ name: Sign Release
 #      `git verify-tag` can resolve it.
 #        gpg --armor --export <fingerprint> | gpg --keyserver keys.openpgp.org --send-keys <fingerprint>
 #
-# Rehearsal before the first real release: dispatch this workflow with the
-# `tag` input set to an existing tag to exercise the artifact-signing job
-# (safe: it only adds assets). Rehearse the tag-signing job in a fork or on a
-# throwaway tag first, because it force-pushes the tag ref. If a tag
-# protection rule rejects the force push, add `github-actions[bot]` to the
-# rule's bypass list and re-run.
+# Backfill an older release by dispatching this workflow with the `tag` input
+# set to the existing tag.
 
 on:
-  release:
-    types:
-      - published
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag name to sign (for example v2.0.3)
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
-        description: Tag name to sign (for example v2.0.2)
+        description: Tag name to sign (for example v2.0.3)
         required: true
 
 permissions: {}
@@ -74,7 +80,7 @@ jobs:
       - name: Find release ID for the tag
         id: release
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ inputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_ID=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
@@ -89,7 +95,7 @@ jobs:
 
       - name: Download release artifacts
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           mkdir -p artifacts
@@ -99,8 +105,9 @@ jobs:
             "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
           curl -sSfL -o "artifacts/${REPO_NAME}-${RELEASE_TAG}.zip" \
             "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${RELEASE_TAG}.zip"
-          # The SBOM is attached by sbom.yml. Both workflows race on release
-          # publication, so a missing SBOM is a notice, not an error.
+          # Release workflows call this after the SBOM workflow, so the SBOM is
+          # already attached. A standalone backfill may run first, so a missing
+          # SBOM is a notice, not an error.
           if ! curl -sSfL -o "artifacts/sbom.spdx.json" \
             "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/sbom.spdx.json"; then
             echo "::notice::sbom.spdx.json not available yet; SHA256SUMS covers only the source archives."
@@ -156,7 +163,7 @@ jobs:
       - name: Notify if no release found for tag
         if: steps.release.outputs.release_id == '' || steps.release.outputs.release_id == 'null'
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           echo "::notice::No GitHub Release found for tag $RELEASE_TAG. The signature files were produced at ./SHA256SUMS and ./SHA256SUMS.sigstore.json but were not attached to a release."
 
@@ -183,7 +190,7 @@ jobs:
         if: steps.key.outputs.configured == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ inputs.tag }}
           persist-credentials: false
 
       - name: Import GPG signing key
@@ -202,7 +209,7 @@ jobs:
       - name: Re-create and push signed annotated tag
         if: steps.key.outputs.configured == 'true'
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -54,6 +54,9 @@ jobs:
       contents: write # create release PR and tag
       issues: write # label and comment on release PR
       pull-requests: write # open and update release PR
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Create release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
@@ -75,6 +78,9 @@ jobs:
       contents: write # create maintenance release PR and tag
       issues: write # label maintenance release PR
       pull-requests: write # open maintenance release PR
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       # The manifest check inspects files, and runners start with an empty
       # workspace, so the pushed ref must be checked out before the guard.
@@ -105,3 +111,36 @@ jobs:
           # Operate on this maintenance line; without this pin the action
           # computes releases against the repository's default branch (main).
           target-branch: ${{ github.ref_name }}
+
+  # Attach provenance assets to whatever release this run created. The
+  # release-please jobs run the actual SBOM generation and signing as reusable
+  # workflows so the artifacts are produced in-band (deterministically, no
+  # reliance on GitHub delivering a `release` event from a GITHUB_TOKEN-created
+  # release) and so a manual backfill stays possible via workflow_dispatch on
+  # the reusable files. Exactly one of the two release-please jobs can create a
+  # release per push (main, or a release/v* line), and only when a conventional
+  # commit bumped the version; both conditions are encoded in the gate below.
+  attach-sbom:
+    name: Attach SBOM to Release
+    needs: [release-please, release-please-maintenance]
+    if: >-
+      (needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true') ||
+      (needs.release-please-maintenance.result == 'success' && needs.release-please-maintenance.outputs.release_created == 'true')
+    permissions:
+      contents: write # callee uploads the SBOM asset to the GitHub release
+    uses: ./.github/workflows/sbom.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name || needs.release-please-maintenance.outputs.tag_name }}
+
+  attach-sign:
+    name: Sign Release Artifacts and Tag
+    needs: [attach-sbom, release-please, release-please-maintenance]
+    if: >-
+      (needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true') ||
+      (needs.release-please-maintenance.result == 'success' && needs.release-please-maintenance.outputs.release_created == 'true')
+    permissions:
+      contents: write # callee uploads signature assets and force-pushes the signed tag
+      id-token: write # callee signs keylessly with the OIDC identity
+    uses: ./.github/workflows/sign-release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name || needs.release-please-maintenance.outputs.tag_name }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -63,9 +63,39 @@ jobs:
       contents: write # create preview release PR and tag
       issues: write # label preview release PR
       pull-requests: write # open preview release PR
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Create preview release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           config-file: weekly-release-please-config.json
+
+  # Attach provenance assets to the preview release, using the same reusable
+  # workflows as Stable Release so previews get the same SBOM and signatures.
+  attach-sbom:
+    name: Attach SBOM to Release
+    needs: release-please
+    if: >-
+      needs.release-please.result == 'success' &&
+      needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write # callee uploads the SBOM asset to the GitHub release
+    uses: ./.github/workflows/sbom.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+
+  attach-sign:
+    name: Sign Release Artifacts and Tag
+    needs: [attach-sbom, release-please]
+    if: >-
+      needs.release-please.result == 'success' &&
+      needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write # callee uploads signature assets and force-pushes the signed tag
+      id-token: write # callee signs keylessly with the OIDC identity
+    uses: ./.github/workflows/sign-release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## What's changing

- `sbom.yml` and `sign-release.yml`: drop the `release: published` trigger; expose a `tag` input via `workflow_call` (primary) and keep `workflow_dispatch` for backfills such as the v2.0.3 one.
- `stable-release.yml` and `weekly-release.yml`: publish `release_created` and `tag_name` outputs from their `release-please` jobs, and add `attach-sbom` + `attach-sign` jobs that call the reusable workflows, gated on `release_created == 'true'`. Signing is ordered after SBOM so the checksums always cover the SBOM.

## Why

`release: published` has never fired in this repo. release-please creates releases as GitHub Actions using the default token, and GitHub deliberately does not start new workflow runs from `GITHUB_TOKEN`-created events (anti-recursion). v2.0.3 shipped with neither SBOM nor signature; v2.0.2's SBOM was attached manually. This makes provenance generation deterministic and in-band with the release, removing the event-delivery dependency entirely.

## Notes

- Exactly one release-please job can create a release per push (main vs release/v\*), so the gate ORs both, handling the skipped-other-job case via `needs.<job>.result`.
- The cosign certificate keeps naming `sign-release.yml` under `workflow_call` because OIDC `job_workflow_ref` points to the called workflow; the self-verification step is unchanged.
- The next release (the first `fix:`/`feat:` push after merge) exercises the full chain; a `chore:` merge does not release, so this PR itself will not.

## Checklist

- [x] CI-only change, conventional commit type `chore:`