### PR TITLE
chore(ci): run release verification in-band and record release-provenance ADRs

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,19 +1,36 @@
 name: Release Verify
 
-# Tripwire for the release path: runs the full quality gate against the exact
-# tagged ref after a tag is pushed. Release PRs already run CI pre-merge (see
-# ci.yml `changes` job); this catches anything that slips through via direct
-# pushes or automation bugs. It cannot undo a published tag, so failures here
-# page a human to yank/patch the release immediately.
+# Tripwire for the release path: runs the full quality gate (modules, build,
+# lint, unit tests) against the exact tagged ref after a release is created.
+# Release PRs already run the same gate before merge (see ci.yml `changes`
+# job); this catches anything that slips through direct pushes or automation
+# bugs. It cannot undo a published tag, so a failure here pages a human to
+# yank or patch the release immediately.
+#
+# This workflow runs two ways:
+# - workflow_call: Stable Release and Weekly Preview Release call it in-band
+#   after the release-please step, passing the tag that run created. This is
+#   how release-please-created tags get verified. release-please creates tags
+#   as GitHub Actions using the default token, and GitHub does not start new
+#   workflow runs from events created by GITHUB_TOKEN, so the old
+#   `push tags v*` trigger never fired for those tags.
+# - push on v* tags: covers tags that a human pushes directly, which do not
+#   pass through the releasing workflows.
 on:
   push:
     tags:
       - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag name to verify (for example v2.0.3)
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: release-verify-${{ github.ref }}
+  group: release-verify-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -24,9 +41,13 @@ jobs:
     permissions:
       contents: read # checkout and verification
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout the tagged ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Explicit ref when called in-band; a push event already points at
+          # the tag, so fall back to the event ref.
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -144,3 +144,19 @@ jobs:
     uses: ./.github/workflows/sign-release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name || needs.release-please-maintenance.outputs.tag_name }}
+
+  # Runs the full quality gate against the tagged ref. The release-please
+  # tag push is invisible to the `push tags` trigger (GITHUB_TOKEN events do
+  # not start new runs), so this must be called in-band. See
+  # release-verify.yml for both trigger paths.
+  verify-release:
+    name: Verify Release Against Full Quality Gate
+    needs: [attach-sign, release-please, release-please-maintenance]
+    if: >-
+      (needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true') ||
+      (needs.release-please-maintenance.result == 'success' && needs.release-please-maintenance.outputs.release_created == 'true')
+    permissions:
+      contents: read # checkout and verification
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name || needs.release-please-maintenance.outputs.tag_name }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -99,3 +99,19 @@ jobs:
     uses: ./.github/workflows/sign-release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  # Runs the full quality gate against the tagged ref. The release-please
