### PR TITLE
chore: make lint job modular

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,29 +151,9 @@ jobs:
     needs:
       - changes
     if: ${{ needs.changes.outputs.code == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read # checkout and lint
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ["stable", "oldstable"]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        # zizmor: ignore[cache-poisoning] -- lint-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
-        with:
-          install-mode: goinstall
-          version: v2.13.0
-          skip-cache: false
-          args: --timeout=5m
+    uses: ./.github/workflows/reusable-lint-go.yaml
+    with:
+      go-version: '["1.22", "1.23"]'
 
   check-license:
     name: License Headers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ on:
       - "**/*.feature"
       - ".github/workflows/ci.yml"
       - ".golangci.yml"
+      - ".github/workflows/reusable-lint-go.yaml"
 
 concurrency:
   # Scheduled runs carry no head_ref or ref, so without the run_id fallback
@@ -72,6 +73,7 @@ jobs:
             tests/integration/**
             **/*.feature
             .github/workflows/ci.yml
+            .github/workflows/reusable-lint-go.yaml"
 
       # Files in scope for the license-header check (matches scripts/add-license.sh:
       # all .go/.sh plus root-level .yml/.yaml). A separate output keeps shell-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - "tests/integration/**"
       - "**/*.feature"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/reusable-lint-go.yaml"
   pull_request:
     paths:
       - "**.go"
@@ -153,7 +154,7 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     uses: ./.github/workflows/reusable-lint-go.yaml
     with:
-      go-version: '["1.22", "1.23"]'
+      go-version: '["stable", "oldstable"]'
 
   check-license:
     name: License Headers

--- a/.github/workflows/reusable-lint-go.yaml
+++ b/.github/workflows/reusable-lint-go.yaml
@@ -1,0 +1,69 @@
+name: Lint Go Code
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: 'Go version(s) to use, as a JSON array string, e.g. ["1.22","1.23"]'
+        required: false
+        default: '["stable"]'
+        type: string
+      golangci-lint-version:
+        description: "golangci-lint version to use"
+        required: false
+        default: "v2.13.0"
+        type: string
+      working-directory:
+        description: "Directory containing the Go module to lint"
+        required: false
+        default: "."
+        type: string
+  workflow_dispatch:
+    inputs:
+      go-version:
+        description: 'Go version(s) to use, as a JSON array string, e.g. ["1.22","1.23"]'
+        required: false
+        default: '["stable"]'
+        type: string
+      golangci-lint-version:
+        description: "golangci-lint version to use"
+        required: false
+        default: "v2.13.0"
+        type: string
+      working-directory:
+        description: "Directory containing the Go module to lint"
+        required: false
+        default: "."
+        type: string
+
+concurrency:
+  group: lint-go-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint Go Code (${{ matrix.go-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ${{ fromJSON(inputs.go-version) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read # checkout and lint
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- lint-go: setup-go saves caches only on default-branch refs; PR/fork runs only restore, so no fork-persisted cache reaches trusted runs
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        with:
+          install-mode: goinstall
+          version: ${{ inputs.golangci-lint-version }}
+          working-directory: ${{ inputs.working-directory }}
+          skip-cache: false
+          args: --timeout=5m

--- a/.github/workflows/reusable-lint-go.yaml
+++ b/.github/workflows/reusable-lint-go.yaml
@@ -18,27 +18,12 @@ on:
         required: false
         default: "."
         type: string
-  workflow_dispatch:
-    inputs:
-      go-version:
-        description: 'Go version(s) to use, as a JSON array string, e.g. ["1.22","1.23"]'
-        required: false
-        default: '["stable"]'
-        type: string
-      golangci-lint-version:
-        description: "golangci-lint version to use"
-        required: false
-        default: "v2.13.0"
-        type: string
-      working-directory:
-        description: "Directory containing the Go module to lint"
-        required: false
-        default: "."
-        type: string
 
 concurrency:
   group: lint-go-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   lint:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,9 @@
     "usernamehw.errorlens",
     "msyrus.go-doc",
     "766b.go-outliner",
-    "yzhang.markdown-all-in-one"
+    "yzhang.markdown-all-in-one",
+    "alexkrechik.cucumberautocomplete",
+    "mermaidchart.vscode-mermaid-chart",
+    "redhat.vscode-yaml"
   ]
 }


### PR DESCRIPTION
<!--
  PR title MUST be a Conventional Commit line — CI lints it and it becomes the squash commit.
  Examples:
    feat(tableapi): add display-value support
    fix(credentials): handle expired refresh token
    chore(ci): update golangci-lint version
    docs: fix broken link in tableapi README
-->

## What & why

Separates go linting into its own reusable workflow.

## Type of change

<!-- Check one. This determines which checklist items apply. -->

- [ ] `feat` — new or changed exported API surface
- [ ] `fix` — bug fix
- [ ] `refactor` — internal improvement, no behavior change
- [ ] `docs` — documentation only
- [X] `chore` — CI, tooling, dependencies, or other non-release work
- [ ] `test` — test coverage or infrastructure

## Checklist

<!-- Only check items relevant to your change type. -->

- [ ] `gofmt -s -w .` and `golangci-lint run ./...` pass
- [ ] `go test ./...` passes
- [ ] New or changed exported surface has unit tests
- [ ] `website/` is updated (or explain why not below)
- [ ] Code samples use `website/snippets/*.go` region markers, not inline in pages
- [ ] `VERSION` and `CHANGELOG.md` are untouched (release-please manages them)

<!-- If docs or tests are intentionally untouched, say why: -->
