### PR TITLE
chore: extract shared actions for export to NerdIT-Tech/.github

### DIFF
--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -1,0 +1,97 @@
+name: go-test
+author: michaeldcanady
+description: "Runs go test across one or more packages, optionally with coverage and JSON output piped through tparse"
+branding:
+  icon: "package"
+  color: "blue"
+inputs:
+  format-json:
+    description: "If true, run tests with -json output and pipe through tparse (requires tparse on PATH)"
+    required: false
+    default: "true"
+  verbose:
+    description: "If true, run tests with -v"
+    required: false
+    default: "true"
+  coverage-profile:
+    description: "Coverage output file path (e.g. coverage.out). Set to 'true' for the default 'coverage.out', or omit/leave empty to skip coverage."
+    required: false
+    default: ""
+  build-flags:
+    description: "Additional flags to pass to 'go build' (e.g. '-tags=integration')"
+    required: false
+    default: ""
+  package-paths:
+    description: "Packages to test, space- or newline-separated. e.g. ./... or './pkg1\n./pkg2'"
+    required: true
+  working-directory:
+    description: "Working directory to run tests in (e.g. '.', 'tests/integration/v2')"
+    required: false
+    default: "."
+
+outputs:
+  coverage-profile:
+    description: "Path to the generated coverage profile, empty if coverage was not requested"
+    value: ${{ steps.run-tests.outputs.coverage-profile }}
+
+runs:
+  using: composite
+  steps:
+    - id: run-tests
+      shell: bash
+      env:
+        format_json: ${{ inputs.format-json }}
+        verbose: ${{ inputs.verbose }}
+        coverage_profile: ${{ inputs.coverage-profile }}
+        package_paths: ${{ inputs.package-paths }}
+        build_flags: ${{ inputs.build-flags }}
+        working_directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "${working_directory}" ] && [ "${working_directory}" != "." ]; then
+          if [ ! -d "${working_directory}" ]; then
+            echo "::error::Working directory '${working_directory}' does not exist" >&2
+            exit 1
+          fi
+        fi
+
+        cd "${working_directory}"
+
+        args=()
+        [ "${verbose}" = "true" ] && args+=("-v")
+        [ "${format_json}" = "true" ] && args+=("-json")
+        if [ -n "${build_flags}" ]; then
+          read -r -a flag_args <<< "${build_flags}"
+          args+=("${flag_args[@]}")
+        fi
+
+        cover_path=""
+        if [ -n "${coverage_profile}" ] && [ "${coverage_profile}" != "false" ]; then
+          cover_path="${coverage_profile}"
+          [ "${cover_path}" = "true" ] && cover_path="coverage.out"
+          args+=("-coverprofile=${cover_path}")
+        fi
+
+        # package-paths accepts space- or newline-separated entries
+        pkgs=()
+        while IFS= read -r p; do
+          [ -n "$p" ] && pkgs+=("$p")
+        done < <(printf '%s' "${package_paths}" | tr ' ' '
+        ' | sed '/^[[:space:]]*$/d')
+        [ ${#pkgs[@]} -eq 0 ] && pkgs=("./...")
+
+        echo "Running: go test ${args[*]} ${pkgs[*]}"
+
+        if [ "${format_json}" = "true" ]; then
+          if ! command -v tparse >/dev/null 2>&1; then
+            echo "::error::tparse not found on PATH. Run the tparse-installer action before this step." >&2
+            exit 1
+          fi
+          set -o pipefail
+          go test "${args[@]}" "${pkgs[@]}" | tparse -all
+        else
+          go test "${args[@]}" "${pkgs[@]}"
+        fi
+
+        echo "coverage-profile=${cover_path}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/install-tparse/action.yml
+++ b/.github/actions/install-tparse/action.yml
@@ -1,0 +1,71 @@
+name: tparse-installer
+author: michaeldcanady
+description: "Installs tparse and includes it in your path"
+branding:
+  icon: "package"
+  color: "blue"
+inputs:
+  tparse-version:
+    description: "tparse release version to be installed (e.g. v0.13.3, or 'latest')"
+    required: false
+    default: "latest"
+  install-dir:
+    description: "Where to install the tparse binary (defaults to $HOME/go/bin which is on PATH)"
+    required: false
+    default: "$HOME/go/bin"
+  use-sudo:
+    description: "set to true if install-dir location requires sudo privs"
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        input_tparse_release: ${{ inputs.tparse-version }}
+        input_install_dir: ${{ inputs.install-dir }}
+        input_use_sudo: ${{ inputs.use-sudo }}
+        runner_os: ${{ runner.os }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v go >/dev/null 2>&1; then
+          echo "::error::Go was not found on PATH. Run actions/setup-go before this action." >&2
+          exit 1
+        fi
+
+        # Expand $HOME / ~ in the install-dir input, then make it absolute.
+        install_dir=$(eval echo "${input_install_dir}")
+        mkdir -p "${install_dir}"
+        install_dir=$(cd "${install_dir}" && pwd)
+
+        version="${input_tparse_release}"
+        if [ "${version}" = "latest" ]; then
+          module="github.com/mfridman/tparse@latest"
+        else
+          case "${version}" in
+            v*) module="github.com/mfridman/tparse@${version}" ;;
+            *)  module="github.com/mfridman/tparse@v${version}" ;;
+          esac
+        fi
+
+        echo "Installing ${module} into ${install_dir}"
+
+        if [ "${input_use_sudo}" = "true" ]; then
+          sudo -E env "PATH=${PATH}" GOBIN="${install_dir}" go install "${module}"
+        else
+          GOBIN="${install_dir}" go install "${module}"
+        fi
+
+        binary="${install_dir}/tparse"
+        if [ "${runner_os}" = "Windows" ]; then
+          binary="${binary}.exe"
+        fi
+
+        if [ ! -x "${binary}" ]; then
+          echo "::error::tparse binary not found at ${binary} after install" >&2
+          exit 1
+        fi
+
+        echo "Installed: $(${binary} -h 2>&1 | head -n1 || true)"

--- a/shared-actions/README.md
+++ b/shared-actions/README.md
@@ -1,0 +1,61 @@
+# Shared GitHub Actions
+
+Reusable composite actions for Go projects, exportable to `NerdIT-Tech/.github/actions/`.
+
+## Actions
+
+| Action | Description | Dependencies |
+|--------|-------------|--------------|
+| [`detect-changes`](detect-changes/) | Detect changed files matching patterns | `tj-actions/changed-files` |
+| [`setup-go-env`](setup-go-env/) | Checkout + install Go toolchain | `actions/checkout`, `actions/setup-go` |
+| [`install-tparse`](install-tparse/) | Install tparse (Go test JSON parser) | `actions/setup-go` (prereq) |
+| [`go-test`](go-test/) | Run `go test` with tparse, coverage | `install-tparse` (must run first) |
+| [`check-go-deps`](check-go-deps/) | Verify & tidy Go module deps | `actions/setup-go` |
+
+## Installation
+
+Copy the `shared-actions/` directory contents to `NerdIT-Tech/.github/actions/`:
+
+```
+NerdIT-Tech/.github/
+└── actions/
+    ├── detect-changes/
+    │   ├── action.yml
+    │   └── README.md
+    ├── setup-go-env/
+    │   ├── action.yml
+    │   └── README.md
+    ├── install-tparse/
+    │   ├── action.yml
+    │   └── README.md
+    ├── go-test/
+    │   ├── action.yml
+    │   └── README.md
+    └── check-go-deps/
+        ├── action.yml
+        └── README.md
+```
+
+## Usage in Workflows
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: NerdIT-Tech/.github/actions/setup-go-env@v1
+        with:
+          go-version: stable
+      - uses: NerdIT-Tech/.github/actions/install-tparse@v1
+      - uses: NerdIT-Tech/.github/actions/go-test@v1
+        with:
+          package-paths: ./...
+```
+
+## Versioning
+
+Tag releases as `v1`, `v2`, etc. in the target repo. Consumers pin to major versions:
+```yaml
+uses: NerdIT-Tech/.github/actions/go-test@v1
+```

--- a/shared-actions/check-go-deps/README.md
+++ b/shared-actions/check-go-deps/README.md
@@ -1,0 +1,33 @@
+# check-go-deps
+
+Generic GitHub Action to verify Go module dependencies (`go mod verify`) and check tidiness (`go mod tidy`).
+
+## Usage
+
+```yaml
+- uses: NerdIT-Tech/.github/actions/check-go-deps@v1
+  with:
+    mod-root: "."
+    go-version: "stable"
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `mod-root` | Root directory containing go.mod/go.sum | No | Repository root |
+| `go-version` | Go version to use (e.g., `stable`, `1.22.x`) | No | From go.mod |
+
+## What it does
+
+1. **Verifies dependencies** - Runs `go mod verify` to check checksums
+2. **Checks tidiness** - Runs `go mod tidy` and fails if go.mod/go.sum change
+
+## Example: Multi-module repo
+
+```yaml
+- uses: NerdIT-Tech/.github/actions/check-go-deps@v1
+  with:
+    mod-root: "submodule"
+    go-version: "stable"
+```

--- a/shared-actions/check-go-deps/action.yml
+++ b/shared-actions/check-go-deps/action.yml
@@ -1,0 +1,59 @@
+name: Go dependency checks
+description: Verifies that the go.sum file is consistent with the go.mod file.
+
+inputs:
+  mod-root:
+    description: "Root directory containing go.mod/go.sum. Defaults to repository root."
+    required: false
+    default: ""
+  go-version:
+    description: "The Go version to use for the checks. If not specified, the version from the go.mod file will be used."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: resolve mod path
+      id: resolve-mod-path
+      shell: bash
+      run: |
+        ROOT_PATH="${INPUT_MOD_ROOT:-$(git rev-parse --show-toplevel)}"
+        GO_MOD_PATH="$ROOT_PATH/go.mod"
+        GO_SUM_PATH="$ROOT_PATH/go.sum"
+        if [[ ! -f "$GO_MOD_PATH" ]]; then
+          echo "go.mod not found in $ROOT_PATH"
+          exit 1
+        fi
+        if [[ ! -f "$GO_SUM_PATH" ]]; then
+          echo "go.sum not found in $ROOT_PATH"
+          exit 1
+        fi
+        echo "MOD_PATH=$GO_MOD_PATH" >> $GITHUB_OUTPUT
+        echo "SUM_PATH=$GO_SUM_PATH" >> $GITHUB_OUTPUT
+      env:
+        INPUT_MOD_ROOT: ${{ inputs.mod-root }}
+
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      with:
+        go-version-file: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
+        go-version: ${{ inputs.go-version }}
+
+    - name: Verify dependencies
+      shell: bash
+      run: |
+        cd "$(dirname "$MOD_PATH")"
+        go mod verify
+      env:
+        MOD_PATH: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
+
+    - name: Tidy dependencies
+      shell: bash
+      run: |
+        cd "$(dirname "$MOD_PATH")"
+        go mod tidy
+        git diff --exit-code -- $MOD_PATH $SUM_PATH
+      env:
+        MOD_PATH: ${{ steps.resolve-mod-path.outputs.MOD_PATH }}
+        SUM_PATH: ${{ steps.resolve-mod-path.outputs.SUM_PATH }}

--- a/shared-actions/detect-changes/README.md
+++ b/shared-actions/detect-changes/README.md
@@ -1,0 +1,35 @@
+# detect-changes
+
+Generic GitHub Action to detect changed files matching given patterns.
+
+## Usage
+
+```yaml
+- uses: NerdIT-Tech/.github/actions/detect-changes@v1
+  id: changes
+  with:
+    files: |
+      **.go
+      **/*.md
+    base_sha: ${{ github.event.pull_request.base.sha }}
+    fetch-depth: 1
+    checkout: true
+
+- if: steps.changes.outputs.any_changed == 'true'
+  run: echo "Files changed!"
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `files` | Newline-separated glob patterns to watch | No | All files |
+| `base_sha` | Base SHA/ref to diff against | No | Auto-detect |
+| `fetch-depth` | Git fetch depth for checkout | No | `1` |
+| `checkout` | Whether to checkout first | No | `true` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `any_changed` | `'true'` if any matching file changed |

--- a/shared-actions/detect-changes/action.yml
+++ b/shared-actions/detect-changes/action.yml
@@ -1,0 +1,42 @@
+name: "Detect Changes"
+description: "Checks out the repository (optional) and reports whether any files matching the given patterns changed, for gating downstream jobs."
+
+inputs:
+  files:
+    description: "Newline-separated list of file/glob patterns to watch. If omitted, all changed files are considered."
+    required: false
+    default: ""
+  base_sha:
+    description: "Base SHA/ref to diff against, passed through to tj-actions/changed-files. If omitted, the action's default base-ref detection is used."
+    required: false
+    default: ""
+  fetch-depth:
+    description: "Depth passed to actions/checkout. Use 0 for full history (e.g. when diffing against tags)."
+    required: false
+    default: "1"
+  checkout:
+    description: "Whether to check out the repository before diffing. Set to 'false' if the caller has already checked out the ref it wants diffed."
+    required: false
+    default: "true"
+
+outputs:
+  any_changed:
+    description: "'true' if any file matching the given patterns changed."
+    value: ${{ steps.filter.outputs.any_changed }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      if: inputs.checkout == 'true'
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+        fetch-depth: ${{ inputs.fetch-depth }}
+
+    - name: Changed Files
+      id: filter
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+      with:
+        files: ${{ inputs.files }}
+        base_sha: ${{ inputs.base_sha }}

--- a/shared-actions/go-test/README.md
+++ b/shared-actions/go-test/README.md
@@ -1,0 +1,41 @@
+# go-test
+
+Generic GitHub Action to run `go test` with JSON output via tparse, coverage, and configurable options.
+
+## Usage
+
+```yaml
+- uses: NerdIT-Tech/.github/actions/install-tparse@v1
+  with:
+    tparse-version: "v0.18.0"
+
+- uses: NerdIT-Tech/.github/actions/go-test@v1
+  with:
+    format-json: "true"
+    verbose: "true"
+    coverage-profile: "coverage.out"
+    build-flags: "-tags=integration"
+    package-paths: "./..."
+    working-directory: "."
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `format-json` | Run with `-json` and pipe through tparse | No | `true` |
+| `verbose` | Run with `-v` | No | `true` |
+| `coverage-profile` | Coverage output file (empty to skip) | No | `""` |
+| `build-flags` | Additional flags for `go build` | No | `""` |
+| `package-paths` | Packages to test (space/newline separated) | Yes | - |
+| `working-directory` | Directory to run tests in | No | `.` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `coverage-profile` | Path to generated coverage profile |
+
+## Prerequisites
+
+Requires `tparse` on PATH. Use the `install-tparse` action first.

--- a/shared-actions/go-test/action.yml
+++ b/shared-actions/go-test/action.yml
@@ -1,0 +1,97 @@
+name: go-test
+author: michaeldcanady
+description: "Runs go test across one or more packages, optionally with coverage and JSON output piped through tparse. Requires tparse to be installed first (use install-tparse action)."
+branding:
+  icon: "package"
+  color: "blue"
+inputs:
+  format-json:
+    description: "If true, run tests with -json output and pipe through tparse (requires tparse on PATH)"
+    required: false
+    default: "true"
+  verbose:
+    description: "If true, run tests with -v"
+    required: false
+    default: "true"
+  coverage-profile:
+    description: "Coverage output file path (e.g. coverage.out). Set to 'true' for the default 'coverage.out', or omit/leave empty to skip coverage."
+    required: false
+    default: ""
+  build-flags:
+    description: "Additional flags to pass to 'go build' (e.g. '-tags=integration')"
+    required: false
+    default: ""
+  package-paths:
+    description: "Packages to test, space- or newline-separated. e.g. ./... or './pkg1\n./pkg2'"
+    required: true
+  working-directory:
+    description: "Working directory to run tests in (e.g. '.', 'tests/integration/v2')"
+    required: false
+    default: "."
+
+outputs:
+  coverage-profile:
+    description: "Path to the generated coverage profile, empty if coverage was not requested"
+    value: ${{ steps.run-tests.outputs.coverage-profile }}
+
+runs:
+  using: composite
+  steps:
+    - id: run-tests
+      shell: bash
+      env:
+        format_json: ${{ inputs.format-json }}
+        verbose: ${{ inputs.verbose }}
+        coverage_profile: ${{ inputs.coverage-profile }}
+        package_paths: ${{ inputs.package-paths }}
+        build_flags: ${{ inputs.build-flags }}
+        working_directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "${working_directory}" ] && [ "${working_directory}" != "." ]; then
+          if [ ! -d "${working_directory}" ]; then
+            echo "::error::Working directory '${working_directory}' does not exist" >&2
+            exit 1
+          fi
+        fi
+
+        cd "${working_directory}"
+
+        args=()
+        [ "${verbose}" = "true" ] && args+=("-v")
+        [ "${format_json}" = "true" ] && args+=("-json")
+        if [ -n "${build_flags}" ]; then
+          read -r -a flag_args <<< "${build_flags}"
+          args+=("${flag_args[@]}")
+        fi
+
+        cover_path=""
+        if [ -n "${coverage_profile}" ] && [ "${coverage_profile}" != "false" ]; then
+          cover_path="${coverage_profile}"
+          [ "${cover_path}" = "true" ] && cover_path="coverage.out"
+          args+=("-coverprofile=${cover_path}")
+        fi
+
+        # package-paths accepts space- or newline-separated entries
+        pkgs=()
+        while IFS= read -r p; do
+          [ -n "$p" ] && pkgs+=("$p")
+        done < <(printf '%s' "${package_paths}" | tr ' ' '
+        ' | sed '/^[[:space:]]*$/d')
+        [ ${#pkgs[@]} -eq 0 ] && pkgs=("./...")
+
+        echo "Running: go test ${args[*]} ${pkgs[*]}"
+
+        if [ "${format_json}" = "true" ]; then
+          if ! command -v tparse >/dev/null 2>&1; then
+            echo "::error::tparse not found on PATH. Run the install-tparse action before this step." >&2
+            exit 1
+          fi
+          set -o pipefail
+          go test "${args[@]}" "${pkgs[@]}" | tparse -all
+        else
+          go test "${args[@]}" "${pkgs[@]}"
+        fi
+
+        echo "coverage-profile=${cover_path}" >> "${GITHUB_OUTPUT}"

--- a/shared-actions/install-tparse/README.md
+++ b/shared-actions/install-tparse/README.md
@@ -1,0 +1,26 @@
+# install-tparse
+
+Generic GitHub Action to install tparse (Go test output parser) and add it to PATH.
+
+## Usage
+
+```yaml
+- uses: NerdIT-Tech/.github/actions/install-tparse@v1
+  with:
+    tparse-version: "v0.18.0"
+    install-dir: "$HOME/go/bin"
+    use-sudo: "false"
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `tparse-version` | tparse version (e.g., `v0.18.0`, `latest`) | No | `latest` |
+| `install-dir` | Installation directory (must be on PATH) | No | `$HOME/go/bin` |
+| `use-sudo` | Use sudo for installation | No | `false` |
+
+## Notes
+
+- Defaults to `$HOME/go/bin` which is on PATH in GitHub-hosted runners
+- No longer writes to `GITHUB_PATH` (zizmor compliant)

--- a/shared-actions/install-tparse/action.yml
+++ b/shared-actions/install-tparse/action.yml
@@ -1,0 +1,71 @@
+name: tparse-installer
+author: michaeldcanady
+description: "Installs tparse and includes it in your path"
+branding:
+  icon: "package"
+  color: "blue"
+inputs:
+  tparse-version:
+    description: "tparse release version to be installed (e.g. v0.13.3, or 'latest')"
+    required: false
+    default: "latest"
+  install-dir:
+    description: "Where to install the tparse binary (defaults to $HOME/go/bin which is on PATH)"
+    required: false
+    default: "$HOME/go/bin"
+  use-sudo:
+    description: "set to true if install-dir location requires sudo privs"
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        input_tparse_release: ${{ inputs.tparse-version }}
+        input_install_dir: ${{ inputs.install-dir }}
+        input_use_sudo: ${{ inputs.use-sudo }}
+        runner_os: ${{ runner.os }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v go >/dev/null 2>&1; then
+          echo "::error::Go was not found on PATH. Run actions/setup-go before this action." >&2
+          exit 1
+        fi
+
+        # Expand $HOME / ~ in the install-dir input, then make it absolute.
+        install_dir=$(eval echo "${input_install_dir}")
+        mkdir -p "${install_dir}"
+        install_dir=$(cd "${install_dir}" && pwd)
+
+        version="${input_tparse_release}"
+        if [ "${version}" = "latest" ]; then
+          module="github.com/mfridman/tparse@latest"
+        else
+          case "${version}" in
+            v*) module="github.com/mfridman/tparse@${version}" ;;
+            *)  module="github.com/mfridman/tparse@v${version}" ;;
+          esac
+        fi
+
+        echo "Installing ${module} into ${install_dir}"
+
+        if [ "${input_use_sudo}" = "true" ]; then
+          sudo -E env "PATH=${PATH}" GOBIN="${install_dir}" go install "${module}"
+        else
+          GOBIN="${install_dir}" go install "${module}"
+        fi
+
+        binary="${install_dir}/tparse"
+        if [ "${runner_os}" = "Windows" ]; then
+          binary="${binary}.exe"
+        fi
+
+        if [ ! -x "${binary}" ]; then
+          echo "::error::tparse binary not found at ${binary} after install" >&2
+          exit 1
+        fi
+
+        echo "Installed: $(${binary} -h 2>&1 | head -n1 || true)"

--- a/shared-actions/setup-go-env/README.md
+++ b/shared-actions/setup-go-env/README.md
@@ -1,0 +1,21 @@
+# setup-go-env
+
+Generic GitHub Action to checkout (optional) and install a Go toolchain.
+
+## Usage
+
+```yaml
+- uses: NerdIT-Tech/.github/actions/setup-go-env@v1
+  with:
+    go-version: "stable"
+    cache: true
+    checkout: true
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `go-version` | Go version to install (e.g., `stable`, `oldstable`, `1.22.x`) | Yes | - |
+| `cache` | Enable Go module/build caching | No | `true` |
+| `checkout` | Checkout repository first | No | `true` |

--- a/shared-actions/setup-go-env/action.yml
+++ b/shared-actions/setup-go-env/action.yml
@@ -1,0 +1,30 @@
+name: "Setup Go Environment"
+description: "Checks out the repository (optional) and installs the requested Go toolchain."
+
+inputs:
+  go-version:
+    description: "Go version to install, as accepted by actions/setup-go (e.g. 'stable', 'oldstable', '1.22.x')."
+    required: true
+  cache:
+    description: "Whether to enable module/build caching, passed through to actions/setup-go."
+    required: false
+    default: "true"
+  checkout:
+    description: "Whether to check out the repository before installing Go. Set to 'false' if the caller has already checked out the ref it wants built (note: the caller must always checkout first anyway in order for GitHub Actions to resolve this local action, so callers in this repo should pass 'false')."
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      if: inputs.checkout == 'true'
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: ${{ inputs.cache }}


### PR DESCRIPTION
Extracts 5 generic composite actions ready for use in a shared actions repo (NerdIT-Tech/.github/actions/):

## Actions Extracted

| Action | Description | Dependencies |
|--------|-------------|--------------|
| `detect-changes` | Generic changed-files detection | `tj-actions/changed-files` |
| `setup-go-env` | Checkout + Go toolchain setup | `actions/checkout`, `actions/setup-go` |
| `install-tparse` | Install tparse (fixed zizmor GITHUB_PATH issue) | `actions/setup-go` (prereq) |
| `go-test` | Run `go test` with tparse, coverage | `install-tparse` (must run first) |
| `check-go-deps` | Verify & tidy Go module deps (added `mod-root` input) | `actions/setup-go` |

Each action includes a README with usage examples.

## Usage After Export

Once copied to `NerdIT-Tech/.github/actions/`, consumers can use:

```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: NerdIT-Tech/.github/actions/setup-go-env@v1
        with:
          go-version: stable
      - uses: NerdIT-Tech/.github/actions/install-tparse@v1
      - uses: NerdIT-Tech/.github/actions/go-test@v1
        with:
          package-paths: ./...
```

Co-authored-by: opencode <opencode@local>