+  # tag push is invisible to the `push tags` trigger (GITHUB_TOKEN events do
+  # not start new runs), so this must be called in-band. See
+  # release-verify.yml for both trigger paths.
+  verify-release:
+    name: Verify Release Against Full Quality Gate
+    needs: [attach-sign, release-please]
+    if: >-
+      needs.release-please.result == 'success' &&
+      needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read # checkout and verification
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/website/docs/contributing/adrs/012-release-provenance-in-band.md
+++ b/website/docs/contributing/adrs/012-release-provenance-in-band.md
@@ -1,0 +1,93 @@
+---
+title: 'ADR 012: Release provenance is generated in-band, not event-driven'
+description: >-
+  SBOM generation, artifact signing, and release verification run as reusable
+  workflows called by the releasing workflow, because GitHub suppresses new
+  workflow runs from events created by the default token.
+---
+
+# ADR 012: Release provenance is generated in-band, not event-driven
+
+## Status
+
+Accepted (2026-09-02). This is the root record for the release-provenance
+pipeline. The rules apply to any workflow that must react to a release-please-
+created release.
+
+## Context
+
+The v2.0.3 release (2026-09-02) shipped with zero provenance assets: no SBOM,
+no checksums, and no signature. v2.0.2's SBOM only existed because a maintainer
+attached it by manual dispatch. The releases themselves were created correctly
+by release-please; the follow-on work never ran.
+
+Root cause: GitHub suppresses new workflow runs for repository events created
+by the default `GITHUB_TOKEN`, with two explicit exceptions,
+`workflow_dispatch` and `repository_dispatch`. `sbom.yml` and `sign-release.yml`
+triggered on `release: published`, and `release-verify.yml` triggered on
+`push tags v*`. release-please-action creates both the tag and the release as
+a GitHub Action running with the default token, so neither event ever arrived.
+`sign-release.yml` had never run once; `sbom.yml` had only manual runs.
+
+Alternatives considered:
+
+1. **Repository-event triggers (`release: published`, `push tags v*`)** — this
+   is what shipped and what broke. Dead on arrival for any release created by
+   automation running on the default token. Rejected as the operating model.
+2. **A real principal for release-please (PAT or GitHub App installation
+   token)** — events created by an app or PAT do start new workflow runs, so
+   this restores the event-driven design. It adds a secret or key lifecycle,
+   a security review of a write-scoped credential, and no delivery guarantee:
+   a missed event is still silent. Rejected for now; revisited in ADR 013.
+3. **`repository_dispatch` event bridge** — dispatch events are explicitly
+   exempt from suppression, so an in-band POST reliably starts consumers.
+   The POST is fire-and-forget: ordering across consumers is not guaranteed,
+   and a lost dispatch fails silently. Rejected as the primary path; the
+   payload versioning and reconciliation needed to make it reliable are
+   deferred to ADR 013.
+4. **In-band `workflow_call` fan-out** (chosen) — the releasing workflow calls
+   each dependent directly as a reusable workflow, gated on the release-please
+   job's `release_created` output, passing the created tag as an input.
+   Deterministic, ordered, and auditable in one run; no new credentials.
+5. **State-file polling** — a scheduled workflow diffs the release manifest
+   (`.release-please-manifest*.json`) against created tags. Fully decoupled
+   but laggy and failure-agnostic; not suitable as the only mechanism on the
+   release-critical path.
+
+## Decision
+
+Couple release-please's follow-on work to the releasing workflow in-band.
+The releasing workflows (`stable-release.yml`, `weekly-release.yml`) publish
+`release_created` and `tag_name` outputs from their release-please jobs, then
+call each dependent as a reusable workflow via
+`uses: ./.github/workflows/<name>.yml` with a `tag` input, gated on
+`release_created == 'true'`. The pattern covers:
+
+- **SBOM generation and attachment** (`sbom.yml`).
+- **Artifact signing and optional tag signing** (`sign-release.yml`), ordered
+  by `needs: attach-sbom` so the SHA256SUMS always cover the SBOM.
+- **Release verification** (`release-verify.yml`), which keeps its
+  `push tags v*` trigger only for tags that a human pushes directly, because
+  those do not pass through the releasing workflows.
+
+Each reusable workflow also keeps a `workflow_dispatch` trigger with the same
+`tag` input so a maintainer can backfill older releases, as happened for
+v2.0.3 and v2.0.2.
+
+## Consequences
+
+- **Pros:** deterministic — the follow-on work fires in the same run that
+  created the release, with no reliance on event delivery; ordered, so signing
+  always sees the SBOM; one workflow run to inspect after a release; manual
+  backfill stays available; no new secrets or credentials.
+- **Cons:** the releasing workflows must name every dependent, so adding a
+  consumer is a change to the production release path; the gate expression is
+  hand-maintained and a wrong `if` silently skips coverage; concerns that are
+  logically separate share one run's history and retry semantics.
+- **Rule for future release questions:** do not add `release: published` or
+  `push tags v*` triggers for releases that release-please creates with the
+  default token — the trigger is dead on arrival. Add the work as a reusable
+  `workflow_call` workflow and invoke it from `stable-release.yml` and
+  `weekly-release.yml`. Revisit this rule only under the conditions in
+  [ADR 013](013-event-driven-release-dispatch.md), which may supersede this
+  record.

