### PR TITLE
chore: cleanup dep check

### DIFF
--- a/.github/actions/check-go-deps/action.yml
+++ b/.github/actions/check-go-deps/action.yml
@@ -18,7 +18,7 @@ runs:
       id: resolve-mod-path
       shell: bash
       run: |
-        ROOT_PATH="${${{ inputs.mod-path }}:=$(git rev-parse --show-toplevel)}"
+        ROOT_PATH="${${{ inputs.mod-path }}:-$(git rev-parse --show-toplevel)}"
         GO_MOD_PATH="$ROOT_PATH/go.mod"
         GO_SUM_PATH="$ROOT_PATH/go.sum"
         if [[ ! -f "$GO_MOD_PATH" ]]; then

--- a/.github/actions/check-go-deps/action.yml
+++ b/.github/actions/check-go-deps/action.yml
@@ -1,0 +1,54 @@
+name: Go dependency checks
+description: Verifies that the go.sum file is consistent with the go.mod file.
+
+inputs:
+  mod-path:
+    description: "Path to the go.mod and go.sum files to check. Defaults to the root of the repository."
+    required: false
+    default: ""
+  go-version:
+    description: "The Go version to use for the checks. If not specified, the version from the go.mod file will be used."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: resolve mod path
+      id: resolve-mod-path
+      shell: bash
+      run: |
+        ROOT_PATH="{${{ inputs.mod-path }}:=$(git rev-parse --show-toplevel)}"
+        GO_MOD_PATH="$ROOT_PATH/go.mod"
+        GO_SUM_PATH="$ROOT_PATH/go.sum"
+        if [[ ! -f "$GO_MOD_PATH" ]]; then
+          echo "go.mod not found in $ROOT_PATH"
+          exit 1
+        fi
+        if [[ ! -f "$GO_SUM_PATH" ]]; then
+          echo "go.sum not found in $ROOT_PATH"
+          exit 1
+        fi
+        echo "MOD_PATH=$GO_MOD_PATH" >> $GITHUB_OUTPUT
+        echo "SUM_PATH=$GO_SUM_PATH" >> $GITHUB_OUTPUT
+
+    - name: Change to module directory
+      shell: bash
+      run: |
+        cd "$(dirname "${{ steps.resolve-mod-path.outputs.MOD_PATH }}")"
+
+    - name: Set up Go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      with:
+        go-version-file: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
+        go-version: ${{ inputs.go-version }}
+
+    - name: Verify dependencies
+      shell: bash
+      run: go mod verify
+    
+    - name: Tidy dependencies
+      shell: bash
+      run: |
+        go mod tidy
+        git diff --exit-code -- ${{ steps.resolve-mod-path.outputs.MOD_PATH }} ${{ steps.resolve-mod-path.outputs.SUM_PATH }}

--- a/.github/actions/check-go-deps/action.yml
+++ b/.github/actions/check-go-deps/action.yml
@@ -34,13 +34,8 @@ runs:
       env:
         INPUT_MOD_PATH: ${{ inputs.mod-path }}
 
-    - name: Change to module directory
-      shell: bash
-      run: |
-        cd "$(dirname "${{ steps.resolve-mod-path.outputs.MOD_PATH }}")"
-
     - name: Set up Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version-file: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
         go-version: ${{ inputs.go-version }}
@@ -48,18 +43,17 @@ runs:
     - name: Verify dependencies
       shell: bash
       run: |
-        cd $MODULE_PATH
+        cd "$(dirname "$MOD_PATH")"
         go mod verify
       env:
-        MODULE_PATH: ${{ inputs.mod-path }}
+        MOD_PATH: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
     
     - name: Tidy dependencies
       shell: bash
       run: |
-        cd $MODULE_PATH
+        cd "$(dirname "$MOD_PATH")"
         go mod tidy
         git diff --exit-code --  $MOD_PATH $SUM_PATH
       env:
-        MODULE_PATH: ${{ inputs.mod-path }}
         MOD_PATH: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
         SUM_PATH: ${{ steps.resolve-mod-path.outputs.SUM_PATH }}

--- a/.github/actions/check-go-deps/action.yml
+++ b/.github/actions/check-go-deps/action.yml
@@ -53,7 +53,7 @@ runs:
       run: |
         cd "$(dirname "$MOD_PATH")"
         go mod tidy
-        git diff --exit-code --  $MOD_PATH $SUM_PATH
+        git diff --exit-code -- $MOD_PATH $SUM_PATH
       env:
         MOD_PATH: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
         SUM_PATH: ${{ steps.resolve-mod-path.outputs.SUM_PATH }}

--- a/.github/actions/check-go-deps/action.yml
+++ b/.github/actions/check-go-deps/action.yml
@@ -18,7 +18,8 @@ runs:
       id: resolve-mod-path
       shell: bash
       run: |