--- a/website/docs/contributing/adrs/012-release-provenance-in-band.md
+++ b/website/docs/contributing/adrs/012-release-provenance-in-band.md
@@ -41,18 +41,18 @@ Alternatives considered:
    a missed event is still silent. Rejected for now; revisited in ADR 013.
 3. **`repository_dispatch` event bridge** — dispatch events are explicitly
    exempt from suppression, so an in-band POST reliably starts consumers.
-   The POST is fire-and-forget: ordering across consumers is not guaranteed,
+   The POST is fire-and-forget: ordering across consumers isn't guaranteed,
    and a lost dispatch fails silently. Rejected as the primary path; the
    payload versioning and reconciliation needed to make it reliable are
    deferred to ADR 013.
 4. **In-band `workflow_call` fan-out** (chosen) — the releasing workflow calls
    each dependent directly as a reusable workflow, gated on the release-please
    job's `release_created` output, passing the created tag as an input.
-   Deterministic, ordered, and auditable in one run; no new credentials.
+   Deterministic and ordered in one run; no new credentials.
 5. **State-file polling** — a scheduled workflow diffs the release manifest
    (`.release-please-manifest*.json`) against created tags. Fully decoupled
-   but laggy and failure-agnostic; not suitable as the only mechanism on the
-   release-critical path.
+   but slow to react and failure-agnostic; not suitable as the only mechanism
+   on the release-critical path.
 
 ## Decision
 
@@ -68,7 +68,7 @@ call each dependent as a reusable workflow via
   by `needs: attach-sbom` so the SHA256SUMS always cover the SBOM.
 - **Release verification** (`release-verify.yml`), which keeps its
   `push tags v*` trigger only for tags that a human pushes directly, because
-  those do not pass through the releasing workflows.
+  those don't pass through the releasing workflows.
 
 Each reusable workflow also keeps a `workflow_dispatch` trigger with the same
 `tag` input so a maintainer can backfill older releases, as happened for
@@ -84,7 +84,7 @@ v2.0.3 and v2.0.2.
   consumer is a change to the production release path; the gate expression is
   hand-maintained and a wrong `if` silently skips coverage; concerns that are
   logically separate share one run's history and retry semantics.
-- **Rule for future release questions:** do not add `release: published` or
+- **Rule for future release questions:** don't add `release: published` or
   `push tags v*` triggers for releases that release-please creates with the
   default token — the trigger is dead on arrival. Add the work as a reusable
   `workflow_call` workflow and invoke it from `stable-release.yml` and

--- a/website/docs/contributing/adrs/013-event-driven-release-dispatch.md
+++ b/website/docs/contributing/adrs/013-event-driven-release-dispatch.md
@@ -13,12 +13,12 @@ description: >-
 Proposed (2026-09-02). Not adopted — this records a direction for moving
 release follow-on tasks from in-band coupling (ADR 012) to event-driven
 dispatch. If adopted, it supersedes [ADR 012](012-release-provenance-in-band.md),
-whose Status then reads "Superseded by ADR-013".
+whose Status then reads "Superseded by ADR-013."
 
 ## Context
 
 [ADR 012](012-release-provenance-in-band.md) couples follow-on work to the
-releasing workflows because GitHub does not start new runs from events created
+releasing workflows because GitHub doesn't start new runs from events created
 by `GITHUB_TOKEN`. In-band coupling is correct today, but it has real costs:
 
 - The releasing workflows name every consumer (`attach-sbom`, `attach-sign`,
@@ -31,9 +31,9 @@ by `GITHUB_TOKEN`. In-band coupling is correct today, but it has real costs:
 Event-driven dispatch is attractive because each concern becomes its own
 workflow with an explicit contract: consumers subscribe and receive a durable
 event rather than being invoked by the producer. GitHub offers one event type
-that is exempt from the `GITHUB_TOKEN` suppression and can carry arbitrary
+that's exempt from the `GITHUB_TOKEN` suppression and can carry arbitrary
 data: `repository_dispatch`. `workflow_dispatch` is the other exemption but
-cannot carry a custom payload.
+can't carry a custom payload.
 
 Options for true event delivery:
 
@@ -46,14 +46,15 @@ Options for true event delivery:
    new runs, restoring native triggers such as `release: published` and
    `push tags v*`. Adds an org-installed GitHub App, key storage and rotation,
    permitting scope, and a write-credential security review. This is the
-   "real principal" end state, but it is a heavy operational lift.
+   "real principal" end state, but it's a heavy operational lift.
 3. **`workflow_run` trigger** — keys off a dedicated "emit release events"
    workflow run rather than a repository event. The consumer receives no
    inputs and must resolve state from run metadata or artifacts, and the
    written security guidance prefers `workflow_call` chains over
    `workflow_run`. Kept out of scope.
 4. **State-file polling** — a scheduled sweep diffs the release manifest
-   against created tags and attached assets. Fully decoupled, laggy, and
+   against created tags and attached assets. Fully decoupled, slow to react,
+   and
    failure-agnostic on its own; valuable as the reconciliation layer for the
    dispatch bus rather than as the primary mechanism.
 
@@ -67,14 +68,14 @@ consumers honor), or have signing wait until the SBOM asset exists and retry.
 
 ## Decision
 
-Do not adopt yet. If adopted, pursue this phased path:
+Don't adopt yet. If adopted, pursue this phased path:
 
 1. **Phase 1 — add a dispatch emitter alongside the in-band calls.** The
    releasing workflows POST `repository_dispatch` events of type
    `release-created` with a versioned payload (`v1`, `tag`, `sha`), with a
    small retry-and-jitter loop. In-band attachment continues unchanged.
 2. **Phase 2 — move stateless consumers to the bus.** `release-verify.yml`