-        ROOT_PATH="${${{ inputs.mod-path }}:-$(git rev-parse --show-toplevel)}"
+        INPUT_MOD_PATH="${{ inputs.mod-path }}"
+        ROOT_PATH="${INPUT_MOD_PATH:-$(git rev-parse --show-toplevel)}"
         GO_MOD_PATH="$ROOT_PATH/go.mod"
         GO_SUM_PATH="$ROOT_PATH/go.sum"
         if [[ ! -f "$GO_MOD_PATH" ]]; then

--- a/.github/actions/check-go-deps/action.yml
+++ b/.github/actions/check-go-deps/action.yml
@@ -18,7 +18,6 @@ runs:
       id: resolve-mod-path
       shell: bash
       run: |
-        INPUT_MOD_PATH="${{ inputs.mod-path }}"
         ROOT_PATH="${INPUT_MOD_PATH:-$(git rev-parse --show-toplevel)}"
         GO_MOD_PATH="$ROOT_PATH/go.mod"
         GO_SUM_PATH="$ROOT_PATH/go.sum"
@@ -32,6 +31,8 @@ runs:
         fi
         echo "MOD_PATH=$GO_MOD_PATH" >> $GITHUB_OUTPUT
         echo "SUM_PATH=$GO_SUM_PATH" >> $GITHUB_OUTPUT
+      env:
+        INPUT_MOD_PATH: ${{ inputs.mod-path }}
 
     - name: Change to module directory
       shell: bash
@@ -46,10 +47,19 @@ runs:
 
     - name: Verify dependencies
       shell: bash
-      run: go mod verify
+      run: |
+        cd $MODULE_PATH
+        go mod verify
+      env:
+        MODULE_PATH: ${{ inputs.mod-path }}
     
     - name: Tidy dependencies
       shell: bash
       run: |
+        cd $MODULE_PATH
         go mod tidy
-        git diff --exit-code -- ${{ steps.resolve-mod-path.outputs.MOD_PATH }} ${{ steps.resolve-mod-path.outputs.SUM_PATH }}
+        git diff --exit-code --  $MOD_PATH $SUM_PATH
+      env:
+        MODULE_PATH: ${{ inputs.mod-path }}
+        MOD_PATH: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
+        SUM_PATH: ${{ steps.resolve-mod-path.outputs.SUM_PATH }}

--- a/.github/actions/check-go-deps/action.yml
+++ b/.github/actions/check-go-deps/action.yml
@@ -18,7 +18,7 @@ runs:
       id: resolve-mod-path
       shell: bash
       run: |
-        ROOT_PATH="{${{ inputs.mod-path }}:=$(git rev-parse --show-toplevel)}"
+        ROOT_PATH="${${{ inputs.mod-path }}:=$(git rev-parse --show-toplevel)}"
         GO_MOD_PATH="$ROOT_PATH/go.mod"
         GO_SUM_PATH="$ROOT_PATH/go.sum"
         if [[ ! -f "$GO_MOD_PATH" ]]; then

--- a/.github/actions/check-snippets/action.yml
+++ b/.github/actions/check-snippets/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,22 +104,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        # zizmor: ignore[cache-poisoning] -- check-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache: true
-      - run: go mod download
-      - run: go mod verify
       - name: Check root module tidiness
-        run: |
-          go mod tidy
-          git diff --exit-code -- go.mod go.sum
+        uses: ./.github/actions/check-go-deps
+        with:
+          mod-path: ""
+          go-version: ${{ matrix.go-version }}
       - name: Check integration test module tidiness
-        run: |
-          cd tests/integration/v2
-          go mod tidy
-          git diff --exit-code -- go.mod go.sum
+        uses: ./.github/actions/check-go-deps
+        with:
+          mod-path: "tests/integration/v2"
+          go-version: ${{ matrix.go-version }}
 
   build-go:
     name: Build Go Code


### PR DESCRIPTION
<!--
  PR title MUST be a Conventional Commit line — CI lints it and it becomes the squash commit.
  Examples:
    feat(tableapi): add display-value support
    fix(credentials): handle expired refresh token
    chore(ci): update golangci-lint version
    docs: fix broken link in tableapi README
-->

## What & why

<!-- Short description of the change and the problem it solves. Link related issues with "Closes #123". -->
Cleanup the dependency checks

## Type of change

<!-- Check one. This determines which checklist items apply. -->

- [ ] `feat` — new or changed exported API surface
- [ ] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [X] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

<!-- Only check items relevant to your change type. -->

- [ ] `gofmt -s -w .` and `golangci-lint run ./...` pass
- [ ] `go test ./...` passes
- [ ] New or changed exported surface has unit tests
- [ ] `website/` is updated (or explain why not below)
- [ ] Code samples use `website/snippets/*.go` region markers, not inline in pages
- [ ] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

<!-- If docs or tests are intentionally untouched, say why: -->