-   (and any future consumer that does not affect artifact ordering) subscribes
+   (and any future consumer that doesn't affect artifact ordering) subscribes
    to `release-created` instead of being called in-band. SBOM and signing stay
    in-band because their ordering matters.
 3. **Phase 3 — reconciliation sweep.** A scheduled workflow diffs tags against
@@ -84,12 +85,12 @@ Do not adopt yet. If adopted, pursue this phased path:
 4. **Phase 4 (optional) — GitHub App for native triggers.** If a maintainer
    stands up a GitHub App, the emitter switches from `repository_dispatch` to
    the app token, native triggers return, and the event bus disappears. This
-   substitutes an operational credential for pipeline complexity; do not do it
+   substitutes an operational credential for pipeline complexity; don't do it
    without an explicit cost decision.
 
 ## Consequences
 
-- **Pros:** consumers decouple from the release path — adding one does not
+- **Pros:** consumers decouple from the release path — adding one doesn't
   touch the production release workflow; each concern reverts to its own
   workflow, history, and retry semantics; the design matches the mental model
   of subscriptions to durable events; reconciliation makes the pipeline fail

--- a/website/docs/contributing/adrs/013-event-driven-release-dispatch.md
+++ b/website/docs/contributing/adrs/013-event-driven-release-dispatch.md
@@ -1,0 +1,108 @@
+---
+title: 'ADR 013: Release tasks may move to event-driven dispatch'
+description: >-
+  Proposed direction: decouple release follow-on work from the releasing
+  workflows using repository_dispatch events and a reconciliation sweep,
+  possibly ending at a GitHub App token for native event triggers.
+---
+
+# ADR 013: Release tasks may move to event-driven dispatch
+
+## Status
+
+Proposed (2026-09-02). Not adopted — this records a direction for moving
+release follow-on tasks from in-band coupling (ADR 012) to event-driven
+dispatch. If adopted, it supersedes [ADR 012](012-release-provenance-in-band.md),
+whose Status then reads "Superseded by ADR-013".
+
+## Context
+
+[ADR 012](012-release-provenance-in-band.md) couples follow-on work to the
+releasing workflows because GitHub does not start new runs from events created
+by `GITHUB_TOKEN`. In-band coupling is correct today, but it has real costs:
+
+- The releasing workflows name every consumer (`attach-sbom`, `attach-sign`,
+  `verify-release`), so a new consumer is a change to the production release
+  path, and the fan-out list grows with each concern.
+- A skipped dependency or a subtly wrong `if` gate drops coverage silently.
+- Logically separate concerns share one run's history, retry, and concurrency
+  semantics.
+
+Event-driven dispatch is attractive because each concern becomes its own
+workflow with an explicit contract: consumers subscribe and receive a durable
+event rather than being invoked by the producer. GitHub offers one event type
+that is exempt from the `GITHUB_TOKEN` suppression and can carry arbitrary
+data: `repository_dispatch`. `workflow_dispatch` is the other exemption but
+cannot carry a custom payload.
+
+Options for true event delivery:
+
+1. **`repository_dispatch` event bus** — the releasing workflow POSTs a
+   `release-created` dispatch with `client_payload` (`tag`, `sha`) after the
+   release-please step; every consumer subscribes independently. Fire-and-
+   forget: a lost dispatch is silent, so the bus needs a reconciliation sweep
+   (see Decision) to become at-least-once. Payload must be versioned.
+2. **GitHub App installation token** — events created with an app token start
+   new runs, restoring native triggers such as `release: published` and
+   `push tags v*`. Adds an org-installed GitHub App, key storage and rotation,
+   permitting scope, and a write-credential security review. This is the
+   "real principal" end state, but it is a heavy operational lift.
+3. **`workflow_run` trigger** — keys off a dedicated "emit release events"
+   workflow run rather than a repository event. The consumer receives no
+   inputs and must resolve state from run metadata or artifacts, and the
+   written security guidance prefers `workflow_call` chains over
+   `workflow_run`. Kept out of scope.
+4. **State-file polling** — a scheduled sweep diffs the release manifest
+   against created tags and attached assets. Fully decoupled, laggy, and
+   failure-agnostic on its own; valuable as the reconciliation layer for the
+   dispatch bus rather than as the primary mechanism.
+
+### Ordering constraint
+
+SDK releases must ship SBOM before checksums: SHA256SUMS must cover the SBOM.
+Event delivery is unordered across consumers, so any event-driven design must
+either keep order-sensitive steps in-band (call `sbom.yml` before
+`sign-release.yml` as today), encode ordering in the payload (a `phase` that
+consumers honor), or have signing wait until the SBOM asset exists and retry.
+
+## Decision
+
+Do not adopt yet. If adopted, pursue this phased path:
+
+1. **Phase 1 — add a dispatch emitter alongside the in-band calls.** The
+   releasing workflows POST `repository_dispatch` events of type
+   `release-created` with a versioned payload (`v1`, `tag`, `sha`), with a
+   small retry-and-jitter loop. In-band attachment continues unchanged.
+2. **Phase 2 — move stateless consumers to the bus.** `release-verify.yml`
+   (and any future consumer that does not affect artifact ordering) subscribes
+   to `release-created` instead of being called in-band. SBOM and signing stay
+   in-band because their ordering matters.
+3. **Phase 3 — reconciliation sweep.** A scheduled workflow diffs tags against
+   attached assets and re-dispatches anything missing, converting the bus from
+   fire-and-forget to at-least-once with observable drift. Only when this sweep
+   has proven itself in production would the in-band calls become redundant.
+4. **Phase 4 (optional) — GitHub App for native triggers.** If a maintainer
+   stands up a GitHub App, the emitter switches from `repository_dispatch` to
+   the app token, native triggers return, and the event bus disappears. This
+   substitutes an operational credential for pipeline complexity; do not do it
+   without an explicit cost decision.
+
+## Consequences
+
+- **Pros:** consumers decouple from the release path — adding one does not
+  touch the production release workflow; each concern reverts to its own
+  workflow, history, and retry semantics; the design matches the mental model
+  of subscriptions to durable events; reconciliation makes the pipeline fail
+  loud instead of silent.
+- **Cons:** the event bus and the reconciliation sweep are new pipeline to
+  build and maintain; ordering between SBOM and signing must survive
+  nondeterministic delivery, so the order-sensitive steps stay in-band for
+  now; the phased approach intentionally keeps two mechanisms (in-band calls
+  and dispatches) alive in parallel during the transition; the GitHub App
+  option trades an operational credential for the least pipeline surface, and
+  only a maintainer decision can settle that.
+- **Rule for future work:** until both ordering and at-least-once delivery are
+  guaranteed, keep SBOM and signing in-band (`attach-sbom` before
+  `attach-sign`) and treat any event-driven consumer as best-effort overlays
+  with their own reconciliation. Never make the event bus the only mechanism
+  for a step that must not be missed.

--- a/website/docs/contributing/adrs/index.md
+++ b/website/docs/contributing/adrs/index.md
@@ -1,8 +1,8 @@
 ---
 title: Architecture decision records
 description: >-
-  The catalog of accepted ADRs — every load-bearing design trade-off in the
-  SDK, what was rejected, and the rules each decision imposes on new code.
+  The catalog of accepted and proposed ADRs — every load-bearing design trade-off
+  in the SDK, what was rejected, and the rules each decision imposes on new code.
 ---
 
 # Architecture decision records
@@ -29,6 +29,8 @@ below are the primary sources.
 | [009](009-requestbuilder-requestinformation-naming.md) | Keep `RequestBuilder`/`RequestInformation` naming (Kiota parity) — settled through v3 | Accepted |
 | [010](010-no-nerdit-tech-migration.md) | Stay at `github.com/michaeldcanady/servicenow-sdk-go` — settled through v3 | Accepted |
 | [011](011-release-branches-and-cross-major-flow.md) | Release branches are lazily cut, downstream-only, and never silently diverge | Accepted |
+| [012](012-release-provenance-in-band.md) | Release provenance (SBOM, signatures, verification) is generated in-band, not event-driven | Accepted |
+| [013](013-event-driven-release-dispatch.md) | Proposed direction: decouple release tasks via `repository_dispatch` events with reconciliation, ending at a GitHub App for native triggers | Proposed |
 
 ## Proposing a new ADR
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -341,6 +341,8 @@ const sidebars: SidebarsConfig = {
             'contributing/adrs/009-requestbuilder-requestinformation-naming',
             'contributing/adrs/010-no-nerdit-tech-migration',
             'contributing/adrs/011-release-branches-and-cross-major-flow',
+            'contributing/adrs/012-release-provenance-in-band',
+            'contributing/adrs/013-event-driven-release-dispatch',
           ],
         },
       ],


### PR DESCRIPTION
## What's changing

- `release-verify.yml` gains a `workflow_call` entry point with a `tag` input. The old `push tags v*` trigger stays, but only for tags that a human pushes directly.
- `stable-release.yml` and `weekly-release.yml` add a `verify-release` job that calls it in-band after `attach-sign`, gated on `release_created` and passing `tag_name`. This replaces the dead trigger path for release-please-created tags.
- New **ADR 012** (Accepted): release provenance is generated in-band, not event-driven — records the v2.0.3 root cause and forbids reintroducing `release: published` triggers for release-please-created releases.
- New **ADR 013** (Proposed): direction for moving stateless release tasks to a `repository_dispatch` event bus with a reconciliation sweep, ending at a GitHub App for native triggers.

## Why

release-please creates tags as GitHub Actions using the default token, and GitHub does not start new workflow runs from events created by `GITHUB_TOKEN`. `release-verify.yml` therefore never ran for release-please-created tags — the same root cause as the v2.0.3 SBOM and signature gap. Calling it in-band makes verification deterministic and keeps the push trigger only for the case a human bypasses the releasing workflows.

## Notes

- `verify-release` runs after `attach-sign`, so verification sees the final release state (including the re-created signed tag pointing at the same commit).
- The releasing workflows are unchanged for non-release pushes: the gate requires `release_created == 'true'`, so a `chore` merge like this one runs nothing extra.
- ADR 013 is intentionally status **Proposed**; it does not describe shipped behavior.

## Checklist

- [x] Workflow changes committed as `chore:`, ADRs as `docs:`